### PR TITLE
v0.8.2: CLI cleanup — push/pull + drop reward/init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,10 @@ Cutting a release (full flow):
 # Run a full bootstrap with the live UI (interactive terminal only)
 ./demo_bootstrap.sh
 
+# Full end-to-end demo: bootstrap → generate → validate → harbor (oracle + opencode×2)
+./demo_e2e.sh                                # default: pallets/click
+REPO=pocketbase/pocketbase ./demo_e2e.sh     # different repo
+
 # Generate a sandbox-verified dataset (auto-triggers bootstrap if needed)
 uv run repo2rlenv generate \
   --repo <owner>/<repo> --pipeline pr_runtime \
@@ -170,11 +174,18 @@ uv run repo2rlenv generate \
   --llm anthropic/claude-sonnet-4-6 \
   --out ./datasets/<dataset-name>
 
-# Score a candidate diff
-uv run repo2rlenv reward --task ./out/some-task --prediction ./candidate.diff
-
-# Validate a dataset
+# Validate a dataset (fast structural check, no LLM, no Docker)
 uv run repo2rlenv validate ./datasets/<dataset-name>
+
+# Publish to HF Hub
+uv run repo2rlenv push ./datasets/<dataset-name> hf://<your-org>/<dataset-name>
+
+# Pull a published dataset back later
+uv run repo2rlenv pull hf://<your-org>/<dataset-name>
+
+# Diff-similarity reward for training loops — Python import only, no CLI:
+#   from repo2rlenv.reward import calculate_diff_similarity_reward
+# Test-execution reward comes from `harbor run`.
 
 # Run all tests + lint + format check (everything CI runs)
 uv run pytest -q

--- a/README.md
+++ b/README.md
@@ -35,17 +35,23 @@ repo2rlenv generate \
   --llm anthropic/claude-sonnet-4-6 \
   --out ./datasets/<dataset-name>
 
-# Or push straight to HF Hub with --out hf://<your-org>/<dataset-name>
+# Validate the emitted dataset (fast structural check)
+repo2rlenv validate ./datasets/<dataset-name>
 
-# Validate a local dataset against the spec
-repo2rlenv validate ./path/to/dataset
+# Publish to HF Hub
+repo2rlenv push ./datasets/<dataset-name> hf://<your-org>/<dataset-name>
 
-# Score a candidate diff against a task's oracle (diff-similarity reward)
-repo2rlenv reward --task ./datasets/<dataset-name>/<task-id> --prediction ./candidate.diff
+# Pull a published dataset back later
+repo2rlenv pull hf://<your-org>/<dataset-name> ./datasets/<dataset-name>
 
-# Or write a sample config first and use --config
-repo2rlenv init && repo2rlenv generate --config repo2rlenv.config.yaml
+# Run an agent against the spec — Harbor (separate tool) handles execution
+harbor run --agent oracle --path ./datasets/<dataset-name>/<task-id>
 ```
+
+> **Diff-similarity reward for training loops:** import the function directly —
+> `from repo2rlenv.reward import calculate_diff_similarity_reward`. There is no
+> CLI wrapper; Harbor handles test-execution rewards, this function handles the
+> cheap dense signal that RL training uses.
 
 Full walkthrough in [**`docs/quickstart.md`**](./docs/quickstart.md).
 
@@ -98,7 +104,7 @@ A dataset format that:
 - **Trains anywhere via Harbor** — TRL, SkyRL, Prime-RL, Tinker, Miles, Slime, harbor.rl
 - **Evaluates with any agent harness** — Claude Code, OpenHands, Codex CLI, Gemini CLI, …
 - Is **language-agnostic** by spec — `_runtime` pipelines emit Dockerfile + shell verifier; `_diff` pipelines are pure text and work for any language with no extra config
-- **Publishes natively** to Hugging Face Hub — `--out hf://owner/name` writes a Harbor-compatible `registry.json` so consumers can `harbor download` without any glue
+- **Publishes natively** to Hugging Face Hub — `repo2rlenv push ./datasets/<name> hf://owner/name` writes a Harbor-compatible `registry.json` so consumers can `harbor download` (or `repo2rlenv pull`) without any glue
 - Supports **private repos** end-to-end — `gh auth token` resolved automatically; build secrets declared by name; verifier-time secrets forbidden by spec
 
 ---

--- a/docs/pipelines/pr_diff.md
+++ b/docs/pipelines/pr_diff.md
@@ -117,15 +117,15 @@ repo2rlenv generate \
   --llm anthropic/claude-sonnet-4-6 \
   --out ./datasets/trl-r2e
 
-# Generate AND push to HF Hub in one command
+# Generate locally, then push to HF Hub
 repo2rlenv generate \
   --repo huggingface/trl \
   --pipeline pr_diff \
   --pipeline-opt limit=5 \
   --llm anthropic/claude-sonnet-4-6 \
