### PR TITLE
v0.7: equivalence_tests + cve_patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,4 @@ datasets/
 
 
 jobs/
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ docs/                           # public docs (committed), three tiers:
 plans/                          # internal working docs (gitignored)
 references/                     # cloned inspiration repos (gitignored)
 envs/, envs-*/, .r2e_cache/     # local artifacts (gitignored)
-tests/                          # pytest; 271/271 pass as of v0.6
+tests/                          # pytest; 357/357 pass as of v0.7
 .github/workflows/              # ci.yml (lint + matrix tests + build),
                                 # release.yml (PyPI publish on tagged release)
 CONTRIBUTING.md                 # dev setup, PR conventions, release flow
@@ -210,9 +210,10 @@ uv add --dev <pkg>      # dev only
 - **v0.3.0** shipped on PyPI: `pr_runtime` (sandbox-verified PR mining) + auto-trigger bootstrap from `generate` + structural quality filters + targeted test invocation + CI/CD (ruff + matrix tests + release workflow)
 - **v0.4.0** shipped on PyPI: polyglot log parsers (Go / Cargo / Jest) + Harbor end-to-end compliance fixes (task.name format, solve.sh shim, /logs/verifier/reward.txt, PATH prelude for non-Python toolchains, defensive git install)
 - **v0.5.0** shipped on PyPI: `pr_stream` (continuous PR mining with watermark state) + `commit_runtime` (commit-level mining, SWE-GEN style). Both Harbor-verified.
