### PR TITLE
Infer repo_source and pipeline from task.toml when pushing to HF Hub

### DIFF
--- a/src/repo2rlenv/cli.py
+++ b/src/repo2rlenv/cli.py
@@ -459,6 +459,22 @@ def cmd_push(args: argparse.Namespace) -> int:
             f"--push does not pin revisions; ignoring `@{revision}` (Hub commit will be the push commit)"
         )
 
+    # Infer repo_source and pipeline from the first task.toml found in the dataset dir
+    repo_source = ""
+    pipeline = "pr_diff"
+    for task_toml in sorted(local_dir.rglob("task.toml")):
+        try:
+            import tomllib
+
+            with open(task_toml, "rb") as f:
+                meta = tomllib.load(f)
+            r2e = meta.get("metadata", {}).get("repo2env", {})
+            repo_source = r2e.get("repo", "")
+            pipeline = r2e.get("pipeline", "pr_diff")
+        except Exception:
+            pass
+        break
+
     with console.section(f"Pushing {local_dir.name} → hf://{repo_id}"):
         try:
             result = push_to_hub(
@@ -467,6 +483,8 @@ def cmd_push(args: argparse.Namespace) -> int:
                 auth=AuthSpec(),
                 private=args.private,
                 commit_message=args.message,
+                repo_source=repo_source,
+                pipeline=pipeline,
             )
         except Exception as exc:
             console.error(f"push failed: {exc}")


### PR DESCRIPTION
## Problem

When running `repo2rlenv push`, the source repo and pipeline were not passed to `push_to_hub`, so the generated README and registry.json had empty/placeholder values:

- README: `**Source repo**: [``](https://github.com/)`
- registry.json: `"description": "Repo2RLEnv pr_diff from "`

Example: https://huggingface.co/datasets/sergiopaniego/trl-r2e-test

## Fix

`cmd_push` now reads the first `task.toml` it finds in the dataset directory and extracts `metadata.repo2env.repo` and `metadata.repo2env.pipeline` before calling `push_to_hub`. Both fields are already present in every task generated by Repo2RLEnv pipelines.

The fallback behavior (empty repo_source, pipeline="pr_diff") is unchanged, so existing calls are not affected.

## Testing

Generated a dataset from `huggingface/trl` via `pr_diff`, pushed to HF Hub, and verified the README and registry.json are correctly populated.