-  --out hf://AdithyaSK/trl-r2e-v0-1 \
-  --org AdithyaSK --dataset-name trl-r2e-v0-1 \
-  --visibility public
+  --out ./datasets/trl-r2e-v0-1
+
+repo2rlenv push ./datasets/trl-r2e-v0-1 hf://AdithyaSK/trl-r2e-v0-1
 ```
 
 ### Python
@@ -163,13 +163,7 @@ oracle = (task_dir / "solution" / "patch.diff").read_text()
 reward, meta = calculate_diff_similarity_reward(oracle, prediction_diff)
 ```
 
-Or via CLI:
-
-```bash
-repo2rlenv reward --task ./out/<task-id> --prediction ./candidate.diff
-```
-
-That's the full consumer-side loop for a lite task — no Docker, no sandbox needed. If you want to actually *exercise* an agent against the repo (clone, edit, capture diff), spin up your own sandbox or use `harbor run` once we ship the full `pr_runtime` variant.
+That's the full consumer-side loop for a lite task — no Docker, no sandbox needed. If you want to actually *exercise* an agent against the repo (clone, edit, capture diff), use `harbor run` against the emitted task directory.
 
 ## Limitations (v0.1)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,27 +53,39 @@ Output lands in `./datasets/<dataset-name>/<owner>__<repo>-<pr_number>/`.
 Replace the `--out` flag with an `hf://` destination and the dataset is pushed after generation:
 
 ```bash
+# 1. Generate to a local directory
 repo2rlenv generate \
   --repo <owner>/<repo> \
   --pipeline pr_diff \
   --pipeline-opt limit=10 \
   --llm anthropic/claude-sonnet-4-6 \
-  --out hf://<your-org>/<dataset-name>
+  --out ./datasets/<dataset-name>
+
+# 2. Push to HF Hub
+repo2rlenv push ./datasets/<dataset-name> hf://<your-org>/<dataset-name>
+
+# 3. Pull it back anywhere later
+repo2rlenv pull hf://<your-org>/<dataset-name>
 ```
 
-The push also emits a `registry.json` so `harbor download --registry-url hf://<your-org>/<dataset-name>` works out of the box.
+The push emits a `registry.json` so `harbor download --registry-url hf://<your-org>/<dataset-name>` works out of the box.
 
-## Validate + reward
+## Validate the dataset
 
 ```bash
-# Verify every task.toml in the dataset parses + has required fields
+# Fast structural check — every task.toml parses + has required fields
 repo2rlenv validate ./datasets/<dataset-name>
-
-# Score a predicted diff against the oracle (smoke test for the reward function)
-repo2rlenv reward \
-  --task ./datasets/<dataset-name>/<task-id> \
-  --prediction ./my_candidate.diff
 ```
+
+For diff-similarity scoring inside a training loop, import the Python function
+directly instead of shelling out:
+
+```python
+from repo2rlenv.reward import calculate_diff_similarity_reward
+reward, meta = calculate_diff_similarity_reward(oracle_diff_text, prediction_text)
+```
+
+(Test-execution rewards — `Mean = 1.000` etc. — come from `harbor run`, not from this package.)
 
 ## Run the dataset with Harbor
 

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -151,14 +151,17 @@ Two-commit upload: tasks first, then `registry.json` pinned to the resulting com
 
 Repo2RLEnv ships **no execution runtime**. To run/score:
 
-- **Lite tasks** — just call `reward.calculate_diff_similarity_reward(oracle, prediction)` directly. The `repo2rlenv reward` CLI is a thin wrapper. No sandbox needed.
-- **Full tasks** (Dockerfile + tests) — use `harbor run -d <dataset> -e <provider> ...`. Repo2RLEnv emits Harbor-compatible task directories so this works out of the box once full pipelines ship.
+- **Diff-similarity scoring** — call `reward.calculate_diff_similarity_reward(oracle, prediction)` directly from Python. Used by RL training loops where running tests every rollout is too expensive. There is no CLI wrapper.
+- **Test execution** — use `harbor run --agent <agent> --path <task>`. Repo2RLEnv emits Harbor-compatible task directories that work out of the box across Harbor's Local Docker / Modal / Daytona / E2B / Runloop backends.
 
 ## CLI ↔ API mapping
 
 | CLI subcommand | Python equivalent |
 |---|---|
-| `repo2rlenv init` | (writes a sample YAML) |
-| `repo2rlenv generate ...` | `pipelines.PIPELINES[name](input, opts).run(out_dir)` + (optional) `hub.push_to_hub` |
+| `repo2rlenv generate ...` | `pipelines.PIPELINES[name](input, opts).run(out_dir)` |
 | `repo2rlenv validate <path>` | walk task.toml files + `tomllib.loads` |
-| `repo2rlenv reward --task --prediction` | `reward.calculate_diff_similarity_reward` |
+| `repo2rlenv push <dir> <hf://...>` | `hub.push_to_hub(local_dir, repo_id, auth, ...)` |
+| `repo2rlenv pull <hf://...> [<dir>]` | `hub.pull_from_hub(repo_id, local_dir, auth, ...)` |
+| `repo2rlenv bootstrap ...` | `bootstrap.ensure_bootstrap(repo, spec, llm)` |
+| diff-similarity reward | `reward.calculate_diff_similarity_reward(oracle, prediction)` (Python only) |
+| test-execution reward | `harbor run --agent <agent> --path <task>` (separate tool) |