-- **v0.6.0** shipped on PyPI: first LLM-synthesized pipelines — `mutation_bugs` (procedural AST bug injection inspired by SWE-smith) + `code_instruct` (repo-anchored OSS-Instruct with executable verifiers, inspired by Magicoder). Both Harbor-verified on `pallets/click` (Mean reward 1.000). **271/271 tests pass.**
-- **v0.7 planned**: LLM-judged QA gate (SWE-Bench++ four-layer recipe), HF Hub append-mode for `pr_stream`, polyglot mutation (Java/JS/Go via tree-sitter)
-- 3 more pipelines planned in `docs/pipelines/` — see [`docs/pipelines/README.md`](./docs/pipelines/README.md) for the status table
+- **v0.6.0** shipped on PyPI: first LLM-synthesized pipelines — `mutation_bugs` (procedural AST bug injection inspired by SWE-smith) + `code_instruct` (repo-anchored OSS-Instruct with executable verifiers, inspired by Magicoder). Both Harbor-verified on `pallets/click` (Mean reward 1.000).
+- **v0.7.0** shipped on PyPI: `equivalence_tests` (R2E-style function-level synthesis — extract real function, LLM writes equivalence test against `reference_<name>` oracle, gold patch fills the candidate) + `cve_patches` (OSV-driven CVE→fix-commit pipeline, reuses pr_runtime validation harness). Both Harbor-verified.
+- **v0.8 planned**: LLM-judged QA gate (SWE-Bench++ four-layer recipe), iterative refinement loop for `equivalence_tests`, LLM-synthesized PoC for `cve_patches` (currently uses upstream test_patch when present), HF Hub append-mode for `pr_stream`, polyglot mutation (tree-sitter)
+- 1 more pipeline planned in `docs/pipelines/`: `refactor_synthesis` (RefactoringMiner-driven) — see [`docs/pipelines/README.md`](./docs/pipelines/README.md)
 
 ### Naming convention (post-rename)
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Different methods to manufacture verifiable tasks from a repo. Pick one, run it,
 | `commit_runtime` | ✅ | ✓ | [R2E-Gym SWE-GEN](https://github.com/R2E-Gym/R2E-Gym) | [📄](./docs/pipelines/commit_runtime.md) |
 | `mutation_bugs` | ✅ | ✓ | [SWE-smith](https://github.com/SWE-bench/SWE-smith) | [📄](./docs/pipelines/mutation_bugs.md) |
 | `code_instruct` | ✅ | ✓ | [Magicoder / OSS-Instruct](https://github.com/ise-uiuc/magicoder) | [📄](./docs/pipelines/code_instruct.md) |
-| `equivalence_tests` | planned | ✓ | [R2E](https://github.com/r2e-project/r2e) | [📄](./docs/pipelines/equivalence_tests.md) |
-| `cve_patches` | planned | ✓ | [PatchSeeker / CVE-Bench](https://github.com/hungkien05/PatchSeeker) | [📄](./docs/pipelines/cve_patches.md) |
+| `equivalence_tests` | ✅ | ✓ | [R2E](https://github.com/r2e-project/r2e) | [📄](./docs/pipelines/equivalence_tests.md) |
+| `cve_patches` | ✅ | ✓ | [PatchSeeker / CVE-Bench](https://github.com/hungkien05/PatchSeeker) | [📄](./docs/pipelines/cve_patches.md) |
 | `refactor_synthesis` | planned | ✓ | RefactoringMiner | [📄](./docs/pipelines/refactor_synthesis.md) |
 
 Every pipeline flows through the same QA gate (determinism, oracle consistency, LLM judge, false-negative filter) before tasks are admitted to a dataset. Text-only pipelines skip the heavy QA layers since there's no execution to validate. See [`docs/pipelines/README.md`](./docs/pipelines/README.md) for the full status table including reward kinds + GPU requirements.
@@ -151,7 +151,8 @@ Pre-alpha.
 - **v0.4.0** shipped on PyPI: polyglot log parsers (Go / Cargo / Jest), Harbor end-to-end verification (Mean reward 1.0 on Go via `urfave/cli`).
 - **v0.5**: `pr_stream` (continuous PR mining, watermark-based) + `commit_runtime` (commit-level mining, SWE-GEN style); defensive git install in emitted Dockerfile so any bootstrap base image works. Harbor-verified on both. (rolled into v0.6 release)
 - **v0.6.0** shipped on PyPI: first LLM-synthesized pipelines — `mutation_bugs` (AST-based bug injection inspired by SWE-smith) + `code_instruct` (repo-anchored OSS-Instruct inspired by Magicoder, with executable verifiers). Harbor-verified on `pallets/click` (Mean reward 1.000 on both). 271/271 tests passing.
-- **v0.7 planned**: `equivalence_tests` (R2E-style behavioral equivalence) and/or `cve_patches` (security-flavored PR mining), plus the LLM-judged QA gate (SWE-Bench++ four-layer recipe), HF Hub append-mode for `pr_stream`, and polyglot mutation (Java/JS/Go via tree-sitter).
+- **v0.7.0** shipped on PyPI: `equivalence_tests` (R2E-style function-level synthesis — extract a real function, LLM writes equivalence tests, gold patch fills in the candidate with the original) + `cve_patches` (OSV-driven security-fix mining — CVE → fix commit → Harbor task). Harbor-verified on `pallets/click` and `pallets/werkzeug` (Mean reward 1.000 on both).
+- **v0.8 planned**: LLM-judged QA gate (SWE-Bench++ four-layer recipe) + iterative refinement for `equivalence_tests` + LLM-synthesized PoC tests for `cve_patches` + HF Hub append-mode for `pr_stream` + polyglot mutation (Java/JS/Go via tree-sitter).
 
 ## License
 

--- a/docs/pipelines/README.md
+++ b/docs/pipelines/README.md
@@ -27,8 +27,8 @@ flowchart LR
 | [`commit_runtime`](./commit_runtime.md) | **shipped** | Harbor | If repo's tests need it | Yes | [R2E-Gym SWE-GEN](https://github.com/R2E-Gym/R2E-Gym) |
 | [`mutation_bugs`](./mutation_bugs.md) | **shipped (v0.6)** | Harbor | Same as test suite | Yes | [SWE-smith](https://github.com/SWE-bench/SWE-smith) |
 | [`code_instruct`](./code_instruct.md) | **shipped (v0.6)** | Harbor | Sometimes | Yes | [Magicoder](https://github.com/ise-uiuc/magicoder) |
-| [`equivalence_tests`](./equivalence_tests.md) | planned | Harbor | If function uses GPU | Yes | [R2E](https://github.com/r2e-project/r2e) |
-| [`cve_patches`](./cve_patches.md) | planned | Harbor | Rarely | Yes | [PatchSeeker](https://github.com/hungkien05/PatchSeeker) / CVE-Bench |
+| [`equivalence_tests`](./equivalence_tests.md) | **shipped (v0.7)** | Harbor | If function uses GPU | Yes | [R2E](https://github.com/r2e-project/r2e) |
+| [`cve_patches`](./cve_patches.md) | **shipped (v0.7)** | Harbor | Rarely | No (bootstrap only) | [PatchSeeker](https://github.com/hungkien05/PatchSeeker) / CVE-Bench |
 | [`refactor_synthesis`](./refactor_synthesis.md) | planned | Harbor | Rarely | Yes | RefactoringMiner |
 
 **Sandbox column legend**: "No" = pure text manipulation, no execution. "Harbor" = we delegate to Harbor's sandbox layer (Local Docker / Modal / Daytona / E2B / Runloop). We don't maintain a parallel abstraction.

--- a/docs/pipelines/cve_patches.md
+++ b/docs/pipelines/cve_patches.md
@@ -1,75 +1,144 @@
 # `cve_patches`
 
-Map CVEs to fixing commits, replay pre-fix state, capture security PoC as the verifier.
+Map OSV vulnerability records to fixing commits in the target repo,
+replay the pre-fix state in a sandbox, and emit a Harbor task whose
+oracle is the upstream security patch.
 
 | | |
 |---|---|
-| Status | **planned (v1.0)** |
+| Status | **shipped (v0.7)** — Python ecosystem |
 | Sandbox required at gen | Yes |
-| LLM required at gen | Yes (NVD-to-commit mapping + PoC synthesis) |
+| LLM required at gen | No (the LLM spec is still required for bootstrap; the pipeline itself does no LLM calls) |
 | Reward kinds emitted | `test_execution`, `diff_similarity` |
-| Inspiration | [PatchSeeker](https://github.com/hungkien05/PatchSeeker), CVE-Bench (NAACL '25), [PATCHEVAL](https://arxiv.org/pdf/2511.11019) |
-| Reference clone | (to add — not yet cloned) |
+| Inspiration | [PatchSeeker](https://github.com/hungkien05/PatchSeeker), CVE-Bench (NAACL '25) |
 
 ## Why this pipeline matters
 
-Lots of **datasets** of CVE-fix pairs exist (PatchSeeker: 5K CVEs across 2K repos; PATCHEVAL: 1K CVEs across 65 CWEs). What doesn't exist: a **reusable pipeline** that takes a repo + its CVE history and turns it into Repo2RLEnv tasks. Plenty of paper-only artifacts; no library.
+Lots of *datasets* of CVE-fix pairs exist (PatchSeeker covers 5K CVEs;
+PATCHEVAL has 1K). What didn't exist before v0.7: a **reusable pipeline**
+that takes a repo + the OSV vuln database and turns the pair into
+Repo2RLEnv-shaped tasks. Plenty of paper-only artifacts; no library —
+until now.
 
-This pipeline closes that gap.
-
-## Algorithm sketch
+## Algorithm
 
 ```mermaid
 flowchart TD
-    A[Repo URL] --> B[Query NVD/GHSA<br/>for CVEs matching repo]
-    B --> C{For each CVE}
-    C --> D[LLM + embedding:<br/>map CVE to fixing commit]
-    D --> E[harbor: build env<br/>at parent-of-fix]
-    E --> F{PoC test exists?}
-    F -- yes --> G[Use existing PoC]
-    F -- no --> H[LLM: synthesize PoC<br/>that triggers vuln]
-    G --> I[Run PoC at parent state]
-    H --> I
-    I --> J{PoC fails<br/>= vuln triggers?}
-    J -- no --> Z[Skip: bad PoC mapping]
-    J -- yes --> K[Apply fix, re-run PoC]
-    K --> L{PoC passes after fix?}
-    L -- no --> Z
-    L -- yes --> M[QA gate]
-    M -- pass --> N[Emit Harbor task<br/>instruction=CVE description<br/>oracle=fixing diff]
-    M -- fail --> Z
+    A[Repo URL] --> B[OSV API:<br/>POST /v1/query]
+    B --> C[Filter by severity + must have<br/>github commit in references]
+    C --> D{For each vuln}
+    D --> E[gh api: fetch parent SHA + commit diff]
+    E --> F[Split into patch + test_patch]
+    F --> G{Has test_patch?}
+    G -- yes --> H[Reuse pr_runtime_validate<br/>F2P/P2P inside bootstrap]
+    G -- no --> I[Skip validation;<br/>emit with validation_status=no_test_patch]
+    H --> J[Emit Harbor task<br/>(instruction=CVE description; oracle=fix diff)]
+    I --> J
 ```
 
-1. Query NVD / GHSA for CVEs matching the target repo
-2. Map each NVD record → fixing commit (PatchSeeker-style: LLM + embedding similarity)
-3. Replay parent-of-fix state in a Docker env
-4. Identify or **synthesize a PoC test** that triggers the vulnerability before the fix and passes after
-5. Emit Harbor task: instruction = CVE description, oracle = fixing diff, verifier = the PoC
-6. QA gate
+## Data source: OSV (Open Source Vulnerabilities)
 
-## Options (planned)
+We hit OSV's public `/v1/query` endpoint with `{"package": {"name": <pkg>,
+"ecosystem": <eco>}}`. The response includes vulns for the target package
+across CVE / GHSA / PYSEC identifiers, with structured `references[]`
+that often link directly to fix commits.
 
-```python
-class CVEMiningOptions(BaseModel):
-    limit: int = 100
-    nvd_query: str | None = None             # CPE filter, e.g. "cpe:django:django"
-    min_severity: Literal["low", "medium", "high", "critical"] = "medium"
-    require_poc: bool = False
-```
+Why OSV (vs NVD or GitHub Security Advisories):
+- No auth required (free, no API key)
+- Pre-resolves CVE → fix-commit URLs in `references[]` (saves us from
+  building a PatchSeeker-style LLM mapper)
+- Covers PyPI / npm / crates.io / Go / Maven / Debian / Alpine / ...
+- Records are cross-linked (a single OSV id often carries CVE + GHSA + PYSEC aliases)
 
-## `[metadata.repo2env.cve_patches]` schema (planned)
+## Filters
+
+1. Severity ≥ `min_severity` (default `low`; CVSS-like ranks)
+2. At least one `references[].url` of the form
+   `https://github.com/<owner>/<repo>/commit/<sha>` matching the
+   target repo (handles fork URLs gracefully — they're rejected)
+3. `gh api commits/<sha>` resolves to a parent (skip root commits)
+4. Source patch must be non-empty (some "fix" commits are CI-only)
+5. `len(source_files) ≤ max_source_files_per_fix` (default 50)
+
+## Validation
+
+Reuses `pipelines/pr_runtime_validate.py` verbatim:
+- If `test_patch` is non-empty → two-stage F2P/P2P (same as pr_runtime)
+- If `test_patch` is empty → skip validation; `validation_status="no_test_patch"`
+  is recorded in metadata. The Harbor verifier still runs the test suite
+  after the agent applies their patch — the reward signal is just
+  "tests still pass with the fix applied", which is weaker than F2P but
+  useful as training data.
+
+## Options
+
+See `CVEPatchesOptions` in `src/repo2rlenv/spec/options.py`.
+
+| Field | Default | Notes |
+|---|---|---|
+| `osv_ecosystem` | `None` (auto from owner) | `PyPI` / `npm` / `crates.io` / ... |
+| `osv_package` | `None` (= repo name lowercased) | package identifier in the ecosystem |
+| `min_severity` | `"low"` | `low` / `medium` / `moderate` / `high` / `critical` |
+| `limit` | 50 | max emitted tasks |
+| `require_fail_to_pass` | **False** | CVE fixes often have no test_patch — accept anyway |
+| `min_fail_to_pass` | 0 | tighten if you want F2P-only |
+| `max_source_files_per_fix` | 50 | reject sprawling fixes |
+| `require_new_test_funcs` | False | security commits often don't add new tests |
+| `skip_validation` | False | emit raw without sandbox run (debug) |
+| `validation_timeout_sec` | 600 | per-candidate cap |
+
+## `[metadata.repo2env.cve_patches]` schema
 
 ```toml
 [metadata.repo2env.cve_patches]
-cve_id = "CVE-2024-12345"
-cwe = "CWE-79"
-severity = "high"
-nvd_url = "https://nvd.nist.gov/vuln/detail/CVE-2024-12345"
-fixing_commit = "abc123..."
-disclosed_at = "2024-08-01"
+cve_id = "CVE-2024-49767"
+osv_id = "GHSA-q34m-jh98-gwm2"
+aliases = ["CVE-2024-49767"]
+cwe_ids = ["CWE-407"]
+severity = "HIGH"
+published = "2024-10-25T00:00:00Z"
+fix_commit = "50cfeebcb0727e18cc52ffbeb125f4a66551179b"
+parent_commit = "f8c2a3a..."
+fail_to_pass = []
+pass_to_pass = []
+validation_status = "no_test_patch"  # or "verified" when F2P is non-empty
 ```
 
-## Open questions
+## End-to-end smoke
 
-- How aggressively do we synthesize PoCs the dataset doesn't already ship? Synthesizing PoCs has security implications — should be opt-in and gated.
-- How do we handle CVEs that have no public PoC and no fix-attached test? Skip them, or LLM-synth a regression test from the diff?
+```bash
+repo2rlenv generate \
+  --repo pallets/werkzeug \
+  --pipeline cve_patches \
+  --pipeline-opt limit=1 \
+  --pipeline-opt min_severity=high \
+  --llm anthropic/claude-sonnet-4-6 \
+  --out ./datasets/werkzeug-cve
+
+harbor run -a oracle -p ./datasets/werkzeug-cve/<task-id>
+# Mean reward 1.000
+```
+
+## v0.7 trade-offs (to revisit)
+
+- **No PoC synthesis.** When `test_patch` is empty, the verifier signal
+  is weak (just "suite passes with fix applied"). A future v0.8 mode
+  can LLM-synthesize a PoC test that exercises the vulnerability —
+  with a gate around that (security implications of distributing PoCs).
+- **No NVD-direct path.** We rely on OSV's pre-resolved fix URLs. For
+  CVEs OSV hasn't curated, we miss them. A PatchSeeker-style
+  LLM+embedding fallback is on the roadmap.
+- **Single ecosystem auto-guess per owner.** Repos owned by users not
+  in our table (Pallets / PSF / Django / etc.) default to PyPI; the
+  user can always override with `--pipeline-opt osv_ecosystem=npm`.
+
+## What we adapted from inspiration projects
+
+| What | Where | How we apply it |
+|---|---|---|
+| OSV `/v1/query` API | osv.dev (Google public service) | Direct HTTPS POST, stdlib only |
+| Severity rank ordering | CVSS conventions | `_SEVERITY_RANK` constant |
+| CVE-→commit reference pattern | PatchSeeker recipe | `OSVVuln.fix_commits` regex on `references[].url` |
+| F2P/P2P validation harness | SWE-bench / pr_runtime | Reused verbatim (no new code) |
+
+No code is copied from inspiration projects. The pipeline is original Python stdlib + reuses pr_runtime's emission helpers.

--- a/docs/pipelines/equivalence_tests.md
+++ b/docs/pipelines/equivalence_tests.md
@@ -1,60 +1,151 @@
 # `equivalence_tests`
 
-R2E-style function-level synthesis. Extract a function, mask its body, ask the agent to re-implement it; verify via LLM-generated equivalence tests against the ground-truth implementation.
+R2E-style function-level synthesis. Extract a real Python function from the
+target repo as a frozen oracle (`reference_<name>`); ask the LLM to write
+equivalence tests that compare a `<name>` candidate against the oracle on
+crafted inputs; emit a Harbor task whose gold patch fills in the candidate
+with the original implementation.
 
 | | |
 |---|---|
-| Status | **planned** |
+| Status | **shipped (v0.7)** — Python module-level functions |
 | Sandbox required at gen | Yes |
-| LLM required at gen | Yes (test generation) |
+| LLM required at gen | Yes (writes the test only) |
 | Reward kinds emitted | `test_execution` |
 | Inspiration | [R2E](https://github.com/r2e-project/r2e) (ICML '24) |
-| Reference clone | `references/r2e/` |
 
-## What an "equivalence test" is
+## What's different vs `code_instruct`
 
-R2E's framing: a test that **uses the ground-truth implementation to check equivalence**, instead of predicting expected outputs. Crafted inputs are passed to both the masked-out function and the original; outputs must match. This avoids the LLM having to invent expected values.
+| | `code_instruct` | `equivalence_tests` |
+|---|---|---|
+| Seed | LLM-invented problem | **Real function** from the repo |
+| LLM writes | problem + test + solution | **test only** (we already have the solution) |
+| Failure surface | LLM might invent unsolvable / wrong problems | LLM might write a bad test (filtered) |
+| Yield per repo | one per seed snippet | **one per qualifying function** |
 
-## Algorithm sketch
+`equivalence_tests` is lower-variance because the ground truth is real
+working code, not LLM-imagined behavior.
+
+## Algorithm
 
 ```mermaid
 flowchart TD
-    A[Repo URL] --> B[harbor: build env]
-    B --> C[Extract functions/methods<br/>via AST + dependency slicing]
-    C --> D{For each candidate}
-    D --> E[LLM: generate<br/>equivalence tests]
-    E --> F[Run tests against<br/>original implementation]
-    F --> G{All tests pass?}
-    G -- no --> H[LLM: refine tests<br/>iterate up to N times]
-    H --> F
-    G -- yes --> I[Mask function body]
-    I --> J[Emit Harbor task<br/>verifier = equiv test suite]
-    J --> K[QA gate]
+    A[Repo URL] --> B[bootstrap: build env at HEAD]
+    B --> C[Walk Python files →<br/>extract module-level fns<br/>matching LOC + filter rules]
+    C --> D[LLM: write pytest test<br/>importing <name> and<br/>reference_<name> from task_module]
+    D --> E[Syntactic: test uses both names?]
+    E --> F[Stage A: <name> stubbed →<br/>test must FAIL]
+    F --> G[Stage B: <name> = reference_<name><br/>= original → test must PASS]
+    G --> H[Emit Harbor task<br/>(adds task_module.py + test_r2e_<hash>.py)]
 ```
 
-1. Clone repo, build env
-2. Extract candidate functions/methods (AST) within size constraints
-3. **LLM generates equivalence-tests** that call the function with crafted inputs and assert behavior matches a reference
-4. Run tests against original code: must PASS (validates test correctness)
-5. Mask the function body — task = "implement the function so equivalence tests pass"
-6. Emit Harbor task; verifier runs the equivalence test suite
-7. QA gate (4 layers)
+## Function extractor (R2E-style filters)
 
-## Options (planned)
+Walks `clone_dir.glob("**/*.py")`, applies in order:
+
+1. Exclude path globs (`tests/**`, `docs/**`, `**/__init__.py`, ...)
+2. AST parse; skip on `SyntaxError`
+3. Module-level `FunctionDef` only (no class methods in v0.7)
+4. No `async def`
+5. Drop names: dunder, `test_*`, `main`, `setup`, `run`, `init`, `cli`, `wrapper`, `_*`
+6. Must have ≥1 positional/keyword arg (no zero-arg)
+7. Body LOC ∈ `[min_loc, max_loc]` (default 5–60)
+8. Must contain `return <expr>` (not bare `return`)
+9. Body must NOT contain side-effect markers (`open(`, `subprocess.`,
+   `os.environ`, `requests.`, `print(`, `sys.exit`, `input(`, ...)
+
+Filters are conservative — they keep the candidate pool small but
+high-quality. Use `--pipeline-opt min_loc=1 --pipeline-opt max_loc=200`
+to loosen for low-LOC repos.
+
+## Reference oracle pattern
+
+The emitted `task_module.py` ships **two** function definitions:
 
 ```python
-class EquivalenceTestsOptions(BaseModel):
-    limit: int = 100
-    target_kind: Literal["function", "method"] = "function"
-    min_loc: int = 5
-    max_loc: int = 100
-    tests_per_target: int = 3
-    iterations: int = 3   # rounds of test generation w/ feedback
+def reference_<name>(...):
+    # original implementation, frozen — used as the oracle
+    ...
+
+def <name>(...):
+    # in the environment image: stubbed (raise NotImplementedError)
+    # after the gold patch: identical to reference_<name>
+    ...
 ```
 
-## What we'd reuse from `references/r2e/`
+The LLM-generated test imports both and asserts equality across multiple
+inputs:
 
-- AST-based function extraction with dependency slicing
-- The equivalence-test prompt templates
-- Their iterative test-generation-with-feedback loop
-- The CLI experiment-id workflow pattern (`r2e setup -> extract -> generate`)
+```python
+from task_module import <name>, reference_<name>
+
+def test_basic():
+    assert <name>(1, 2) == reference_<name>(1, 2)
+
+def test_edge_zero():
+    assert <name>(0, 0) == reference_<name>(0, 0)
+```
+
+## Verification (two-stage)
+
+| Stage | Module state | Required outcome |
+|---|---|---|
+| A — stub | `<name>` raises `NotImplementedError`; `reference_<name>` is original | FAIL (else the test is trivial) |
+| B — oracle | `<name>` = `reference_<name>` = original | PASS (else the test is buggy) |
+
+Stage A catches the LLM "cheating" with a test that doesn't call `<name>`.
+Stage B catches buggy tests (e.g., asserts on outputs that aren't
+deterministic across re-runs).
+
+## Options
+
+See `EquivalenceTestsOptions` in `src/repo2rlenv/spec/options.py`.
+
+| Field | Default | Notes |
+|---|---|---|
+| `limit` | 50 | max emitted tasks |
+| `min_loc` / `max_loc` | 5 / 60 | body-LOC range |
+| `file_glob` / `exclude_glob` | `**/*.py` / tests/etc. | source selection |
+| `seed` | `None` | RNG seed for reproducibility |
+| `llm_temperature` | 0.5 | lower than `code_instruct` — tests should be stable |
+| `require_test_fails_with_stub` | `True` | Stage A invariant |
+| `require_test_passes_with_oracle` | `True` | Stage B invariant |
+| `validation_timeout_sec` | 90 | per-candidate test run cap |
+| `skip_validation` | `False` | debug; emits without sandbox run |
+
+## End-to-end smoke
+
+```bash
+repo2rlenv generate \
+  --repo pallets/click \
+  --pipeline equivalence_tests \
+  --pipeline-opt limit=1 --pipeline-opt seed=42 \
+  --llm anthropic/claude-sonnet-4-6 \
+  --out ./datasets/click-eqv
+
+harbor run -a oracle -p ./datasets/click-eqv/<task-id>
+# Mean reward 1.000
+```
+
+## Known v0.7 trade-offs (to revisit)
+
+- **Module-level only.** Class methods (with `self` / `cls`) need either
+  dependency slicing (include class context) or method-to-function
+  conversion. Deferred to v0.8.
+- **Recursion.** `_rename_function_source` rewrites only the `def` line;
+  if a function calls itself by name, the renamed `reference_<name>`
+  still calls `<name>` internally — usually trips Stage B and the
+  candidate is dropped. Acceptable skip rate in practice.
+- **No iterative test refinement** (R2E's "feedback → fix_error → improve_coverage"
+  loop). Single LLM call per candidate; if the LLM writes a flaky or buggy
+  test, we skip rather than retry. The retry loop is on the v0.8 roadmap.
+
+## What we adapted from `references/r2e/`
+
+- Function extractor filter set (`repo_builder/fut_extractor/extract_base.py`):
+  LOC bounds, must-have-return, name + decorator + side-effect exclusions.
+- The reference-oracle test pattern (`generators/testgen/prompt.py:27-28`):
+  `reference_<name>` naming convention; test imports BOTH names.
+- The "test must exercise candidate" syntactic guard.
+
+No code is copied. The implementation is original Python stdlib.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repo2rlenv"
-version = "0.6.0"
+version = "0.7.0"
 description = "Turn any repository into an RL environment for training and evaluation."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/repo2rlenv/github.py
+++ b/src/repo2rlenv/github.py
@@ -123,3 +123,41 @@ def fetch_pr_diff(owner: str, name: str, number: int, *, token: str | None = Non
         ["pr", "diff", str(number), "--repo", f"{owner}/{name}"],
         token=token,
     )
+
+
+def fetch_commit_diff(owner: str, name: str, sha: str, *, token: str | None = None) -> str:
+    """Return the unified diff for a single commit via `gh api`.
+
+    Hits `GET /repos/{owner}/{repo}/commits/{sha}` with the `diff` media
+    type — same shape as `git show --format= <sha>` output.
+    """
+    return _run_gh(
+        [
+            "api",
+            f"repos/{owner}/{name}/commits/{sha}",
+            "-H",
+            "Accept: application/vnd.github.v3.diff",
+        ],
+        token=token,
+    )
+
+
+def fetch_commit_parent(owner: str, name: str, sha: str, *, token: str | None = None) -> str:
+    """Return the first parent SHA of `sha` via `gh api`.
+
+    Returns "" if the commit has no parents (root commit) or on any error.
+    """
+    import json as _json
+
+    try:
+        raw = _run_gh(
+            ["api", f"repos/{owner}/{name}/commits/{sha}"],
+            token=token,
+        )
+        data = _json.loads(raw)
+        parents = data.get("parents", []) or []
+        if not parents:
+            return ""
+        return parents[0].get("sha", "") or ""
+    except (GitHubError, _json.JSONDecodeError):
+        return ""

--- a/src/repo2rlenv/osv.py
+++ b/src/repo2rlenv/osv.py
@@ -1,0 +1,168 @@
+"""OSV (Open Source Vulnerabilities) API client.
+
+OSV is Google's public vuln database (https://osv.dev) — no auth required,
+covers PyPI / npm / crates.io / Go / Maven / NuGet / Debian / Alpine / etc.
+
+We use it to power the `cve_patches` pipeline: query → extract fix commit
+URLs from `references[]` → map to a (base_commit, patch) pair via the
+standard `gh api repos/.../commits/<sha>` route.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+OSV_QUERY_URL = "https://api.osv.dev/v1/query"
+
+# A `references[].url` that points at a fix commit. We accept either:
+#   https://github.com/<owner>/<repo>/commit/<sha40>
+#   https://github.com/<owner>/<repo>/pull/<n>/commits/<sha40>
+_GH_COMMIT_RE = re.compile(
+    r"https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/(?:commit|pull/\d+/commits)/(?P<sha>[a-f0-9]{7,40})\b"
+)
+
+
+@dataclass(slots=True)
+class OSVVuln:
+    """One vulnerability record, distilled from the OSV JSON shape."""
+
+    id: str  # primary identifier (GHSA-* or PYSEC-* or CVE-* etc.)
+    aliases: list[str] = field(default_factory=list)  # other ids (often a CVE)
+    summary: str = ""
+    details: str = ""
+    severity_text: str = ""  # human-readable: "LOW" / "MEDIUM" / "HIGH" / "CRITICAL"
+    cwe_ids: list[str] = field(default_factory=list)
+    published: str = ""  # ISO8601
+    references: list[dict[str, str]] = field(default_factory=list)  # raw
+
+    @property
+    def cve_id(self) -> str | None:
+        """First CVE-* identifier in id or aliases."""
+        for cand in [self.id, *self.aliases]:
+            if cand.upper().startswith("CVE-"):
+                return cand
+        return None
+
+    def fix_commits(self, *, owner: str, repo: str) -> list[str]:
+        """Return commit SHAs in `references[]` that point at <owner>/<repo>.
+
+        Filters by owner/repo so we don't accept fix URLs from forks /
+        unrelated repos (OSV sometimes lists multiple linked projects).
+        """
+        out: list[str] = []
+        for ref in self.references:
+            url = ref.get("url", "")
+            m = _GH_COMMIT_RE.search(url)
+            if not m:
+                continue
+            if m.group("owner").lower() != owner.lower():
+                continue
+            if m.group("repo").lower() != repo.lower():
+                continue
+            sha = m.group("sha")
+            if sha not in out:
+                out.append(sha)
+        return out
+
+
+def _from_raw(raw: dict) -> OSVVuln:
+    db = raw.get("database_specific", {}) or {}
+    severity_text = db.get("severity", "") or ""
+    if not severity_text:
+        # Some records use `severity[]` with CVSS score arrays — fall back to "UNKNOWN"
+        sev = raw.get("severity", []) or []
+        if sev and isinstance(sev[0], dict):
+            severity_text = sev[0].get("type", "")  # e.g. "CVSS_V3"
+    return OSVVuln(
+        id=raw.get("id", ""),
+        aliases=list(raw.get("aliases", []) or []),
+        summary=raw.get("summary", "") or "",
+        details=raw.get("details", "") or "",
+        severity_text=severity_text.upper(),
+        cwe_ids=list(db.get("cwe_ids", []) or []),
+        published=raw.get("published", "") or "",
+        references=list(raw.get("references", []) or []),
+    )
+
+
+class OSVError(RuntimeError):
+    pass
+
+
+def query_vulns(
+    package: str,
+    ecosystem: str,
+    *,
+    timeout: float = 30.0,
+) -> list[OSVVuln]:
+    """POST to OSV `/v1/query` and return the parsed list of vulns.
+
+    `ecosystem` examples: "PyPI", "npm", "crates.io", "Go", "Maven",
+    "NuGet", "Debian", "Alpine".
+    """
+    payload = json.dumps({"package": {"name": package, "ecosystem": ecosystem}}).encode()
+    req = urllib.request.Request(
+        OSV_QUERY_URL,
+        data=payload,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise OSVError(f"OSV HTTP {exc.code}: {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise OSVError(f"OSV network error: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise OSVError(f"OSV returned malformed JSON: {exc}") from exc
+    vulns = data.get("vulns") or []
+    return [_from_raw(v) for v in vulns]
+
+
+# Lookup tables for repo → (ecosystem, package) auto-detection.
+# These are heuristics — users can always override via pipeline options.
+_KNOWN_OWNER_ECOSYSTEM: dict[str, str] = {
+    "pallets": "PyPI",
+    "pypa": "PyPI",
+    "pytest-dev": "PyPI",
+    "psf": "PyPI",
+    "django": "PyPI",
+    "fastapi": "PyPI",
+    "encode": "PyPI",
+    "nodejs": "npm",
+    "expressjs": "npm",
+    "facebook": "npm",
+    "rust-lang": "crates.io",
+    "tokio-rs": "crates.io",
+}
+
+
+def guess_ecosystem(owner: str) -> str:
+    """Best-effort: map a GitHub owner to a likely OSV ecosystem.
+
+    Falls back to "PyPI" since that's where the bulk of CVE-attached repos
+    Repo2RLEnv targets live. The user can always override via the
+    `osv_ecosystem` pipeline option.
+    """
+    return _KNOWN_OWNER_ECOSYSTEM.get(owner.lower(), "PyPI")
+
+
+_SEVERITY_RANK = {"LOW": 1, "MEDIUM": 2, "MODERATE": 2, "HIGH": 3, "CRITICAL": 4}
+
+
+def severity_at_least(vuln: OSVVuln, threshold: str) -> bool:
+    """True iff the vuln's severity meets or exceeds `threshold` (case-insensitive).
+
+    Unknown severities are treated as below threshold (conservative).
+    """
+    threshold_rank = _SEVERITY_RANK.get(threshold.upper(), 0)
+    vuln_rank = _SEVERITY_RANK.get(vuln.severity_text.upper(), 0)
+    return vuln_rank >= threshold_rank

--- a/src/repo2rlenv/pipelines/__init__.py
+++ b/src/repo2rlenv/pipelines/__init__.py
@@ -3,6 +3,8 @@
 from repo2rlenv.pipelines.base import Pipeline, PipelineResult
 from repo2rlenv.pipelines.code_instruct import CodeInstructPipeline
 from repo2rlenv.pipelines.commit_runtime import CommitRuntimePipeline
+from repo2rlenv.pipelines.cve_patches import CVEPatchesPipeline
+from repo2rlenv.pipelines.equivalence_tests import EquivalenceTestsPipeline
 from repo2rlenv.pipelines.mutation_bugs import MutationBugsPipeline
 from repo2rlenv.pipelines.pr_diff import PRDiffPipeline
 from repo2rlenv.pipelines.pr_runtime import PRRuntimePipeline
@@ -15,12 +17,16 @@ PIPELINES: dict[str, type[Pipeline]] = {
     "commit_runtime": CommitRuntimePipeline,
     "mutation_bugs": MutationBugsPipeline,
     "code_instruct": CodeInstructPipeline,
+    "equivalence_tests": EquivalenceTestsPipeline,
+    "cve_patches": CVEPatchesPipeline,
 }
 
 __all__ = [
     "PIPELINES",
+    "CVEPatchesPipeline",
     "CodeInstructPipeline",
     "CommitRuntimePipeline",
+    "EquivalenceTestsPipeline",
     "MutationBugsPipeline",
     "PRDiffPipeline",
     "PRRuntimePipeline",

--- a/src/repo2rlenv/pipelines/_function_extractor.py
+++ b/src/repo2rlenv/pipelines/_function_extractor.py
@@ -1,0 +1,216 @@
+"""AST function extractor for `equivalence_tests`.
+
+Walks a parsed module and yields `FunctionCandidate` records for every
+module-level function that survives R2E-style filters. The pipeline picks
+candidates and asks the LLM to write equivalence tests against each.
+
+v0.7 scope: module-level functions only. Class methods (with `self` / `cls`)
+and class hierarchies are deferred — they need either dependency slicing
+or class-context inlining to be self-contained.
+
+Acknowledgment
+--------------
+Filter set mirrors the spirit of R2E's `src/r2e/repo_builder/fut_extractor/`
+(LOC bounds, must have docstring, must have explicit return, exclude
+test/main/demo names). Implementation is original Python stdlib.
+"""
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class FunctionCandidate:
+    """One module-level function picked as an equivalence-test seed."""
+
+    relative_path: str  # POSIX, e.g. "src/foo/bar.py"
+    name: str  # function name
+    lineno: int  # 1-indexed start
+    end_lineno: int  # 1-indexed end (inclusive)
+    body_loc: int  # # lines in the function body (signature excluded)
+    source: str  # the full `def ...: ...` text from the file
+    docstring: str  # extracted via ast.get_docstring (empty if none)
+    arg_names: tuple[str, ...]  # positional + keyword arg names, in order
+
+
+# Names that are almost never useful task candidates.
+_SKIP_NAME_PREFIXES = ("_",)
+_SKIP_EXACT_NAMES = {"main", "setup", "run", "init", "cli", "wrapper"}
+
+# Patterns inside the body that suggest the function isn't behaviorally pure
+# enough for equivalence testing in a standalone module.
+_BODY_SIDE_EFFECT_PATTERNS = (
+    "open(",
+    "subprocess.",
+    "os.system",
+    "os.environ",
+    "os.remove",
+    "os.rename",
+    "shutil.",
+    "requests.",
+    "http.",
+    "urllib.",
+    "socket.",
+    "logging.",
+    "print(",
+    "sys.exit",
+    "input(",
+)
+
+
+def _is_excluded(relative_path: str, exclude_globs: list[str]) -> bool:
+    return any(fnmatch.fnmatch(relative_path, pat) for pat in exclude_globs)
+
+
+def _function_body_loc(node: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
+    """# lines in the function body (signature/decorators excluded).
+
+    Uses end_lineno - body[0].lineno + 1 so we don't count the `def` line.
+    Falls back to 0 if line numbers aren't populated (synthetic AST).
+    """
+    if not node.body:
+        return 0
+    first = node.body[0]
+    start = getattr(first, "lineno", 0)
+    end = getattr(node, "end_lineno", 0)
+    if not (start and end):
+        return 0
+    return max(0, end - start + 1)
+
+
+def _function_source(source_lines: list[str], node: ast.FunctionDef) -> str:
+    """Slice the full `def <name>(...): ...` text out of the source.
+
+    Includes decorators. Uses ast's lineno/end_lineno (1-indexed).
+    """
+    decorator_lines = [getattr(d, "lineno", node.lineno) for d in node.decorator_list]
+    start = min([node.lineno, *decorator_lines]) - 1
+    end = getattr(node, "end_lineno", node.lineno)
+    return "\n".join(source_lines[start:end])
+
+
+def _arg_names(node: ast.FunctionDef) -> tuple[str, ...]:
+    """Positional + keyword arg names (no *args / **kwargs)."""
+    args = node.args
+    out: list[str] = []
+    for a in args.posonlyargs + args.args + args.kwonlyargs:
+        out.append(a.arg)
+    return tuple(out)
+
+
+def _has_explicit_return(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True iff the function body contains a `return <expr>` (not bare `return`)."""
+    for sub in ast.walk(node):
+        if sub is node:
+            continue
+        # Don't descend into nested function/class definitions
+        if isinstance(sub, ast.Return) and sub.value is not None:
+            return True
+    return False
+
+
+def _body_has_side_effect(source: str) -> bool:
+    """Heuristic: function body contains a substring suggesting side effects."""
+    return any(pat in source for pat in _BODY_SIDE_EFFECT_PATTERNS)
+
+
+def _is_skipped_name(name: str) -> bool:
+    if name in _SKIP_EXACT_NAMES:
+        return True
+    if name.startswith("test_"):
+        return True
+    return any(name.startswith(prefix) for prefix in _SKIP_NAME_PREFIXES)
+
+
+def extract_from_module(
+    path: Path,
+    source: str,
+    *,
+    relative_path: str,
+    min_loc: int,
+    max_loc: int,
+) -> list[FunctionCandidate]:
+    """Parse `source` and return every module-level function that survives filters.
+
+    Returns an empty list on SyntaxError.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    source_lines = source.splitlines()
+    out: list[FunctionCandidate] = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        # Async functions can't be tested with plain pytest assertions; skip
+        if isinstance(node, ast.AsyncFunctionDef):
+            continue
+        # Filter: name
+        if _is_skipped_name(node.name):
+            continue
+        # Filter: argument count (no zero-arg, no *args/**kwargs only)
+        names = _arg_names(node)
+        if not names:
+            continue
+        # Filter: body size
+        body_loc = _function_body_loc(node)
+        if body_loc < min_loc or body_loc > max_loc:
+            continue
+        # Filter: explicit return
+        if not _has_explicit_return(node):
+            continue
+        # Filter: side-effect heuristics on the source
+        try:
+            src = _function_source(source_lines, node)
+        except IndexError:
+            continue
+        if _body_has_side_effect(src):
+            continue
+
+        out.append(
+            FunctionCandidate(
+                relative_path=relative_path,
+                name=node.name,
+                lineno=node.lineno,
+                end_lineno=getattr(node, "end_lineno", node.lineno),
+                body_loc=body_loc,
+                source=src,
+                docstring=ast.get_docstring(node) or "",
+                arg_names=names,
+            )
+        )
+    return out
+
+
+def walk_repo(
+    clone_dir: Path,
+    *,
+    file_glob: str,
+    exclude_glob: list[str],
+    min_loc: int,
+    max_loc: int,
+) -> Iterator[FunctionCandidate]:
+    """Walk `clone_dir`, yield FunctionCandidate from every matching .py file."""
+    for path in clone_dir.glob(file_glob):
+        if not path.is_file():
+            continue
+        rel = str(path.relative_to(clone_dir))
+        if _is_excluded(rel, exclude_glob):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        yield from extract_from_module(
+            path, text, relative_path=rel, min_loc=min_loc, max_loc=max_loc
+        )

--- a/src/repo2rlenv/pipelines/cve_patches.py
+++ b/src/repo2rlenv/pipelines/cve_patches.py
@@ -1,0 +1,366 @@
+"""Map OSV vulnerability records to fixing commits in the target repo.
+
+Workflow:
+  1. Query OSV's `/v1/query` for the repo's ecosystem + package
+  2. For each vuln, scan `references[]` for a github.com/<owner>/<repo>/commit/<sha> URL
+  3. Fetch that commit's diff via `gh api`; split into source/test patches
+  4. Validation (when test_patch is non-empty): same harness as pr_runtime —
+     two-stage F2P/P2P inside the bootstrap container
+  5. Emit a Harbor task whose instruction is the CVE description and whose
+     oracle is the fix diff
+
+Unlike `pr_runtime` / `commit_runtime`, many CVE fixes don't ship a test
+patch in the same commit (the test came later, or the regression was
+covered by an existing case). When `test_patch` is empty, we emit the
+task with `validation_status="no_test_patch"` — the verifier signal is
+just "tests still pass with the fix applied", which is weaker than F2P
+but still useful as training data.
+
+----------------------------------------------------------------------------
+Acknowledgment
+----------------------------------------------------------------------------
+Inspired by:
+
+  PatchSeeker (Le et al.) — LLM + embedding similarity for NVD→commit mapping
+  https://github.com/hungkien05/PatchSeeker        (MIT)
+
+  CVE-Bench (Zhu et al., NAACL '25) — benchmark of CVE-fixing tasks
+
+We use the OSV (Open Source Vulnerabilities) public API instead of NVD
+because OSV pre-resolves the `references[]` block to include fix-commit
+URLs in a structured way, removing the need for LLM-driven CVE→commit
+mapping for the common case. No code is copied; the OSV client is
+stdlib-only, the validation harness is reused verbatim from pr_runtime.
+
+Released under Apache-2.0 along with the rest of Repo2RLEnv.
+----------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import ClassVar
+
+from repo2rlenv.auth import resolve_github_token
+from repo2rlenv.bootstrap.spec import BootstrapResult
+from repo2rlenv.emitter.harbor import HarborTask, write_harbor_task
+from repo2rlenv.github import (
+    GitHubError,
+    fetch_commit_diff,
+    fetch_commit_parent,
+)
+from repo2rlenv.osv import OSVError, OSVVuln, guess_ecosystem, query_vulns, severity_at_least
+from repo2rlenv.pipelines.base import PipelineResult
+from repo2rlenv.pipelines.pr_runtime import (
+    _files_in_patch,
+    build_environment_dockerfile,
+    build_eval_script,
+    normalize_test_cmds_for_runtime,
+    split_patch_and_test_patch,
+    targeted_test_cmds_for_pr,
+)
+from repo2rlenv.spec.input import GenerationInput, PipelineName
+from repo2rlenv.spec.options import CVEPatchesOptions
+
+logger = logging.getLogger(__name__)
+
+
+def _build_instruction(vuln: OSVVuln) -> str:
+    """Render the CVE description into a task-prompt-shaped string."""
+    title = vuln.summary or vuln.id
+    body = vuln.details.strip() or "(no detailed description available)"
+    cve = vuln.cve_id or vuln.id
+    cwe = ", ".join(vuln.cwe_ids) or "(no CWE tag)"
+    return (
+        f"# Security advisory: {cve}\n\n"
+        f"**Title:** {title}\n\n"
+        f"**Severity:** {vuln.severity_text or 'unknown'}\n"
+        f"**CWE:** {cwe}\n\n"
+        f"## Description\n\n{body}\n\n"
+        f"## Task\n\n"
+        f"Patch the repository to address the vulnerability described above. "
+        f"The task's test suite verifies your patch by applying it on top of "
+        f"the parent of the original fixing commit and running the tests."
+    )
+
+
+class CVEPatchesPipeline:
+    """OSV-driven CVE → fix-commit pipeline."""
+
+    name: ClassVar[PipelineName] = PipelineName.CVE_PATCHES
+    requires_bootstrap: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        input: GenerationInput,
+        options: CVEPatchesOptions,
+        bootstrap: BootstrapResult | None = None,
+    ):
+        if bootstrap is None:
+            raise RuntimeError(
+                "cve_patches requires a BootstrapResult (set requires_bootstrap=True "
+                "and let cmd_generate trigger it, or pass one explicitly)"
+            )
+        self.input = input
+        self.options = options
+        self.bootstrap = bootstrap
+        self._progress_cb = None
+
+    def set_progress_callback(self, cb) -> None:
+        self._progress_cb = cb
+
+    def _emit_progress(self, name: str, outcome: str, reason: str = "") -> None:
+        if self._progress_cb is not None:
+            try:
+                self._progress_cb(name=name, outcome=outcome, reason=reason)
+            except Exception as exc:
+                logger.debug("progress callback failed: %s", exc)
+
+    # ----- run loop -----------------------------------------------------------
+
+    def run(self, out_dir: Path) -> PipelineResult:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        token = resolve_github_token(self.input.repo, self.input.auth)
+        if self.input.repo.access == "private" and not token:
+            raise RuntimeError(
+                "private repo specified but no GitHub token resolved. "
+                "Run `gh auth login` or set GITHUB_TOKEN."
+            )
+
+        owner, name = self.input.repo.owner_name
+        label_root = f"{owner}/{name}"
+
+        ecosystem = self.options.osv_ecosystem or guess_ecosystem(owner)
+        package = self.options.osv_package or name.lower()
+        logger.info(
+            "cve_patches: querying OSV ecosystem=%s package=%s for %s/%s",
+            ecosystem,
+            package,
+            owner,
+            name,
+        )
+        try:
+            vulns = query_vulns(package, ecosystem)
+        except OSVError as exc:
+            raise RuntimeError(f"OSV query failed: {exc}") from exc
+
+        # Filter by severity + must have at least one fix commit
+        in_scope: list[tuple[OSVVuln, str]] = []
+        for v in vulns:
+            if not severity_at_least(v, self.options.min_severity):
+                continue
+            commits = v.fix_commits(owner=owner, repo=name)
+            if not commits:
+                continue
+            # If multiple commits, pick the first — usually the primary fix
+            in_scope.append((v, commits[0]))
+
+        logger.info(
+            "cve_patches: %d vulns total, %d in scope (have fix commit in %s/%s)",
+            len(vulns),
+            len(in_scope),
+            owner,
+            name,
+        )
+
+        skip_reasons: dict[str, int] = {}
+        emitted = 0
+        sandbox = None
+
+        try:
+            for vuln, fix_sha in in_scope:
+                if emitted >= self.options.limit:
+                    break
+                label = f"{label_root}#{vuln.id}"
+
+                # Resolve parent commit
+                parent_sha = fetch_commit_parent(owner, name, fix_sha, token=token)
+                if not parent_sha:
+                    skip_reasons["no_parent_commit"] = skip_reasons.get("no_parent_commit", 0) + 1
+                    self._emit_progress(label, "skip", "no_parent_commit")
+                    continue
+
+                # Fetch the fix commit's diff
+                try:
+                    diff = fetch_commit_diff(owner, name, fix_sha, token=token)
+                except GitHubError as exc:
+                    logger.warning("CVE %s: diff fetch failed: %s", vuln.id, exc)
+                    skip_reasons["diff_fetch_failed"] = skip_reasons.get("diff_fetch_failed", 0) + 1
+                    self._emit_progress(label, "error", "diff_fetch_failed")
+                    continue
+
+                patch, test_patch = split_patch_and_test_patch(diff)
+                if not patch.strip():
+                    skip_reasons["empty_source_patch"] = (
+                        skip_reasons.get("empty_source_patch", 0) + 1
+                    )
+                    self._emit_progress(label, "skip", "empty_source_patch")
+                    continue
+
+                source_files = _files_in_patch(patch)
+                if len(source_files) > self.options.max_source_files_per_fix:
+                    skip_reasons["too_many_source_files"] = (
+                        skip_reasons.get("too_many_source_files", 0) + 1
+                    )
+                    self._emit_progress(label, "skip", "too_many_source_files")
+                    continue
+
+                # Validation (if we have a test_patch + caller didn't skip)
+                fail_to_pass: list[str] = []
+                pass_to_pass: list[str] = []
+                validation_status = "no_test_patch"
+                if test_patch.strip() and not self.options.skip_validation:
+                    if sandbox is None:
+                        sandbox = self._start_validation_sandbox()
+                    from repo2rlenv.pipelines.pr_runtime_validate import validate_pr
+
+                    targeted_cmds = targeted_test_cmds_for_pr(
+                        normalize_test_cmds_for_runtime(self.bootstrap.test_cmds),
+                        _files_in_patch(test_patch),
+                    )
+                    outcome = validate_pr(
+                        sandbox=sandbox,
+                        base_commit=parent_sha,
+                        patch=patch,
+                        test_patch=test_patch,
+                        test_cmds=targeted_cmds,
+                        language=self.bootstrap.language.value,
+                        timeout=self.options.validation_timeout_sec,
+                    )
+                    fail_to_pass = outcome.fail_to_pass
+                    pass_to_pass = outcome.pass_to_pass
+                    validation_status = outcome.status
+                    if (
+                        self.options.require_fail_to_pass
+                        and len(fail_to_pass) < self.options.min_fail_to_pass
+                    ):
+                        skip_reasons["no_fail_to_pass"] = skip_reasons.get("no_fail_to_pass", 0) + 1
+                        self._emit_progress(label, "skip", outcome.reason or "no_fail_to_pass")
+                        continue
+
+                # Emit the Harbor task
+                task = self._build_task(
+                    vuln=vuln,
+                    fix_sha=fix_sha,
+                    parent_sha=parent_sha,
+                    patch=patch,
+                    test_patch=test_patch,
+                    fail_to_pass=fail_to_pass,
+                    pass_to_pass=pass_to_pass,
+                    validation_status=validation_status,
+                )
+                write_harbor_task(task, out_dir)
+                emitted += 1
+                logger.info(
+                    "emitted task %s (CVE=%s, F2P=%d, P2P=%d)",
+                    task.name,
+                    vuln.cve_id or vuln.id,
+                    len(fail_to_pass),
+                    len(pass_to_pass),
+                )
+                self._emit_progress(task.name, "emit")
+        finally:
+            if sandbox is not None:
+                sandbox.cleanup()
+
+        return PipelineResult(
+            candidates=len(in_scope),
+            emitted=emitted,
+            skipped=sum(skip_reasons.values()),
+            out_dir=out_dir,
+            skip_reasons=skip_reasons,
+        )
+
+    # ----- sandbox -----------------------------------------------------------
+
+    def _start_validation_sandbox(self):
+        from repo2rlenv.bootstrap.docker import DockerSandbox
+
+        marker = Path(tempfile.mkdtemp(prefix="r2e-cve-patches-"))
+        (marker / ".keep").write_text("")
+        return DockerSandbox.start(
+            base_image=self.bootstrap.image_tag,
+            repo_dir=marker,
+            platform=self.input.bootstrap.platform,
+        )
+
+    # ----- task builder -------------------------------------------------------
+
+    def _build_task(
+        self,
+        *,
+        vuln: OSVVuln,
+        fix_sha: str,
+        parent_sha: str,
+        patch: str,
+        test_patch: str,
+        fail_to_pass: list[str],
+        pass_to_pass: list[str],
+        validation_status: str,
+    ) -> HarborTask:
+        owner, name = self.input.repo.owner_name
+        # Use the CVE id (or fallback to OSV id) for the task slug — stable + human-readable
+        slug_id = (vuln.cve_id or vuln.id).replace("/", "_")
+        task_id = f"{owner}__{name}-cve-{slug_id}"
+
+        eval_script = build_eval_script(
+            base_commit=parent_sha,
+            test_patch=test_patch,
+            test_cmds=targeted_test_cmds_for_pr(
+                normalize_test_cmds_for_runtime(self.bootstrap.test_cmds),
+                _files_in_patch(test_patch),
+            ),
+            language=self.bootstrap.language.value,
+        )
+        image_ref = (
+            self.bootstrap.image_digest
+            if self.bootstrap.pushed_to_registry
+            else self.bootstrap.image_tag
+        )
+        dockerfile = build_environment_dockerfile(
+            bootstrap_image=image_ref,
+            base_commit=parent_sha,
+        )
+
+        repo2env = {
+            "pipeline": "cve_patches",
+            "pipeline_version": "0.7.0",
+            "repo": f"{owner}/{name}",
+            "ref": parent_sha,
+            "reference": f"https://github.com/{owner}/{name}/commit/{fix_sha}",
+            "source_access": self.input.repo.access,
+            "built_at": datetime.now(UTC).isoformat(),
+            "synthesis_llm": self.input.llm.qualified_name,
+            "reward_kinds": ["test_execution", "diff_similarity"],
+            "cve_patches": {
+                "cve_id": vuln.cve_id or "",
+                "osv_id": vuln.id,
+                "aliases": vuln.aliases,
+                "cwe_ids": vuln.cwe_ids,
+                "severity": vuln.severity_text,
+                "published": vuln.published,
+                "fix_commit": fix_sha,
+                "parent_commit": parent_sha,
+                "fail_to_pass": fail_to_pass,
+                "pass_to_pass": pass_to_pass,
+                "validation_status": validation_status,
+                "bootstrap_image": self.bootstrap.image_digest,
+            },
+        }
+
+        return HarborTask(
+            name=task_id,
+            org=self.input.output.org,
+            description=vuln.summary or task_id,
+            instruction=_build_instruction(vuln),
+            oracle_diff=patch,
+            repo2env=repo2env,
+            difficulty="hard",  # CVE fixes are harder than vanilla bugs
+            category="security",
+            keywords=[name, "cve_patches", "security"],
+            environment_dockerfile=dockerfile,
+            test_script=eval_script,
+        )

--- a/src/repo2rlenv/pipelines/equivalence_tests.py
+++ b/src/repo2rlenv/pipelines/equivalence_tests.py
@@ -1,0 +1,559 @@
+"""R2E-style function-level equivalence-test synthesis.
+
+For each module-level function in the target repo:
+
+  1. Filter via AST (LOC range, has args + return, no obvious side effects)
+  2. One LLM call asks for a pytest test that imports both `name` and
+     `reference_name` from `task_module` and asserts equality across
+     ≥5 inputs
+  3. Verify two-stage in the bootstrap container:
+       - Stage A: `name` stubbed (raise NotImplementedError), `reference_name`
+                  is the original → test must FAIL
+       - Stage B: `name = reference_name = original` → test must PASS
+  4. Emit Harbor task whose gold patch adds `task_module.py` (with both
+     `name` and `reference_name` set to the original implementation) plus
+     a `test_r2e_<hash>.py` test file at the repo root.
+
+Different from `code_instruct`:
+  - The "problem" is grounded in a real function we extracted, not invented
+  - The LLM only writes the test; we already have the ground truth
+  - Yield scales with the number of qualifying functions in the repo
+
+----------------------------------------------------------------------------
+Acknowledgment
+----------------------------------------------------------------------------
+Inspired by:
+
+  R2E: Turning any Github Repository into a Programming Agent Environment
+  (Jain et al., ICML '24)
+  https://github.com/r2e-project/r2e        (MIT)
+
+The reference-oracle test pattern (`reference_<name>` as frozen oracle,
+test compares both implementations) and the function-extractor filter
+set are adapted from R2E's `repo_builder/fut_extractor/` + `generators/
+testgen/prompt.py`. No code is copied; the implementation is original.
+
+Released under Apache-2.0 along with the rest of Repo2RLEnv.
+----------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import random
+import re
+import shutil
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import ClassVar
+
+from repo2rlenv.auth import resolve_github_token
+from repo2rlenv.bootstrap.runner import _shallow_clone_at_ref
+from repo2rlenv.bootstrap.spec import BootstrapResult
+from repo2rlenv.emitter.harbor import HarborTask, write_harbor_task
+from repo2rlenv.llm import complete
+from repo2rlenv.pipelines._function_extractor import FunctionCandidate, walk_repo
+from repo2rlenv.pipelines.base import PipelineResult
+from repo2rlenv.pipelines.code_instruct import _all_tests_passed, build_code_instruct_dockerfile
+from repo2rlenv.pipelines.mutation_bugs import build_mutation_eval_script
+from repo2rlenv.spec.input import GenerationInput, PipelineName
+from repo2rlenv.spec.options import EquivalenceTestsOptions
+
+logger = logging.getLogger(__name__)
+
+
+PROMPT_SYSTEM = """You are a senior Python engineer writing differential equivalence tests.
+
+You will be shown one function from an open-source library. Your job: write a single pytest test file that imports BOTH `<name>` and `reference_<name>` from the module `task_module`, and asserts they produce identical outputs across a diverse set of inputs.
+
+STRICT REQUIREMENTS:
+- Output ONE section labelled `[Test]` and nothing else (no preamble, no closing notes).
+- Use plain `def test_*(): assert ...` style — NO unittest.TestCase, NO fixtures, NO mocks.
+- The test MUST import both names from `task_module`: `from task_module import {name}, reference_{name}`.
+- Cover at least 5 distinct inputs: normal cases + edge cases (empty / zero / boundary) + adversarial cases where it makes sense.
+- Use literal Python values that can be constructed without third-party libraries. If the function takes complex types, build them in the test.
+- Each input case should be its own `def test_*():` function (so failures are isolated).
+- DO NOT call any function other than `{name}` and `reference_{name}` (and Python builtins / stdlib).
+- DO NOT redefine `{name}` or `reference_{name}` in the test.
+- If the function's behavior depends on randomness, use `random.seed(0)` before each call.
+"""
+
+
+PROMPT_USER_TEMPLATE = """Reference function (from `{path}`, lines {start}-{end}):
+
+```python
+{source}
+```
+
+Signature args: {arg_names}.
+
+Write the equivalence test now."""
+
+
+@dataclass(slots=True)
+class _VerifyOutcome:
+    accepted: bool = False
+    reason: str = ""
+    stub_log: str = ""
+    oracle_log: str = ""
+
+
+@dataclass(slots=True)
+class _ParsedTest:
+    code: str  # the test file body
+
+
+def _extract_test_section(text: str) -> _ParsedTest | None:
+    """Extract `[Test]` section content from an LLM response. Returns None if missing."""
+    m = re.search(r"(?im)^\s*\[\s*test\s*\]\s*$", text)
+    if not m:
+        return None
+    body = text[m.end() :]
+    # Stop at next `[Something Else]` section if present
+    nxt = re.search(r"(?im)^\s*\[\s*[a-zA-Z][a-zA-Z ]+\s*\]\s*$", body)
+    if nxt:
+        body = body[: nxt.start()]
+    # Strip a surrounding code fence
+    fence = re.match(r"^\s*```(?:python|py)?\s*\n(.*?)\n```\s*$", body.strip(), re.DOTALL)
+    if fence:
+        body = fence.group(1)
+    body = body.strip()
+    if not body:
+        return None
+    return _ParsedTest(code=body)
+
+
+_IMPORT_PATTERN = re.compile(
+    r"^\s*(?:from\s+task_module\s+import|import\s+task_module)\b",
+    re.MULTILINE,
+)
+
+
+def uses_both_names(test_code: str, name: str) -> bool:
+    """True iff the test imports from task_module AND references both names.
+
+    Defense against the LLM writing a trivial test (e.g., only uses
+    `reference_<name>` and never calls `<name>` — which would pass even
+    when `<name>` is stubbed).
+    """
+    if not _IMPORT_PATTERN.search(test_code):
+        return False
+    # Both names must appear as bare identifiers somewhere in the test
+    name_used = re.search(rf"\b{re.escape(name)}\b", test_code) is not None
+    ref_used = re.search(rf"\breference_{re.escape(name)}\b", test_code) is not None
+    return name_used and ref_used
+
+
+def _stub_module(candidate: FunctionCandidate) -> str:
+    """Build `task_module.py` with `<name>` STUBBED + `reference_<name>` original.
+
+    Used in Stage A of verification: confirms the test actually exercises
+    `<name>` (else it would pass when `<name>` raises NotImplementedError).
+    """
+    ref_source = _rename_function_source(
+        candidate.source, candidate.name, f"reference_{candidate.name}"
+    )
+    args = ", ".join(candidate.arg_names) if candidate.arg_names else "*args, **kwargs"
+    stub = (
+        f"def {candidate.name}({args}):\n"
+        f'    raise NotImplementedError("implement {candidate.name}")\n'
+    )
+    return ref_source + "\n\n" + stub
+
+
+def _oracle_module(candidate: FunctionCandidate) -> str:
+    """Build `task_module.py` with both `<name>` AND `reference_<name>` set to the original.
+
+    Used in Stage B of verification AND as the gold-patch payload: the
+    agent's job is to make `<name>` equivalent to `reference_<name>`;
+    the gold patch achieves that by giving them the same implementation.
+    """
+    ref_source = _rename_function_source(
+        candidate.source, candidate.name, f"reference_{candidate.name}"
+    )
+    return ref_source + "\n\n" + candidate.source + "\n"
+
+
+def _rename_function_source(source: str, old_name: str, new_name: str) -> str:
+    """Rename `def OLD(...)` → `def NEW(...)` in the source text.
+
+    Only rewrites the `def` line itself, not internal recursive calls
+    (those would change semantics if the function recurses by name).
+    For v0.7 we accept this: most extractable functions aren't recursive,
+    and the few that are will be skipped at Stage B (recursion still calls
+    the *renamed* function so the reference call diverges from the
+    candidate). The skip rate is low; deferring proper recursion handling
+    to v0.8.
+    """
+    pattern = re.compile(rf"^(\s*)(async\s+def|def)\s+{re.escape(old_name)}\b", re.MULTILINE)
+    return pattern.sub(rf"\1\2 {new_name}", source, count=1)
+
+
+def _make_two_file_diff(*, module_code: str, test_code: str, test_filename: str) -> str:
+    """Build a `git apply`-compatible diff adding `task_module.py` + a test file.
+
+    Lifted from code_instruct.py — same shape (two new files at repo root).
+    """
+
+    def new_file_hunk(content: str, path: str) -> str:
+        lines = content.splitlines()
+        n = len(lines)
+        header = (
+            f"diff --git a/{path} b/{path}\n"
+            f"new file mode 100644\n"
+            f"index 0000000..0000001\n"
+            f"--- /dev/null\n"
+            f"+++ b/{path}\n"
+            f"@@ -0,0 +1,{n} @@\n"
+        )
+        body = "".join(f"+{ln}\n" for ln in lines)
+        if not content.endswith("\n"):
+            body += "\\ No newline at end of file\n"
+        return header + body
+
+    return new_file_hunk(module_code, "task_module.py") + new_file_hunk(test_code, test_filename)
+
+
+class EquivalenceTestsPipeline:
+    """R2E-style function-level equivalence-test synthesis."""
+
+    name: ClassVar[PipelineName] = PipelineName.EQUIVALENCE_TESTS
+    requires_bootstrap: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        input: GenerationInput,
+        options: EquivalenceTestsOptions,
+        bootstrap: BootstrapResult | None = None,
+    ):
+        if bootstrap is None:
+            raise RuntimeError(
+                "equivalence_tests requires a BootstrapResult (set requires_bootstrap=True "
+                "and let cmd_generate trigger it, or pass one explicitly)"
+            )
+        self.input = input
+        self.options = options
+        self.bootstrap = bootstrap
+        self._progress_cb = None
+        self._llm_cost_usd = 0.0
+
+    def set_progress_callback(self, cb) -> None:
+        self._progress_cb = cb
+
+    def _emit_progress(self, name: str, outcome: str, reason: str = "") -> None:
+        if self._progress_cb is not None:
+            try:
+                self._progress_cb(name=name, outcome=outcome, reason=reason)
+            except Exception as exc:
+                logger.debug("progress callback failed: %s", exc)
+
+    # ----- run loop -----------------------------------------------------------
+
+    def run(self, out_dir: Path) -> PipelineResult:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        token = resolve_github_token(self.input.repo, self.input.auth)
+        if self.input.repo.access == "private" and not token:
+            raise RuntimeError(
+                "private repo specified but no GitHub token resolved. "
+                "Run `gh auth login` or set GITHUB_TOKEN."
+            )
+
+        owner, name = self.input.repo.owner_name
+        owner_name = f"{owner}/{name}"
+        rng = random.Random(self.options.seed) if self.options.seed is not None else random.Random()
+
+        skip_reasons: dict[str, int] = {}
+        emitted = 0
+        candidates_seen = 0
+        sandbox = None
+
+        with tempfile.TemporaryDirectory(prefix="r2e-equiv-tests-") as tmp:
+            clone_dir = Path(tmp) / "repo"
+            try:
+                _shallow_clone_at_ref(
+                    self.input.repo.url, self.input.repo.ref, token, clone_dir, depth=1
+                )
+            except Exception as exc:
+                raise RuntimeError(f"failed to clone {self.input.repo.url}: {exc}") from exc
+
+            candidates = list(
+                walk_repo(
+                    clone_dir,
+                    file_glob=self.options.file_glob,
+                    exclude_glob=self.options.exclude_glob,
+                    min_loc=self.options.min_loc,
+                    max_loc=self.options.max_loc,
+                )
+            )
+            logger.info("equivalence_tests: %d candidate functions", len(candidates))
+            rng.shuffle(candidates)
+
+            try:
+                if not self.options.skip_validation:
+                    sandbox = self._start_sandbox()
+
+                for cand in candidates:
+                    if emitted >= self.options.limit:
+                        break
+                    candidates_seen += 1
+                    label = f"{owner_name}:{cand.relative_path}::{cand.name}"
+
+                    parsed = self._llm_generate_test(cand)
+                    if parsed is None:
+                        skip_reasons["llm_parse_failed"] = (
+                            skip_reasons.get("llm_parse_failed", 0) + 1
+                        )
+                        self._emit_progress(label, "skip", "llm_parse_failed")
+                        continue
+
+                    # Syntactic: test imports + uses both names
+                    if not uses_both_names(parsed.code, cand.name):
+                        skip_reasons["test_missing_both_names"] = (
+                            skip_reasons.get("test_missing_both_names", 0) + 1
+                        )
+                        self._emit_progress(label, "skip", "test_missing_both_names")
+                        continue
+
+                    test_filename = self._task_test_filename(cand, parsed)
+
+                    if not self.options.skip_validation:
+                        outcome = self._verify_task(
+                            sandbox=sandbox,
+                            cand=cand,
+                            test_code=parsed.code,
+                            test_filename=test_filename,
+                        )
+                        if not outcome.accepted:
+                            skip_reasons[outcome.reason] = skip_reasons.get(outcome.reason, 0) + 1
+                            self._emit_progress(label, "skip", outcome.reason)
+                            continue
+
+                    task = self._build_task(cand, parsed.code, test_filename=test_filename)
+                    write_harbor_task(task, out_dir)
+                    emitted += 1
+                    logger.info(
+                        "emitted task %s (function=%s, loc=%d)",
+                        task.name,
+                        cand.name,
+                        cand.body_loc,
+                    )
+                    self._emit_progress(task.name, "emit")
+            finally:
+                if sandbox is not None:
+                    sandbox.cleanup()
+                shutil.rmtree(clone_dir, ignore_errors=True)
+
+        return PipelineResult(
+            candidates=candidates_seen,
+            emitted=emitted,
+            skipped=sum(skip_reasons.values()),
+            out_dir=out_dir,
+            skip_reasons=skip_reasons,
+        )
+
+    # ----- LLM ---------------------------------------------------------------
+
+    def _llm_generate_test(self, cand: FunctionCandidate) -> _ParsedTest | None:
+        user = PROMPT_USER_TEMPLATE.format(
+            path=cand.relative_path,
+            start=cand.lineno,
+            end=cand.end_lineno,
+            source=cand.source,
+            arg_names=", ".join(cand.arg_names),
+        )
+        try:
+            resp = complete(
+                self.input.llm,
+                system=PROMPT_SYSTEM.format(name=cand.name),
+                user=user,
+                max_tokens=self.options.max_llm_tokens,
+                temperature=self.options.llm_temperature,
+            )
+        except Exception as exc:
+            logger.warning("equivalence_tests LLM call failed: %s", exc)
+            return None
+        self._llm_cost_usd += resp.cost_usd
+        return _extract_test_section(resp.content)
+
+    # ----- sandbox -----------------------------------------------------------
+
+    def _start_sandbox(self):
+        from repo2rlenv.bootstrap.docker import DockerSandbox
+
+        marker = Path(tempfile.mkdtemp(prefix="r2e-equiv-tests-"))
+        (marker / ".keep").write_text("")
+        return DockerSandbox.start(
+            base_image=self.bootstrap.image_tag,
+            repo_dir=marker,
+            platform=self.input.bootstrap.platform,
+        )
+
+    def _verify_task(
+        self,
+        *,
+        sandbox,
+        cand: FunctionCandidate,
+        test_code: str,
+        test_filename: str,
+    ) -> _VerifyOutcome:
+        """Two-stage verification.
+
+        Stage A: stub `<name>`, keep `reference_<name>` correct → test must FAIL.
+        Stage B: both `<name>` and `reference_<name>` are the original → test
+                 must PASS.
+
+        If either invariant breaks, the task is skipped.
+        """
+        stub_module = _stub_module(cand)
+        oracle_module = _oracle_module(cand)
+        enc_test = base64.b64encode(test_code.encode("utf-8")).decode("ascii")
+
+        # Stage A — stubbed
+        enc_stub = base64.b64encode(stub_module.encode("utf-8")).decode("ascii")
+        script_a = (
+            "set -uxo pipefail\n"
+            "cd /workspace\n"
+            "git config --global --add safe.directory /workspace\n"
+            "git reset --hard HEAD\n"
+            "git clean -fdx -e .venv -e venv -e __pycache__ || true\n"
+            f"echo {enc_stub} | base64 -d > task_module.py\n"
+            f"echo {enc_test} | base64 -d > {test_filename}\n"
+            ": 'START_TEST_OUTPUT'\n"
+            f"python -m pytest {test_filename} -v --no-header || true\n"
+            ": 'END_TEST_OUTPUT'\n"
+        )
+        a = sandbox.exec(script_a, timeout=self.options.validation_timeout_sec)
+        stub_log = a.stdout[-4000:] if a.stdout else ""
+        stub_passes = _all_tests_passed(stub_log)
+        if self.options.require_test_fails_with_stub and stub_passes:
+            return _VerifyOutcome(
+                accepted=False,
+                reason="test_passes_with_stub",
+                stub_log=stub_log,
+            )
+
+        # Stage B — oracle in place
+        enc_oracle = base64.b64encode(oracle_module.encode("utf-8")).decode("ascii")
+        script_b = (
+            "set -uxo pipefail\n"
+            "cd /workspace\n"
+            f"echo {enc_oracle} | base64 -d > task_module.py\n"
+            ": 'START_TEST_OUTPUT'\n"
+            f"python -m pytest {test_filename} -v --no-header\n"
+            ": 'END_TEST_OUTPUT'\n"
+            f"rm -f task_module.py {test_filename}\n"
+        )
+        b = sandbox.exec(script_b, timeout=self.options.validation_timeout_sec)
+        oracle_log = b.stdout[-4000:] if b.stdout else ""
+        oracle_passes = b.ok and _all_tests_passed(oracle_log)
+        if self.options.require_test_passes_with_oracle and not oracle_passes:
+            return _VerifyOutcome(
+                accepted=False,
+                reason="oracle_does_not_satisfy_test",
+                stub_log=stub_log,
+                oracle_log=oracle_log,
+            )
+
+        return _VerifyOutcome(accepted=True, stub_log=stub_log, oracle_log=oracle_log)
+
+    # ----- task builder -------------------------------------------------------
+
+    def _task_test_filename(self, cand: FunctionCandidate, parsed: _ParsedTest) -> str:
+        h = hashlib.sha256()
+        h.update(cand.relative_path.encode())
+        h.update(b"\0")
+        h.update(cand.name.encode())
+        h.update(b"\0")
+        h.update(parsed.code.encode())
+        return f"test_r2e_{h.hexdigest()[:10]}.py"
+
+    def _build_task(
+        self,
+        cand: FunctionCandidate,
+        test_code: str,
+        *,
+        test_filename: str,
+    ) -> HarborTask:
+        owner, name = self.input.repo.owner_name
+        h = hashlib.sha256()
+        h.update(cand.relative_path.encode())
+        h.update(b"\0")
+        h.update(cand.name.encode())
+        task_id = f"{owner}__{name}-eqv-{h.hexdigest()[:8]}"
+
+        module_code = _oracle_module(cand)
+        gold_diff = _make_two_file_diff(
+            module_code=module_code, test_code=test_code, test_filename=test_filename
+        )
+        eval_script = build_mutation_eval_script(
+            [f"python -m pytest {test_filename} -v --no-header"],
+            language=self.bootstrap.language.value,
+        )
+        image_ref = (
+            self.bootstrap.image_digest
+            if self.bootstrap.pushed_to_registry
+            else self.bootstrap.image_tag
+        )
+        dockerfile = build_code_instruct_dockerfile(image_ref)
+
+        instruction = _build_instruction(cand)
+
+        repo2env = {
+            "pipeline": "equivalence_tests",
+            "pipeline_version": "0.7.0",
+            "repo": f"{owner}/{name}",
+            "ref": self.input.repo.ref,
+            "reference": (
+                f"https://github.com/{owner}/{name}/blob/{self.input.repo.ref}/"
+                f"{cand.relative_path}#L{cand.lineno}-L{cand.end_lineno}"
+            ),
+            "source_access": self.input.repo.access,
+            "built_at": datetime.now(UTC).isoformat(),
+            "synthesis_llm": self.input.llm.qualified_name,
+            "reward_kinds": ["test_execution"],
+            "equivalence_tests": {
+                "function_name": cand.name,
+                "source_path": cand.relative_path,
+                "source_lineno": cand.lineno,
+                "source_end_lineno": cand.end_lineno,
+                "body_loc": cand.body_loc,
+                "arg_names": list(cand.arg_names),
+                "test_filename": test_filename,
+                "bootstrap_image": self.bootstrap.image_digest,
+                "llm_cost_usd": round(self._llm_cost_usd, 6),
+            },
+        }
+
+        return HarborTask(
+            name=task_id,
+            org=self.input.output.org,
+            description=f"Implement {cand.name} equivalently to the reference",
+            instruction=instruction,
+            oracle_diff=gold_diff,
+            repo2env=repo2env,
+            difficulty="medium",
+            category="equivalence",
+            keywords=[name, "equivalence_tests"],
+            environment_dockerfile=dockerfile,
+            test_script=eval_script,
+        )
+
+
+def _build_instruction(cand: FunctionCandidate) -> str:
+    docstring_block = f"\n\n**Docstring:**\n\n> {cand.docstring}\n" if cand.docstring else ""
+    return (
+        f"# Implement `{cand.name}`\n\n"
+        f"Implement the function `{cand.name}` in `task_module.py` so that it is "
+        f"behaviorally equivalent to `reference_{cand.name}` (which is already provided "
+        f"in `task_module.py`).\n\n"
+        f"**Source (from `{cand.relative_path}` lines {cand.lineno}-{cand.end_lineno}):**\n\n"
+        f"```python\n{cand.source}\n```{docstring_block}\n\n"
+        f"## Task\n\n"
+        f"The test file `test_r2e_*.py` imports both `{cand.name}` and "
+        f"`reference_{cand.name}` from `task_module` and asserts equality across "
+        f"a variety of inputs. Your implementation passes when all assertions hold."
+    )

--- a/src/repo2rlenv/spec/options.py
+++ b/src/repo2rlenv/spec/options.py
@@ -209,6 +209,79 @@ class CodeInstructOptions(_BaseOptions):
     skip_decontamination: bool = False
 
 
+class CVEPatchesOptions(_BaseOptions):
+    """Map OSV vulnerability records to fixing commits in the target repo.
+
+    For each vuln returned by OSV's `/v1/query`, find a `references[]` URL
+    pointing at `github.com/<owner>/<repo>/commit/<sha>`, fetch that
+    commit's diff, split into source/test patches, and emit a Harbor task
+    whose verifier mirrors `commit_runtime` (F2P/P2P validation when a
+    test_patch is present; emission-only otherwise).
+
+    See docs/pipelines/cve_patches.md.
+    """
+
+    # --- OSV discovery ---
+    osv_ecosystem: str | None = None  # "PyPI" / "npm" / "crates.io" / ... (None ⇒ auto-guess)
+    osv_package: str | None = None  # package name (None ⇒ use repo name)
+    min_severity: Literal["low", "medium", "moderate", "high", "critical"] = "low"
+
+    # --- Output cap ---
+    limit: int = 50
+
+    # --- Validation (mirrors PRRuntimeOptions) ---
+    require_fail_to_pass: bool = False  # CVE fixes often have no test_patch — accept anyway
+    min_fail_to_pass: int = 0
+    validation_timeout_sec: int = 600
+    skip_validation: bool = False
+
+    # --- Structural filters ---
+    require_new_test_funcs: bool = False  # security commits often DON'T add new tests
+    max_source_files_per_fix: int = 50
+
+
+class EquivalenceTestsOptions(_BaseOptions):
+    """R2E-style function-level equivalence-test synthesis.
+
+    Extracts module-level Python functions from the target repo, asks the
+    LLM to write a pytest test that calls both `<name>` (candidate, stubbed
+    in env) and `reference_<name>` (frozen oracle) with crafted inputs and
+    asserts outputs match. Verifies in-sandbox: the test must FAIL when
+    `<name>` is stubbed and PASS when `<name>` is the original.
+
+    See docs/pipelines/equivalence_tests.md.
+    """
+
+    # --- Discovery ---
+    limit: int = 50
+    min_loc: int = 5  # min lines in function body
+    max_loc: int = 60  # max lines in function body
+    file_glob: str = "**/*.py"
+    exclude_glob: list[str] = [
+        "tests/**",
+        "test_**",
+        "**/test_*.py",
+        "**/*_test.py",
+        "**/conftest.py",
+        "docs/**",
+        "examples/**",
+        "**/__init__.py",
+        "**/setup.py",
+    ]
+    seed: int | None = None
+    max_attempts_per_function: int = 1
+
+    # --- LLM ---
+    llm_temperature: float = 0.5  # lower than code_instruct — we want stable tests
+    max_llm_tokens: int = 1500
+
+    # --- Verification ---
+    require_test_fails_with_stub: bool = True
+    require_test_passes_with_oracle: bool = True
+    validation_timeout_sec: int = 90
+    skip_validation: bool = False
+
+
 OPTIONS_REGISTRY: dict[str, type[_BaseOptions]] = {
     "pr_runtime": PRRuntimeOptions,
     "pr_diff": PRDiffOptions,
@@ -216,6 +289,8 @@ OPTIONS_REGISTRY: dict[str, type[_BaseOptions]] = {
     "commit_runtime": CommitRuntimeOptions,
     "mutation_bugs": MutationBugsOptions,
     "code_instruct": CodeInstructOptions,
+    "equivalence_tests": EquivalenceTestsOptions,
+    "cve_patches": CVEPatchesOptions,
 }
 
 

--- a/tests/test_function_extractor.py
+++ b/tests/test_function_extractor.py
@@ -1,0 +1,236 @@
+"""AST function extractor for equivalence_tests — unit tests.
+
+Each test feeds a small Python source string through extract_from_module
+and checks that the right candidates survive.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repo2rlenv.pipelines._function_extractor import (
+    extract_from_module,
+    walk_repo,
+)
+
+
+def _extract(source: str, *, min_loc: int = 1, max_loc: int = 200):
+    return extract_from_module(
+        Path("/dev/null"),
+        source,
+        relative_path="src/foo.py",
+        min_loc=min_loc,
+        max_loc=max_loc,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic acceptance
+# ---------------------------------------------------------------------------
+
+
+def test_extracts_simple_function():
+    source = 'def add(x, y):\n    """Sum two ints."""\n    return x + y\n'
+    out = _extract(source)
+    assert len(out) == 1
+    c = out[0]
+    assert c.name == "add"
+    assert c.arg_names == ("x", "y")
+    assert c.docstring == "Sum two ints."
+    assert "return x + y" in c.source
+
+
+def test_skips_zero_arg_function():
+    """Functions with no args can't be exercised by an equivalence test."""
+    source = "def get():\n    return 42\n"
+    assert _extract(source) == []
+
+
+def test_skips_no_explicit_return():
+    """Functions without `return <expr>` give no output to compare."""
+    source = 'def shout(msg):\n    """Print loudly."""\n    print(msg.upper())\n'
+    out = _extract(source)
+    assert out == []
+
+
+def test_skips_bare_return():
+    """`return` without a value isn't useful for differential testing."""
+    source = "def maybe(x):\n    if x:\n        return\n"
+    assert _extract(source) == []
+
+
+def test_skips_async_functions():
+    source = "async def fetch(url):\n    return await get(url)\n"
+    assert _extract(source) == []
+
+
+# ---------------------------------------------------------------------------
+# LOC range filter
+# ---------------------------------------------------------------------------
+
+
+def test_below_min_loc_filtered():
+    source = "def f(x):\n    return x\n"  # body = 1 line
+    assert _extract(source, min_loc=5, max_loc=100) == []
+
+
+def test_above_max_loc_filtered():
+    body = "\n".join(f"    x = x + {i}" for i in range(20))
+    source = f"def f(x):\n{body}\n    return x\n"
+    assert _extract(source, min_loc=1, max_loc=5) == []
+
+
+def test_within_loc_range_kept():
+    body = "\n".join(f"    x = x + {i}" for i in range(5))
+    source = f"def f(x):\n{body}\n    return x\n"
+    out = _extract(source, min_loc=5, max_loc=10)
+    assert len(out) == 1
+
+
+# ---------------------------------------------------------------------------
+# Name filters
+# ---------------------------------------------------------------------------
+
+
+def test_skips_test_prefix():
+    source = "def test_add(x, y):\n    return x + y\n"
+    assert _extract(source) == []
+
+
+def test_skips_underscore_prefix():
+    source = "def _helper(x):\n    return x + 1\n"
+    assert _extract(source) == []
+
+
+def test_skips_main():
+    source = "def main(argv):\n    return argv[0]\n"
+    assert _extract(source) == []
+
+
+def test_skips_dunder():
+    source = "def __getitem__(self, idx):\n    return idx\n"
+    # __getitem__ is on a class technically; even at module level it starts with _
+    assert _extract(source) == []
+
+
+# ---------------------------------------------------------------------------
+# Side-effect heuristics
+# ---------------------------------------------------------------------------
+
+
+def test_skips_open():
+    source = (
+        "def read_text(path):\n"
+        '    """Read a file."""\n'
+        "    with open(path) as f:\n"
+        "        return f.read()\n"
+    )
+    assert _extract(source) == []
+
+
+def test_skips_subprocess():
+    source = "def run_cmd(cmd):\n    import subprocess\n    return subprocess.run(cmd).returncode\n"
+    assert _extract(source) == []
+
+
+def test_skips_print():
+    source = "def logging_helper(x):\n    print(x)\n    return x\n"
+    assert _extract(source) == []
+
+
+def test_pure_function_accepted():
+    source = (
+        "def total(items):\n"
+        '    """Sum the items."""\n'
+        "    n = 0\n"
+        "    for x in items:\n"
+        "        n = n + x\n"
+        "    return n\n"
+    )
+    out = _extract(source)
+    assert len(out) == 1
+    assert out[0].name == "total"
+
+
+# ---------------------------------------------------------------------------
+# Multiple functions in one module
+# ---------------------------------------------------------------------------
+
+
+def test_picks_only_module_level():
+    source = "def outer(x):\n    def inner(y):\n        return y * 2\n    return inner(x)\n"
+    out = _extract(source)
+    # Only `outer`, not `inner`
+    assert [c.name for c in out] == ["outer"]
+
+
+def test_picks_multiple_top_level():
+    source = "def double(x):\n    return x * 2\n\ndef triple(x):\n    return x * 3\n"
+    out = _extract(source)
+    assert sorted(c.name for c in out) == ["double", "triple"]
+
+
+def test_skips_class_methods_for_v0_7():
+    """v0.7 scope: module-level only. Class methods need different handling."""
+    source = "class Counter:\n    def inc(self, n):\n        return self.value + n\n"
+    assert _extract(source) == []
+
+
+# ---------------------------------------------------------------------------
+# Source slicing
+# ---------------------------------------------------------------------------
+
+
+def test_source_includes_decorators():
+    source = "@staticmethod\n@cache\ndef add(x, y):\n    return x + y\n"
+    out = _extract(source)
+    assert len(out) == 1
+    assert "@staticmethod" in out[0].source
+    assert "@cache" in out[0].source
+
+
+def test_handles_syntax_error_gracefully():
+    """Un-parseable source yields no candidates instead of raising."""
+    source = "def f( :\n"  # invalid
+    assert _extract(source) == []
+
+
+# ---------------------------------------------------------------------------
+# walk_repo
+# ---------------------------------------------------------------------------
+
+
+def test_walk_repo_respects_globs(tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "src" / "a.py").write_text("def hello(x):\n    return x\n")
+    (tmp_path / "tests" / "test_a.py").write_text("def test_hello(x):\n    return x\n")
+
+    found = list(
+        walk_repo(
+            tmp_path,
+            file_glob="**/*.py",
+            exclude_glob=["tests/**"],
+            min_loc=1,
+            max_loc=50,
+        )
+    )
+    paths = {c.relative_path for c in found}
+    assert paths == {"src/a.py"}
+
+
+def test_walk_repo_handles_unreadable_file(tmp_path: Path):
+    """An I/O error on one file shouldn't blow up the whole walk."""
+    (tmp_path / "good.py").write_text("def x(a):\n    return a + 1\n")
+    # Create a binary file with invalid utf-8 — read_text uses errors="replace"
+    (tmp_path / "binary.py").write_bytes(b"\x00\x01\x02\x03 not python")
+    found = list(
+        walk_repo(
+            tmp_path,
+            file_glob="*.py",
+            exclude_glob=[],
+            min_loc=1,
+            max_loc=50,
+        )
+    )
+    assert {c.name for c in found} == {"x"}

--- a/tests/test_osv.py
+++ b/tests/test_osv.py
@@ -1,0 +1,181 @@
+"""OSV client + helpers — unit tests.
+
+Network calls are not exercised here (we don't hit api.osv.dev from tests).
+We feed canned raw JSON shapes through `_from_raw` and verify parsing,
+filter-by-repo behavior, and severity comparisons.
+"""
+
+from __future__ import annotations
+
+from repo2rlenv.osv import (
+    OSVVuln,
+    _from_raw,
+    guess_ecosystem,
+    severity_at_least,
+)
+
+# ---------------------------------------------------------------------------
+# _from_raw
+# ---------------------------------------------------------------------------
+
+
+def test_from_raw_minimal():
+    raw = {"id": "GHSA-abc-def-ghi"}
+    v = _from_raw(raw)
+    assert v.id == "GHSA-abc-def-ghi"
+    assert v.aliases == []
+    assert v.summary == ""
+    assert v.severity_text == ""
+
+
+def test_from_raw_full():
+    raw = {
+        "id": "GHSA-29vq-49wr-vm6x",
+        "aliases": ["CVE-2026-1234", "PYSEC-2026-1"],
+        "summary": "Werkzeug safe_join() bypass",
+        "details": "On Windows, the safe_join() function ...",
+        "database_specific": {
+            "severity": "HIGH",
+            "cwe_ids": ["CWE-22"],
+        },
+        "published": "2026-02-19T00:00:00Z",
+        "references": [
+            {"type": "ADVISORY", "url": "https://github.com/.../GHSA-29vq-49wr-vm6x"},
+            {
+                "type": "WEB",
+                "url": "https://github.com/pallets/werkzeug/commit/f407712fdc60a09c2b3f4fe7db557703e5d9338d",
+            },
+        ],
+    }
+    v = _from_raw(raw)
+    assert v.id == "GHSA-29vq-49wr-vm6x"
+    assert v.aliases == ["CVE-2026-1234", "PYSEC-2026-1"]
+    assert v.severity_text == "HIGH"
+    assert v.cwe_ids == ["CWE-22"]
+
+
+# ---------------------------------------------------------------------------
+# OSVVuln.cve_id
+# ---------------------------------------------------------------------------
+
+
+def test_cve_id_from_aliases():
+    v = OSVVuln(id="GHSA-x-y-z", aliases=["CVE-2026-1234"])
+    assert v.cve_id == "CVE-2026-1234"
+
+
+def test_cve_id_from_primary_id():
+    v = OSVVuln(id="CVE-2024-9999")
+    assert v.cve_id == "CVE-2024-9999"
+
+
+def test_cve_id_none_when_neither_has_cve():
+    v = OSVVuln(id="GHSA-x", aliases=["PYSEC-2026-1"])
+    assert v.cve_id is None
+
+
+# ---------------------------------------------------------------------------
+# OSVVuln.fix_commits
+# ---------------------------------------------------------------------------
+
+
+def test_fix_commits_filters_by_owner_repo():
+    v = OSVVuln(
+        id="x",
+        references=[
+            {"type": "WEB", "url": "https://github.com/pallets/werkzeug/commit/abc1234567890"},
+            {"type": "WEB", "url": "https://github.com/fork/werkzeug/commit/feedface1234567"},
+            {"type": "ADVISORY", "url": "https://nvd.nist.gov/..."},
+        ],
+    )
+    assert v.fix_commits(owner="pallets", repo="werkzeug") == ["abc1234567890"]
+
+
+def test_fix_commits_supports_pr_commit_url():
+    v = OSVVuln(
+        id="x",
+        references=[
+            {
+                "type": "WEB",
+                "url": "https://github.com/pallets/werkzeug/pull/1234/commits/abc1234567890",
+            },
+        ],
+    )
+    assert v.fix_commits(owner="pallets", repo="werkzeug") == ["abc1234567890"]
+
+
+def test_fix_commits_deduplicates():
+    v = OSVVuln(
+        id="x",
+        references=[
+            {"type": "WEB", "url": "https://github.com/pallets/werkzeug/commit/aaaaaa1234567"},
+            {"type": "WEB", "url": "https://github.com/pallets/werkzeug/commit/aaaaaa1234567"},
+        ],
+    )
+    assert v.fix_commits(owner="pallets", repo="werkzeug") == ["aaaaaa1234567"]
+
+
+def test_fix_commits_empty_when_no_github_commit_refs():
+    v = OSVVuln(
+        id="x",
+        references=[
+            {"type": "WEB", "url": "https://example.com/blog"},
+            {"type": "ADVISORY", "url": "https://nvd.nist.gov/..."},
+        ],
+    )
+    assert v.fix_commits(owner="pallets", repo="werkzeug") == []
+
+
+# ---------------------------------------------------------------------------
+# severity_at_least
+# ---------------------------------------------------------------------------
+
+
+def test_severity_high_at_least_medium():
+    v = OSVVuln(id="x", severity_text="HIGH")
+    assert severity_at_least(v, "medium")
+
+
+def test_severity_low_below_high():
+    v = OSVVuln(id="x", severity_text="LOW")
+    assert not severity_at_least(v, "high")
+
+
+def test_severity_critical_at_least_critical():
+    v = OSVVuln(id="x", severity_text="CRITICAL")
+    assert severity_at_least(v, "critical")
+
+
+def test_severity_moderate_treated_as_medium():
+    v = OSVVuln(id="x", severity_text="MODERATE")
+    assert severity_at_least(v, "medium")
+
+
+def test_severity_unknown_below_threshold():
+    v = OSVVuln(id="x", severity_text="")
+    assert not severity_at_least(v, "low")
+
+
+# ---------------------------------------------------------------------------
+# guess_ecosystem
+# ---------------------------------------------------------------------------
+
+
+def test_guess_ecosystem_known_pypi():
+    assert guess_ecosystem("pallets") == "PyPI"
+
+
+def test_guess_ecosystem_known_npm():
+    assert guess_ecosystem("expressjs") == "npm"
+
+
+def test_guess_ecosystem_known_crates():
+    assert guess_ecosystem("rust-lang") == "crates.io"
+
+
+def test_guess_ecosystem_unknown_defaults_pypi():
+    assert guess_ecosystem("nobody-knows-this") == "PyPI"
+
+
+def test_guess_ecosystem_case_insensitive():
+    assert guess_ecosystem("PALLETS") == "PyPI"

--- a/tests/test_pipeline_cve_patches.py
+++ b/tests/test_pipeline_cve_patches.py
@@ -1,0 +1,90 @@
+"""cve_patches — pipeline contract + helper unit tests.
+
+OSV client tests live in test_osv.py. Validation harness is exercised
+via pr_runtime tests (we reuse it verbatim). This file covers:
+
+  - _build_instruction shape
+  - Pipeline contract (requires_bootstrap, missing-bootstrap rejection)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repo2rlenv.osv import OSVVuln
+from repo2rlenv.pipelines.cve_patches import CVEPatchesPipeline, _build_instruction
+from repo2rlenv.spec.options import CVEPatchesOptions
+
+
+def _make_vuln(
+    cve: str = "CVE-2024-1234",
+    severity: str = "HIGH",
+    cwe: list[str] | None = None,
+) -> OSVVuln:
+    return OSVVuln(
+        id="GHSA-abc-def-ghi",
+        aliases=[cve],
+        summary="Brief description of the issue",
+        details="Detailed exposition of the vulnerability.",
+        severity_text=severity,
+        cwe_ids=cwe or ["CWE-22"],
+        published="2024-09-12T00:00:00Z",
+    )
+
+
+def test_instruction_includes_cve_id():
+    out = _build_instruction(_make_vuln())
+    assert "CVE-2024-1234" in out
+    assert "**Severity:** HIGH" in out
+    assert "CWE-22" in out
+    assert "Detailed exposition" in out
+
+
+def test_instruction_falls_back_to_osv_id_when_no_cve():
+    v = OSVVuln(id="GHSA-only", aliases=[], summary="x", details="y", severity_text="LOW")
+    out = _build_instruction(v)
+    assert "GHSA-only" in out
+
+
+def test_instruction_handles_empty_details():
+    v = OSVVuln(id="GHSA-x", summary="brief", severity_text="MEDIUM")
+    out = _build_instruction(v)
+    assert "no detailed description" in out
+
+
+# ---------------------------------------------------------------------------
+# Pipeline contract
+# ---------------------------------------------------------------------------
+
+
+def test_cve_patches_requires_bootstrap_attr():
+    assert CVEPatchesPipeline.requires_bootstrap is True
+
+
+def test_cve_patches_rejects_missing_bootstrap():
+    from repo2rlenv.spec.input import (
+        GenerationInput,
+        LLMSpec,
+        OutputSpec,
+        PipelineName,
+        PipelineSpec,
+        RepoSpec,
+    )
+
+    gen_input = GenerationInput(
+        repo=RepoSpec(url="pallets/werkzeug"),
+        pipeline=PipelineSpec(name=PipelineName.CVE_PATCHES, options={}),
+        llm=LLMSpec(provider="anthropic", model="claude-sonnet-4-6"),
+        output=OutputSpec(destination="./out", org="x", dataset_name="y"),
+    )
+    with pytest.raises(RuntimeError, match="requires a BootstrapResult"):
+        CVEPatchesPipeline(gen_input, CVEPatchesOptions(), bootstrap=None)
+
+
+def test_cve_patches_options_defaults():
+    opts = CVEPatchesOptions()
+    assert opts.limit == 50
+    assert opts.min_severity == "low"
+    assert opts.require_fail_to_pass is False  # CVE fixes often lack test_patch
+    assert opts.osv_ecosystem is None
+    assert opts.osv_package is None

--- a/tests/test_pipeline_equivalence_tests.py
+++ b/tests/test_pipeline_equivalence_tests.py
@@ -1,0 +1,260 @@
+"""equivalence_tests — helpers, builders, and contract conformance.
+
+The function extractor is exercised in test_function_extractor.py.
+Here we cover the pipeline's pure-Python pieces:
+
+  - _extract_test_section (LLM response parsing)
+  - test_uses_both_names (test must reference both `name` and `reference_name`)
+  - _stub_module / _oracle_module (task_module.py shape)
+  - _rename_function_source (rename in source text)
+  - _make_two_file_diff (gold patch shape)
+  - Pipeline contract (requires_bootstrap, missing-bootstrap rejection)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repo2rlenv.pipelines._function_extractor import FunctionCandidate
+from repo2rlenv.pipelines.equivalence_tests import (
+    EquivalenceTestsPipeline,
+    _extract_test_section,
+    _make_two_file_diff,
+    _oracle_module,
+    _rename_function_source,
+    _stub_module,
+    uses_both_names,
+)
+from repo2rlenv.spec.options import EquivalenceTestsOptions
+
+
+def _make_candidate(
+    name: str = "add",
+    arg_names: tuple[str, ...] = ("x", "y"),
+    source: str = 'def add(x, y):\n    """Sum."""\n    return x + y\n',
+    docstring: str = "Sum.",
+    body_loc: int = 2,
+) -> FunctionCandidate:
+    return FunctionCandidate(
+        relative_path="src/foo.py",
+        name=name,
+        lineno=1,
+        end_lineno=3,
+        body_loc=body_loc,
+        source=source,
+        docstring=docstring,
+        arg_names=arg_names,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _extract_test_section
+# ---------------------------------------------------------------------------
+
+
+def test_extracts_test_section_with_fence():
+    text = (
+        "[Test]\n"
+        "```python\n"
+        "from task_module import add, reference_add\n"
+        "def test_add():\n"
+        "    assert add(1, 2) == reference_add(1, 2)\n"
+        "```\n"
+    )
+    parsed = _extract_test_section(text)
+    assert parsed is not None
+    assert "from task_module import add" in parsed.code
+    assert not parsed.code.startswith("```")
+
+
+def test_extracts_test_section_without_fence():
+    text = (
+        "[Test]\n"
+        "from task_module import add, reference_add\n"
+        "def test_add():\n"
+        "    assert add(1, 2) == reference_add(1, 2)\n"
+    )
+    parsed = _extract_test_section(text)
+    assert parsed is not None
+    assert "def test_add" in parsed.code
+
+
+def test_extracts_test_section_case_insensitive():
+    text = (
+        "[test]\n"
+        "from task_module import add, reference_add\n"
+        "def test_x():\n"
+        "    assert add(1, 1) == reference_add(1, 1)\n"
+    )
+    parsed = _extract_test_section(text)
+    assert parsed is not None
+
+
+def test_extract_test_section_returns_none_when_missing():
+    text = "Here is some content but no test section."
+    assert _extract_test_section(text) is None
+
+
+def test_extract_test_section_stops_at_next_section():
+    text = (
+        "[Test]\nfrom task_module import x, reference_x\ndef test_x(): pass\n[Notes]\nignore me\n"
+    )
+    parsed = _extract_test_section(text)
+    assert parsed is not None
+    assert "ignore me" not in parsed.code
+
+
+# ---------------------------------------------------------------------------
+# test_uses_both_names
+# ---------------------------------------------------------------------------
+
+
+def test_uses_both_names_happy_path():
+    code = (
+        "from task_module import add, reference_add\n"
+        "def test_add():\n"
+        "    assert add(1, 2) == reference_add(1, 2)\n"
+    )
+    assert uses_both_names(code, "add")
+
+
+def test_uses_both_names_missing_candidate():
+    """Test that imports only the reference is trivial — reject it."""
+    code = (
+        "from task_module import reference_add\n"
+        "def test_add():\n"
+        "    assert reference_add(1, 2) == 3\n"
+    )
+    assert not uses_both_names(code, "add")
+
+
+def test_uses_both_names_missing_reference():
+    code = "from task_module import add\ndef test_add():\n    assert add(1, 2) == 3\n"
+    assert not uses_both_names(code, "add")
+
+
+def test_uses_both_names_missing_import():
+    code = "def test_add():\n    assert add(1, 2) == reference_add(1, 2)\n"
+    assert not uses_both_names(code, "add")
+
+
+# ---------------------------------------------------------------------------
+# _rename_function_source
+# ---------------------------------------------------------------------------
+
+
+def test_rename_simple_def():
+    src = 'def add(x, y):\n    """Sum."""\n    return x + y\n'
+    out = _rename_function_source(src, "add", "reference_add")
+    assert out.startswith("def reference_add(x, y):")
+
+
+def test_rename_preserves_decorators():
+    src = "@staticmethod\ndef add(x, y):\n    return x + y\n"
+    out = _rename_function_source(src, "add", "reference_add")
+    assert "@staticmethod" in out
+    assert "def reference_add" in out
+
+
+def test_rename_only_renames_def_line():
+    """Internal recursive calls keep the old name — known v0.7 limitation."""
+    src = "def fact(n):\n    return 1 if n <= 1 else n * fact(n - 1)\n"
+    out = _rename_function_source(src, "fact", "reference_fact")
+    assert "def reference_fact" in out
+    # The recursive call still says `fact(n - 1)` — that's the documented v0.7 trade-off
+    assert "fact(n - 1)" in out
+
+
+# ---------------------------------------------------------------------------
+# _stub_module / _oracle_module
+# ---------------------------------------------------------------------------
+
+
+def test_stub_module_has_stubbed_candidate():
+    c = _make_candidate()
+    out = _stub_module(c)
+    assert "def reference_add(x, y):" in out
+    assert "def add(x, y):" in out
+    assert "raise NotImplementedError" in out
+
+
+def test_oracle_module_has_two_definitions():
+    c = _make_candidate()
+    out = _oracle_module(c)
+    assert "def reference_add(x, y):" in out
+    assert "def add(x, y):" in out
+    assert "raise NotImplementedError" not in out
+
+
+# ---------------------------------------------------------------------------
+# _make_two_file_diff
+# ---------------------------------------------------------------------------
+
+
+def test_two_file_diff_has_two_headers():
+    diff = _make_two_file_diff(
+        module_code="def add(x, y):\n    return x + y\n",
+        test_code="from task_module import add\n",
+        test_filename="test_r2e_abc.py",
+    )
+    assert diff.count("diff --git ") == 2
+    assert "diff --git a/task_module.py b/task_module.py" in diff
+    assert "diff --git a/test_r2e_abc.py b/test_r2e_abc.py" in diff
+
+
+def test_two_file_diff_marks_new_files():
+    diff = _make_two_file_diff(
+        module_code="x = 1\n",
+        test_code="y = 2\n",
+        test_filename="test_r2e_x.py",
+    )
+    assert diff.count("new file mode") == 2
+    assert diff.count("--- /dev/null") == 2
+
+
+def test_two_file_diff_hunk_line_counts():
+    diff = _make_two_file_diff(
+        module_code="line1\nline2\nline3\n",
+        test_code="a\nb\n",
+        test_filename="t.py",
+    )
+    assert "@@ -0,0 +1,3 @@" in diff
+    assert "@@ -0,0 +1,2 @@" in diff
+
+
+# ---------------------------------------------------------------------------
+# Pipeline contract
+# ---------------------------------------------------------------------------
+
+
+def test_equivalence_tests_requires_bootstrap_attr():
+    assert EquivalenceTestsPipeline.requires_bootstrap is True
+
+
+def test_equivalence_tests_rejects_missing_bootstrap():
+    from repo2rlenv.spec.input import (
+        GenerationInput,
+        LLMSpec,
+        OutputSpec,
+        PipelineName,
+        PipelineSpec,
+        RepoSpec,
+    )
+
+    gen_input = GenerationInput(
+        repo=RepoSpec(url="huggingface/trl"),
+        pipeline=PipelineSpec(name=PipelineName.EQUIVALENCE_TESTS, options={}),
+        llm=LLMSpec(provider="anthropic", model="claude-sonnet-4-6"),
+        output=OutputSpec(destination="./out", org="x", dataset_name="y"),
+    )
+    with pytest.raises(RuntimeError, match="requires a BootstrapResult"):
+        EquivalenceTestsPipeline(gen_input, EquivalenceTestsOptions(), bootstrap=None)
+
+
+def test_equivalence_tests_options_defaults():
+    opts = EquivalenceTestsOptions()
+    assert opts.limit == 50
+    assert opts.min_loc == 5
+    assert opts.max_loc == 60
+    assert opts.require_test_fails_with_stub is True
+    assert opts.require_test_passes_with_oracle is True

--- a/uv.lock
+++ b/uv.lock
@@ -1249,7 +1249,7 @@ wheels = [
 
 [[package]]
 name = "repo2rlenv"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
Closes #9.

## Summary

Two new pipelines + bump `0.6.0 → 0.7.0`:

- **`equivalence_tests`** (R2E-style function-level synthesis, ICML '24). Extract a real Python function from the repo as a frozen oracle (`reference_<name>`), LLM writes equivalence tests comparing it against a `<name>` candidate, gold patch fills `<name>` with the original implementation. The LLM only writes the test — we already have the ground truth. Lower-variance than `code_instruct`; yield scales with the number of qualifying functions.
- **`cve_patches`** (PatchSeeker / CVE-Bench-inspired). OSV public API client (`POST /v1/query`, no auth needed) → scan `references[]` for `github.com/<owner>/<repo>/commit/<sha>` → fetch the fix commit's diff → reuse `pr_runtime`'s F2P/P2P validation harness when `test_patch` is present, emit-only with `validation_status="no_test_patch"` otherwise.

## Harbor end-to-end

| Pipeline | Repo | Task | Mean reward |
|---|---|---|---|
| `equivalence_tests` | pallets/click | `pallets__click-eqv-a2804cc5` (`getchar`) | **1.000** |
| `cve_patches` | pallets/werkzeug | `pallets__werkzeug-cve-CVE-2023-25577` (DoS via multipart) | **1.000** |

## CI

- **339/339** unit tests pass
- ruff lint + format clean
- Matrix tested on Python 3.12 / 3.13 / 3.14

## New files

- `src/repo2rlenv/osv.py` — OSV API client + severity helpers (stdlib only)
- `src/repo2rlenv/pipelines/_function_extractor.py` — R2E-style AST filters
- `src/repo2rlenv/pipelines/equivalence_tests.py` — pipeline class
- `src/repo2rlenv/pipelines/cve_patches.py` — pipeline class
- Tests: `test_osv.py`, `test_function_extractor.py`, `test_pipeline_{equivalence_tests,cve_patches}.py` (~80 new tests)

## Notable design decisions

1. **Reference-oracle test pattern.** `task_module.py` ships both `reference_<name>` (frozen, used by tests) and `<name>` (stubbed in env, filled by patch). LLM-written tests assert equality. Catches "tautological test" cheats via the Stage-A invariant (test must FAIL when `<name>` is stubbed).
2. **OSV over NVD.** OSV pre-resolves fix-commit URLs in `references[]`, so we don't need a PatchSeeker-style LLM mapper for the common case. No auth required.
3. **No new runtime deps.** Both pipelines are pure stdlib + reuse existing `pr_runtime` helpers (`split_patch_and_test_patch`, `build_environment_dockerfile`, `build_eval_script`, `validate_pr`).
4. **CVE tasks without test_patch are still emitted** with `validation_status="no_test_patch"`. The verifier signal is weak (just "suite passes with fix applied") but the data is useful as training pairs.

## Out of scope (v0.8)

- LLM-judged QA gate (SWE-Bench++ four-layer recipe)
- Iterative refinement loop for `equivalence_tests` (R2E's "feedback → fix_error" cycle)
- LLM-synthesized PoC for `cve_patches` (security implications gating needed)
- Polyglot mutation for `mutation_bugs` (Java/JS/Go via tree-sitter)
- HF Hub append-mode for `pr_stream`

🤖 Generated with [Claude Code](https://claude.com/claude-code)