--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -35,13 +35,15 @@ class GenerationInput(BaseModel):
 **Flag form**:
 
 ```bash
+# Generate locally, then push as two explicit steps
 repo2rlenv generate \
   --repo huggingface/trl \
   --pipeline pr_diff \
   --pipeline-opt limit=5 \
   --llm anthropic/claude-sonnet-4-6 \
-  --out hf://AdithyaSK/trl-r2e-v0-1 \
-  --org AdithyaSK --dataset-name trl-r2e-v0-1
+  --out ./datasets/trl-r2e-v0-1
+
+repo2rlenv push ./datasets/trl-r2e-v0-1 hf://AdithyaSK/trl-r2e-v0-1
 ```
 
 **Config-file form** — `--config <path>` accepts YAML or TOML, format auto-detected by extension. CLI flags override file fields:
@@ -60,13 +62,13 @@ llm:
   provider: "anthropic"
   model: "claude-sonnet-4-6"
 output:
-  destination: "hf://AdithyaSK/trl-r2e-v0-1"
+  destination: "./datasets/trl-r2e-v0-1"
   org: "AdithyaSK"
   dataset_name: "trl-r2e-v0-1"
   visibility: "public"
 ```
 
-`repo2rlenv init` writes a sample config you can tweak.
+Drop this into a file (e.g. `repo2rlenv.config.yaml`) and run with `--config <path>`. Publishing is a separate step via `repo2rlenv push`.
 
 ## Output contract — Harbor + `[metadata.repo2env]`
 
@@ -155,7 +157,7 @@ Repo2RLEnv has **no sandbox abstraction of its own**. Generation-time execution 
 |---|---|---|
 | Generation | Lite (text-only, e.g. `pr_diff`) | Nothing — pure text manipulation |
 | Generation | Full (`pr_runtime`, `mutation_bugs`, etc.) | Harbor's sandbox layer (`harbor` invoked under the hood) |
-| Consumption | Lite | Just call `repo2rlenv reward` — no sandbox needed |
+| Consumption | Lite | `from repo2rlenv.reward import calculate_diff_similarity_reward` — pure Python, no sandbox |
 | Consumption | Full | `harbor run -d <dataset> -e <modal\|daytona\|e2b\|local\|runloop> ...` |
 
 `SandboxSpec` exists to *describe* what the pipeline needs (provider, GPU, network), and at gen-time we lower it onto Harbor's flags. We don't ship a parallel runner. This keeps the surface area small — Harbor already handles GPU, multi-container, parallelism, and provider auth.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repo2rlenv"
-version = "0.8.1"
+version = "0.8.2"
 description = "Turn any repository into an RL environment for training and evaluation."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/repo2rlenv/cli.py
+++ b/src/repo2rlenv/cli.py
@@ -1,11 +1,11 @@
 """Repo2RLEnv CLI — argparse-based, Rich-driven UI.
 
 Subcommands:
-  generate    Run a synthesis pipeline against a repo
-  validate    Validate a generated dataset directory
-  reward      Score a predicted diff against a task's oracle (smoke test)
+  generate    Run a synthesis pipeline against a repo (emits to local dir)
+  validate    Validate a generated dataset directory (fast structural check)
   bootstrap   Build a working Docker image via an LLM agent loop
-  init        Write a sample config file
+  push        Push a local dataset directory to HF Hub
+  pull        Pull a Repo2RLEnv dataset from HF Hub to a local directory
 """
 
 from __future__ import annotations
@@ -14,7 +14,6 @@ import argparse
 import json
 import logging
 import sys
-from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
@@ -195,6 +194,11 @@ def cmd_generate(args: argparse.Namespace) -> int:
     dest = gen_input.output.destination
     push_to_hub_after = dest.startswith("hf://")
     if push_to_hub_after:
+        console.warn(
+            "generate --out hf://... is deprecated and will be removed in v0.9. "
+            "Use `repo2rlenv push <local-dir> <hf://...>` instead — explicit, re-pushable, "
+            "and decouples emission from publication."
+        )
         repo_id = dest.removeprefix("hf://")
         out_dir = Path(f"./.r2e_cache/{repo_id.replace('/', '__')}").resolve()
     else:
@@ -309,31 +313,83 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return 0 if failures == 0 else 1
 
 
-def cmd_reward(args: argparse.Namespace) -> int:
-    from repo2rlenv.reward import calculate_diff_similarity_reward
+def _parse_hf_uri(uri: str, *, flag: str) -> str:
+    """Extract owner/dataset from `hf://owner/dataset` (or accept the bare form)."""
+    s = uri.strip()
+    if s.startswith("hf://"):
+        s = s.removeprefix("hf://")
+    if "/" not in s or len(s.split("/")) != 2 or any(not p for p in s.split("/")):
+        raise SystemExit(f"{flag} expects 'hf://owner/dataset' or 'owner/dataset', got {uri!r}")
+    return s
 
-    task_dir = Path(args.task).expanduser().resolve()
-    oracle_path = task_dir / "solution" / "patch.diff"
-    pred_path = Path(args.prediction).expanduser().resolve()
-    if not oracle_path.exists():
-        console.error(f"oracle not found: {oracle_path}")
-        return 2
-    if not pred_path.exists():
-        console.error(f"prediction not found: {pred_path}")
+
+def cmd_push(args: argparse.Namespace) -> int:
+    """Push a local dataset directory to HF Hub."""
+    from repo2rlenv.hub import push_to_hub
+    from repo2rlenv.spec.input import AuthSpec
+
+    local_dir = Path(args.local_dir).expanduser().resolve()
+    if not local_dir.is_dir():
+        console.error(f"local dataset directory not found: {local_dir}")
         return 2
 
-    reward, meta = calculate_diff_similarity_reward(oracle_path.read_text(), pred_path.read_text())
-    meta_dict = asdict(meta)
-    console.kv(
-        {
-            "task": task_dir.name,
-            "reward": f"{reward:.4f}",
-            "matched_lines": f"{meta_dict['matched_lines']}/{meta_dict['oracle_lines']}",
-            "pred_lines": meta_dict["pred_lines"],
-            "parse_error": meta_dict["parse_error"] or "(none)",
-        },
-        title="diff_similarity reward",
-    )
+    repo_id = _parse_hf_uri(args.dataset, flag="<dataset>")
+
+    with console.section(f"Pushing {local_dir.name} → hf://{repo_id}"):
+        try:
+            result = push_to_hub(
+                local_dataset_dir=local_dir,
+                repo_id=repo_id,
+                auth=AuthSpec(),
+                private=args.private,
+                commit_message=args.message,
+            )
+        except Exception as exc:
+            console.error(f"push failed: {exc}")
+            return 1
+        console.kv(
+            {
+                "repo_id": result.repo_id,
+                "task_count": result.task_count,
+                "commit": result.commit_sha,
+                "registry_url": result.registry_url,
+            },
+            title="HF Hub push",
+        )
+        console.dim(f"  to pull back later:  repo2rlenv pull hf://{result.repo_id} ./<local-dir>")
+    return 0
+
+
+def cmd_pull(args: argparse.Namespace) -> int:
+    """Pull a Repo2RLEnv dataset from HF Hub into a local directory."""
+    from repo2rlenv.hub import pull_from_hub
+    from repo2rlenv.spec.input import AuthSpec
+
+    repo_id = _parse_hf_uri(args.dataset, flag="<dataset>")
+    default_dir = Path(f"./datasets/{repo_id.replace('/', '__')}").resolve()
+    local_dir = Path(args.local_dir).expanduser().resolve() if args.local_dir else default_dir
+
+    with console.section(f"Pulling hf://{repo_id} → {local_dir}"):
+        try:
+            result = pull_from_hub(
+                repo_id=repo_id,
+                local_dir=local_dir,
+                auth=AuthSpec(),
+                task=args.task,
+                force=args.force,
+            )
+        except Exception as exc:
+            console.error(f"pull failed: {exc}")
+            return 1
+        console.kv(
+            {
+                "repo_id": result.repo_id,
+                "local_dir": str(result.local_dir),
+                "task_count": result.task_count,
+            },
+            title="HF Hub pull",
+        )
+        console.dim(f"  validate it: repo2rlenv validate {result.local_dir}")
     return 0
 
 
@@ -443,49 +499,6 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
     return 0
 
 
-_SAMPLE_CONFIG = """spec_version: "0.1.0"
-
-repo:
-  url: "huggingface/trl"
-  access: "auto"
-
-pipeline:
-  name: "pr_diff"
-  options:
-    limit: 10
-    skip_drafts: true
-    max_files_per_pr: 5
-
-llm:
-  provider: "anthropic"
-  model: "claude-sonnet-4-6"
-
-output:
-  destination: "./datasets/trl-r2e"
-  org: "myorg"
-  dataset_name: "trl-r2e"
-  visibility: "public"
-
-qa:
-  enabled: true
-  layers: ["diff_parse"]
-
-sandbox:
-  provider: "none"
-"""
-
-
-def cmd_init(args: argparse.Namespace) -> int:
-    out = Path(args.out or "repo2rlenv.config.yaml").expanduser().resolve()
-    if out.exists() and not args.force:
-        console.error(f"refusing to overwrite {out} (use --force)")
-        return 1
-    out.write_text(_SAMPLE_CONFIG, encoding="utf-8")
-    console.success(f"wrote sample config to {out}")
-    console.dim("  edit it, then run: repo2rlenv generate --config <path>")
-    return 0
-
-
 def main(argv: list[str] | None = None) -> int:
     _load_dotenv_if_present()
 
@@ -567,11 +580,37 @@ def main(argv: list[str] | None = None) -> int:
     v.add_argument("path", help="dataset or task directory")
     v.set_defaults(func=cmd_validate)
 
-    # reward
-    r = sub.add_parser("reward", help="Score a predicted diff against a task's oracle")
-    r.add_argument("--task", required=True, help="task directory containing solution/patch.diff")
-    r.add_argument("--prediction", required=True, help="path to predicted diff file")
-    r.set_defaults(func=cmd_reward)
+    # push
+    p = sub.add_parser("push", help="Push a local dataset directory to HF Hub")
+    p.add_argument("local_dir", help="path to dataset directory (output of `generate`)")
+    p.add_argument("dataset", help="HF Hub target as `hf://owner/dataset` (or `owner/dataset`)")
+    p.add_argument("--private", action="store_true", help="create the Hub repo as private")
+    p.add_argument(
+        "--message",
+        "-m",
+        help="custom commit message (default: 'Repo2RLEnv: add N tasks')",
+    )
+    p.set_defaults(func=cmd_push)
+
+    # pull
+    pl = sub.add_parser("pull", help="Pull a Repo2RLEnv dataset from HF Hub")
+    pl.add_argument("dataset", help="HF dataset as `hf://owner/dataset` (or `owner/dataset`)")
+    pl.add_argument(
+        "local_dir",
+        nargs="?",
+        default=None,
+        help="local destination (default: ./datasets/<owner>__<dataset>)",
+    )
+    pl.add_argument(
+        "--task",
+        help="fetch only this single task by name (e.g. pallets__click-3373)",
+    )
+    pl.add_argument(
+        "--force",
+        action="store_true",
+        help="re-download even if a local copy already exists",
+    )
+    pl.set_defaults(func=cmd_pull)
 
     # bootstrap
     bs = sub.add_parser("bootstrap", help="Build a working Docker image for a repo (v0.2)")
@@ -597,12 +636,6 @@ def main(argv: list[str] | None = None) -> int:
     )
     bs.add_argument("--force", action="store_true", help="ignore cache, rebuild from scratch")
     bs.set_defaults(func=cmd_bootstrap)
-
-    # init
-    i = sub.add_parser("init", help="Write a sample config file")
-    i.add_argument("--out", help="output path (default: repo2rlenv.config.yaml)")
-    i.add_argument("--force", action="store_true", help="overwrite if exists")
-    i.set_defaults(func=cmd_init)
 
     args = parser.parse_args(argv)
     install_logging(level=logging.DEBUG if args.verbose else logging.INFO)

--- a/src/repo2rlenv/hub.py
+++ b/src/repo2rlenv/hub.py
@@ -47,6 +47,14 @@ class PushResult:
     task_count: int
 
 
+@dataclass(slots=True)
+class PullResult:
+    repo_id: str
+    local_dir: Path
+    task_count: int
+    snapshot_path: Path  # actual on-disk location after snapshot_download
+
+
 def _build_registry_json(
     repo_id: str,
     commit_sha: str,
@@ -247,4 +255,105 @@ def push_to_hub(
         commit_sha=commit_sha,
         registry_url=registry_url,
         task_count=len(task_names),
+    )
+
+
+def pull_from_hub(
+    repo_id: str,
+    local_dir: Path,
+    auth: AuthSpec | None = None,
+    *,
+    task: str | None = None,
+    force: bool = False,
+) -> PullResult:
+    """Pull a Repo2RLEnv-published dataset from HF Hub into a local directory.
+
+    Reverses `push_to_hub`: the staged Hub layout has `tasks/<task-id>/...`,
+    and we flatten that back to `<local_dir>/<task-id>/...` so the result is
+    immediately consumable by `repo2rlenv validate` and `harbor run --path`.
+
+    Args:
+        repo_id: HF dataset id, e.g. "AdithyaSK/click-r2e".
+        local_dir: where to materialize the flattened tasks.
+        auth: optional AuthSpec; falls back to env-resolved HF token.
+        task: if set, fetch only that single task subdir (faster, smaller).
+        force: re-download even if a local snapshot already exists.
+
+    Returns a PullResult with the count of task directories materialized.
+    """
+    from huggingface_hub import snapshot_download
+
+    auth = auth or AuthSpec()
+    token = resolve_hf_token(auth)
+    # token is optional for public datasets; pass-through if present
+
+    if force and local_dir.exists():
+        import shutil
+
+        shutil.rmtree(local_dir)
+    local_dir.mkdir(parents=True, exist_ok=True)
+
+    allow_patterns = None
+    if task:
+        # Match the task subdir + the registry/README so a single-task pull
+        # still produces a coherent dataset directory.
+        allow_patterns = [
+            f"tasks/{task}/**",
+            "registry.json",
+            "README.md",
+        ]
+
+    snapshot = Path(
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            token=token,
+            local_dir=str(local_dir / ".r2e_snapshot"),
+            allow_patterns=allow_patterns,
+        )
+    )
+
+    # Flatten staged `tasks/<id>/` → `<local_dir>/<id>/`
+    staged_tasks = snapshot / "tasks"
+    if not staged_tasks.exists():
+        raise RuntimeError(
+            f"{repo_id} doesn't look like a Repo2RLEnv dataset "
+            f"(no `tasks/` subdir under {snapshot})"
+        )
+
+    import shutil
+
+    task_count = 0
+    for child in sorted(staged_tasks.iterdir()):
+        if not child.is_dir():
+            continue
+        if not (child / "task.toml").exists():
+            continue
+        target = local_dir / child.name
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(child, target)
+        task_count += 1
+
+    # Also surface the registry.json + README.md at the dataset root so the
+    # local layout matches what `push_to_hub` originally staged.
+    for top in ("registry.json", "README.md"):
+        src = snapshot / top
+        if src.exists():
+            shutil.copyfile(src, local_dir / top)
+
+    # Clean up the snapshot scratch dir
+    shutil.rmtree(snapshot, ignore_errors=True)
+
+    if task_count == 0:
+        raise RuntimeError(
+            f"no Harbor tasks materialized from {repo_id} into {local_dir}"
+            + (f" (filter: task={task!r})" if task else "")
+        )
+
+    return PullResult(
+        repo_id=repo_id,
+        local_dir=local_dir,
+        task_count=task_count,
+        snapshot_path=local_dir,
     )

--- a/src/repo2rlenv/pipelines/pr_runtime.py
+++ b/src/repo2rlenv/pipelines/pr_runtime.py
@@ -354,6 +354,17 @@ def normalize_test_cmds_for_runtime(test_cmds: list[str]) -> list[str]:
     for cmd in test_cmds:
         cleaned = cmd
 
+        # Strip shell pipes / redirects / tail-truncators that bootstrap agents
+        # sometimes append (e.g. `pytest -q 2>&1 | head -50`) so we capture only
+        # the test runner invocation. If we keep them, `targeted_test_cmds_for_pr`
+        # appends test files AFTER the pipe → broken command.
+        # `[^|]*` swallows whatever flags follow `head`/`tail` (`-50`, `-n 100`, etc.)
+        # without crossing into another piped command.
+        cleaned = re.sub(r"\s*\|\s*(?:head|tail)\s*[^|]*$", "", cleaned)
+        cleaned = re.sub(r"\s*2>&1\b", "", cleaned)
+        cleaned = re.sub(r"\s*&?>\s*/dev/null\b", "", cleaned)
+        cleaned = cleaned.rstrip(" |&")
+
         # --- pytest ---
         if re.search(r"\bpytest\b", cleaned):
             cleaned = re.sub(r"\s+--collect-only\b", "", cleaned)

--- a/tests/test_cli_push_pull.py
+++ b/tests/test_cli_push_pull.py
@@ -1,0 +1,210 @@
+"""push/pull CLI commands + the `hf://` URI parser.
+
+Mock the Hub layer; we just verify the CLI wires arguments through correctly
+and that the URI-parse helper handles all the variants we accept.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from repo2rlenv.cli import _parse_hf_uri, cmd_pull, cmd_push
+from repo2rlenv.hub import PullResult, PushResult
+
+# ----------------------------------------------------------------------------
+# _parse_hf_uri — URI accepted in two forms
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "uri,expected",
+    [
+        ("hf://AdithyaSK/click-r2e", "AdithyaSK/click-r2e"),
+        ("AdithyaSK/click-r2e", "AdithyaSK/click-r2e"),
+        ("hf://huggingface/datasets-launch", "huggingface/datasets-launch"),
+        ("  hf://owner/name  ", "owner/name"),  # tolerates whitespace
+    ],
+)
+def test_parse_hf_uri_accepts_valid(uri, expected):
+    assert _parse_hf_uri(uri, flag="<dataset>") == expected
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "",
+        "no-slash",
+        "hf://",
+        "hf://only-one",
+        "owner/",
+        "/name",
+        "hf://owner/name/extra",
+    ],
+)
+def test_parse_hf_uri_rejects_malformed(uri):
+    with pytest.raises(SystemExit, match="<dataset>"):
+        _parse_hf_uri(uri, flag="<dataset>")
+
+
+# ----------------------------------------------------------------------------
+# cmd_push — wires arguments through to hub.push_to_hub
+# ----------------------------------------------------------------------------
+
+
+def _ns(**kwargs):
+    """Build an argparse.Namespace-ish for cmd_* under test."""
+    import argparse
+
+    return argparse.Namespace(**kwargs)
+
+
+def test_cmd_push_calls_push_to_hub(tmp_path: Path):
+    dataset_dir = tmp_path / "click-e2e"
+    (dataset_dir / "task-1").mkdir(parents=True)
+    (dataset_dir / "task-1" / "task.toml").write_text('[task]\nname="x"\n')
+
+    fake_result = PushResult(
+        repo_id="AdithyaSK/click-r2e",
+        commit_sha="abc123",
+        registry_url="https://huggingface.co/datasets/AdithyaSK/click-r2e/resolve/main/registry.json",
+        task_count=1,
+    )
+
+    with mock.patch("repo2rlenv.hub.push_to_hub", return_value=fake_result) as m:
+        rc = cmd_push(
+            _ns(
+                local_dir=str(dataset_dir),
+                dataset="hf://AdithyaSK/click-r2e",
+                private=False,
+                message=None,
+            )
+        )
+    assert rc == 0
+    m.assert_called_once()
+    kwargs = m.call_args.kwargs
+    assert kwargs["repo_id"] == "AdithyaSK/click-r2e"
+    assert kwargs["private"] is False
+
+
+def test_cmd_push_rejects_missing_local_dir(tmp_path: Path):
+    rc = cmd_push(
+        _ns(
+            local_dir=str(tmp_path / "does-not-exist"),
+            dataset="hf://owner/name",
+            private=False,
+            message=None,
+        )
+    )
+    assert rc == 2
+
+
+def test_cmd_push_propagates_private_flag(tmp_path: Path):
+    dataset_dir = tmp_path / "ds"
+    (dataset_dir / "task-1").mkdir(parents=True)
+    (dataset_dir / "task-1" / "task.toml").write_text("[task]\n")
+
+    fake_result = PushResult(repo_id="me/private-ds", commit_sha="x", registry_url="", task_count=1)
+    with mock.patch("repo2rlenv.hub.push_to_hub", return_value=fake_result) as m:
+        cmd_push(
+            _ns(
+                local_dir=str(dataset_dir),
+                dataset="me/private-ds",
+                private=True,
+                message="custom",
+            )
+        )
+    kwargs = m.call_args.kwargs
+    assert kwargs["private"] is True
+    assert kwargs["commit_message"] == "custom"
+
+
+def test_cmd_push_returns_nonzero_on_hub_failure(tmp_path: Path):
+    dataset_dir = tmp_path / "ds"
+    (dataset_dir / "task-1").mkdir(parents=True)
+    (dataset_dir / "task-1" / "task.toml").write_text("[task]\n")
+
+    with mock.patch("repo2rlenv.hub.push_to_hub", side_effect=RuntimeError("no token")):
+        rc = cmd_push(
+            _ns(
+                local_dir=str(dataset_dir),
+                dataset="me/x",
+                private=False,
+                message=None,
+            )
+        )
+    assert rc == 1
+
+
+# ----------------------------------------------------------------------------
+# cmd_pull — wires arguments through to hub.pull_from_hub
+# ----------------------------------------------------------------------------
+
+
+def test_cmd_pull_calls_pull_from_hub(tmp_path: Path):
+    target = tmp_path / "out"
+    fake_result = PullResult(
+        repo_id="AdithyaSK/click-r2e",
+        local_dir=target,
+        task_count=4,
+        snapshot_path=target,
+    )
+    with mock.patch("repo2rlenv.hub.pull_from_hub", return_value=fake_result) as m:
+        rc = cmd_pull(
+            _ns(
+                dataset="hf://AdithyaSK/click-r2e",
+                local_dir=str(target),
+                task=None,
+                force=False,
+            )
+        )
+    assert rc == 0
+    kwargs = m.call_args.kwargs
+    assert kwargs["repo_id"] == "AdithyaSK/click-r2e"
+    assert Path(kwargs["local_dir"]).resolve() == target.resolve()
+    assert kwargs["task"] is None
+    assert kwargs["force"] is False
+
+
+def test_cmd_pull_default_target_when_local_dir_omitted():
+    """When `local_dir` arg is None, default to ./datasets/<owner>__<dataset>."""
+    fake_result = PullResult(
+        repo_id="owner/ds",
+        local_dir=Path("ignored"),
+        task_count=1,
+        snapshot_path=Path("ignored"),
+    )
+    with mock.patch("repo2rlenv.hub.pull_from_hub", return_value=fake_result) as m:
+        cmd_pull(_ns(dataset="hf://owner/ds", local_dir=None, task=None, force=False))
+    kwargs = m.call_args.kwargs
+    # Path ends with the expected default naming pattern
+    assert str(kwargs["local_dir"]).endswith("datasets/owner__ds")
+
+
+def test_cmd_pull_forwards_task_filter_and_force():
+    fake_result = PullResult(
+        repo_id="owner/ds",
+        local_dir=Path("/tmp/x"),
+        task_count=1,
+        snapshot_path=Path("/tmp/x"),
+    )
+    with mock.patch("repo2rlenv.hub.pull_from_hub", return_value=fake_result) as m:
+        cmd_pull(
+            _ns(
+                dataset="hf://owner/ds",
+                local_dir="/tmp/x",
+                task="pallets__click-3373",
+                force=True,
+            )
+        )
+    kwargs = m.call_args.kwargs
+    assert kwargs["task"] == "pallets__click-3373"
+    assert kwargs["force"] is True
+
+
+def test_cmd_pull_returns_nonzero_on_hub_failure():
+    with mock.patch("repo2rlenv.hub.pull_from_hub", side_effect=RuntimeError("repo not found")):
+        rc = cmd_pull(_ns(dataset="hf://owner/missing", local_dir=None, task=None, force=False))
+    assert rc == 1

--- a/tests/test_pipeline_pr_runtime.py
+++ b/tests/test_pipeline_pr_runtime.py
@@ -349,6 +349,33 @@ def test_normalize_jest_adds_verbose_and_strips_silent():
     assert normalize_test_cmds_for_runtime(["jest --verbose"]) == ["jest --verbose"]
 
 
+def test_normalize_strips_trailing_pipe_head_or_tail():
+    """Bootstrap agents sometimes save commands with a `| head -N` tail truncator.
+
+    targeted_test_cmds_for_pr appends test files at the end, which lands them
+    AFTER the pipe and breaks the shell. Strip the tail truncator BEFORE
+    appending test args.
+
+    Regression test for v0.8.2 e2e finding on pallets/click bootstrap.
+    """
+    assert normalize_test_cmds_for_runtime(["python -m pytest -q 2>&1 | head -50"]) == [
+        "python -m pytest -q -v"
+    ]
+    assert normalize_test_cmds_for_runtime(["pytest 2>&1 | tail -n 100"]) == ["pytest -v"]
+
+
+def test_normalize_strips_dev_null_redirect():
+    """`> /dev/null` or `&> /dev/null` would also swallow output we need to parse."""
+    assert normalize_test_cmds_for_runtime(["go test ./... > /dev/null"]) == [
+        "go test -v ./..."
+    ]
+    assert normalize_test_cmds_for_runtime(["pytest &> /dev/null"]) == ["pytest -v"]
+
+
+def test_normalize_strips_bare_2_redirect_1():
+    assert normalize_test_cmds_for_runtime(["pytest 2>&1"]) == ["pytest -v"]
+
+
 def test_normalize_npm_test_unchanged_when_wrapper():
     """`npm test` is a wrapper — we can't safely add jest flags through it."""
     # Just verify it doesn't crash and doesn't corrupt the cmd

--- a/tests/test_pipeline_pr_runtime.py
+++ b/tests/test_pipeline_pr_runtime.py
@@ -366,9 +366,7 @@ def test_normalize_strips_trailing_pipe_head_or_tail():
 
 def test_normalize_strips_dev_null_redirect():
     """`> /dev/null` or `&> /dev/null` would also swallow output we need to parse."""
-    assert normalize_test_cmds_for_runtime(["go test ./... > /dev/null"]) == [
-        "go test -v ./..."
-    ]
+    assert normalize_test_cmds_for_runtime(["go test ./... > /dev/null"]) == ["go test -v ./..."]
     assert normalize_test_cmds_for_runtime(["pytest &> /dev/null"]) == ["pytest -v"]
 
 


### PR DESCRIPTION
Closes #16.

End-to-end-validated via a live HF Hub round-trip on `pallets/click` (no E2B / cloud sandbox).

## What's changing

| Action | Command |
|---|---|
| **Add** | `repo2rlenv push <local-dir> <hf://owner/dataset>` — supports `--private`, `--message` |
| **Add** | `repo2rlenv pull <hf://owner/dataset> [<local-dir>]` — supports `--task`, `--force` |
| **Remove** | `repo2rlenv reward` (Python function `repo2rlenv.reward.calculate_diff_similarity_reward` stays for training-loop users) |
| **Remove** | `repo2rlenv init` (replaced by README example) |
| **Soft-deprecate** | `--out hf://...` magic inside `generate` — emits a warning; to be removed in v0.9 |

Resulting CLI (5 commands, every one load-bearing):

```
repo2rlenv generate    # emit Harbor task spec → local dir
repo2rlenv validate    # check spec conformance
repo2rlenv bootstrap   # build a Docker image only (no synthesis)
repo2rlenv push        # NEW: local dir → HF Hub
repo2rlenv pull        # NEW: HF Hub → local dir
```

## Live round-trip evidence (Phase 4, all green)

Real Hub round-trip captured in `plans/v0.8.2_e2e.md`:

| Step | Result |
|---|---|
| `generate` (pr_runtime on `pallets/click`) | ✅ 4/8 tasks emitted |
| `validate` (local) | ✅ 4/4 valid |
| `push hf://AdithyaSK/click-r2e-v082` | ✅ commit `82de5c57`, registry.json published |
| `pull hf://AdithyaSK/click-r2e-v082 ... --force` | ✅ 4 tasks materialized |
| `validate` (pulled copy) | ✅ 4/4 valid |
| `harbor run --agent oracle --path <pulled task>` | ✅ **Mean = 1.000 in 5s** |

## Harness bug surfaced + fixed during e2e

Initial Harbor oracle attempt returned Mean = 0.0 — root cause was the bootstrap agent saving `test_cmds` with a trailing `| head -50` pipe, so `targeted_test_cmds_for_pr` appended test files **after** the pipe → broken shell. Fix: `normalize_test_cmds_for_runtime` now strips `| head/tail`, `2>&1`, `> /dev/null` before per-runner normalization. 4 regression tests added.

## Test plan

- [x] **Implementation** complete — push/pull commands wired
- [x] **23 new tests** for push/pull argparse + URI parsing + normalize regex
- [x] All **464 unit tests** pass; `ruff check` + `ruff format --check` clean
- [x] **Live round-trip** completed successfully against `AdithyaSK/click-r2e-v082`
- [x] **Docs**: `README.md`, `CLAUDE.md`, `docs/quickstart.md`, `docs/pipelines/pr_diff.md`, `docs/reference/API.md`, `docs/reference/SPEC.md` all updated
- [ ] CI green (lint + matrix test 3.12/3.13/3.14 + build) — auto on push