### PR TITLE
make llm flag optional for mining pipelines

### DIFF
--- a/docs/pipelines/pr_diff.md
+++ b/docs/pipelines/pr_diff.md
@@ -114,7 +114,6 @@ repo2rlenv generate \
   --pipeline pr_diff \
   --pipeline-opt limit=5 \
   --pipeline-opt max_files_per_pr=10 \
-  --llm anthropic/claude-sonnet-4-6 \
   --out ./datasets/trl-r2e
 
 # Generate locally, then push to HF Hub
@@ -122,7 +121,6 @@ repo2rlenv generate \
   --repo huggingface/trl \
   --pipeline pr_diff \
   --pipeline-opt limit=5 \
-  --llm anthropic/claude-sonnet-4-6 \
   --out ./datasets/trl-r2e-v0-1
 
 repo2rlenv push ./datasets/trl-r2e-v0-1 <your-org>/trl-r2e-v0-1
@@ -133,7 +131,7 @@ repo2rlenv push ./datasets/trl-r2e-v0-1 <your-org>/trl-r2e-v0-1
 ```python
 from pathlib import Path
 from repo2rlenv.spec.input import (
-    GenerationInput, RepoSpec, PipelineSpec, LLMSpec, OutputSpec, PipelineName,
+    GenerationInput, RepoSpec, PipelineSpec, OutputSpec, PipelineName,
 )
 from repo2rlenv.spec.options import PRDiffOptions
 from repo2rlenv.pipelines.pr_diff import PRDiffPipeline
@@ -141,7 +139,6 @@ from repo2rlenv.pipelines.pr_diff import PRDiffPipeline
 g = GenerationInput(
     repo=RepoSpec(url="huggingface/trl", access="auto"),
     pipeline=PipelineSpec(name=PipelineName.PR_DIFF, options={}),
-    llm=LLMSpec(provider="anthropic", model="claude-sonnet-4-6"),
     output=OutputSpec(destination="./out", org="myorg", dataset_name="trl-r2e"),
 )
 options = PRDiffOptions(limit=5, max_files_per_pr=10)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -36,7 +36,6 @@ repo2rlenv generate \
   --repo <owner>/<repo> \
   --pipeline pr_diff \
   --pipeline-opt limit=10 \
-  --llm anthropic/claude-sonnet-4-6 \
   --out ./datasets/<dataset-name>
 ```
 
@@ -56,7 +55,6 @@ repo2rlenv generate \
   --repo <owner>/<repo> \
   --pipeline pr_diff \
   --pipeline-opt limit=10 \
-  --llm anthropic/claude-sonnet-4-6 \
   --out ./datasets/<dataset-name>
 
 # 2. Push to HF Hub (bare name auto-resolves owner via `whoami`)

--- a/src/repo2rlenv/cli.py
+++ b/src/repo2rlenv/cli.py
@@ -126,6 +126,12 @@ def cmd_generate(args: argparse.Namespace) -> int:
     # Auto-trigger bootstrap for sandbox-required pipelines (requires_bootstrap=True).
     # Cache hit ⇒ instant; cache miss ⇒ full LLM-agent run with the live UI.
     bootstrap_result = None
+    if getattr(pipeline_cls, "requires_bootstrap", False) and gen_input.llm is None:
+        console.error(
+            f"pipeline {gen_input.pipeline.name.value!r} requires --llm "
+            f"(bootstrap needs an LLM to build the sandbox image)"
+        )
+        return 2
     if getattr(pipeline_cls, "requires_bootstrap", False):
         from repo2rlenv.bootstrap import LanguageHint, ensure_bootstrap
         from repo2rlenv.bootstrap.runner import BootstrapError

--- a/src/repo2rlenv/cli.py
+++ b/src/repo2rlenv/cli.py
@@ -156,7 +156,7 @@ def cmd_generate(args: argparse.Namespace) -> int:
         with bootstrap_view_or_plain(
             repo=gen_input.repo.url,
             ref=gen_input.repo.ref,
-            model=gen_input.llm.qualified_name,
+            model=gen_input.llm.qualified_name if gen_input.llm else "none",
             max_iterations=bspec.max_iterations,
             language=(bspec.languages_hint[0] if bspec.languages_hint else "unknown"),
             base_image=bspec.base_image or "(auto-detect)",
@@ -210,7 +210,7 @@ def cmd_generate(args: argparse.Namespace) -> int:
     with generation_view_or_plain(
         repo=gen_input.repo.url,
         pipeline=gen_input.pipeline.name.value,
-        model=gen_input.llm.qualified_name,
+        model=gen_input.llm.qualified_name if gen_input.llm else "none",
         limit=limit_hint,
         out=str(out_dir),
         force_plain=args.no_ui,

--- a/src/repo2rlenv/pipelines/code_instruct.py
+++ b/src/repo2rlenv/pipelines/code_instruct.py
@@ -150,6 +150,8 @@ class CodeInstructPipeline:
                 "code_instruct requires a BootstrapResult (set requires_bootstrap=True "
                 "and let cmd_generate trigger it, or pass one explicitly)"
             )
+        if input.llm is None:
+            raise ValueError("code_instruct requires --llm (provider/model)")
         self.input = input
         self.options = options
         self.bootstrap = bootstrap

--- a/src/repo2rlenv/pipelines/commit_runtime.py
+++ b/src/repo2rlenv/pipelines/commit_runtime.py
@@ -392,7 +392,7 @@ class CommitRuntimePipeline:
             "reference": f"https://github.com/{owner}/{name}/commit/{commit.sha}",
             "source_access": self.input.repo.access,
             "built_at": datetime.now(UTC).isoformat(),
-            "synthesis_llm": self.input.llm.qualified_name,
+            "synthesis_llm": self.input.llm.qualified_name if self.input.llm else None,
             "reward_kinds": ["test_execution", "diff_similarity"],
             "commit_runtime": {
                 "commit_sha": commit.sha,

--- a/src/repo2rlenv/pipelines/commit_runtime.py
+++ b/src/repo2rlenv/pipelines/commit_runtime.py
@@ -392,7 +392,7 @@ class CommitRuntimePipeline:
             "reference": f"https://github.com/{owner}/{name}/commit/{commit.sha}",
             "source_access": self.input.repo.access,
             "built_at": datetime.now(UTC).isoformat(),
-            "synthesis_llm": self.input.llm.qualified_name if self.input.llm else None,
+            **({"synthesis_llm": self.input.llm.qualified_name} if self.input.llm else {}),
             "reward_kinds": ["test_execution", "diff_similarity"],
             "commit_runtime": {
                 "commit_sha": commit.sha,

--- a/src/repo2rlenv/pipelines/cve_patches.py
+++ b/src/repo2rlenv/pipelines/cve_patches.py
@@ -333,7 +333,7 @@ class CVEPatchesPipeline:
             "reference": f"https://github.com/{owner}/{name}/commit/{fix_sha}",
             "source_access": self.input.repo.access,
             "built_at": datetime.now(UTC).isoformat(),
-            "synthesis_llm": self.input.llm.qualified_name,
+            "synthesis_llm": self.input.llm.qualified_name if self.input.llm else None,
             "reward_kinds": ["test_execution", "diff_similarity"],
             "cve_patches": {
                 "cve_id": vuln.cve_id or "",

--- a/src/repo2rlenv/pipelines/cve_patches.py
+++ b/src/repo2rlenv/pipelines/cve_patches.py
@@ -333,7 +333,7 @@ class CVEPatchesPipeline:
             "reference": f"https://github.com/{owner}/{name}/commit/{fix_sha}",
             "source_access": self.input.repo.access,
             "built_at": datetime.now(UTC).isoformat(),
-            "synthesis_llm": self.input.llm.qualified_name if self.input.llm else None,
+            **({"synthesis_llm": self.input.llm.qualified_name} if self.input.llm else {}),
             "reward_kinds": ["test_execution", "diff_similarity"],
             "cve_patches": {
                 "cve_id": vuln.cve_id or "",

--- a/src/repo2rlenv/pipelines/equivalence_tests.py
+++ b/src/repo2rlenv/pipelines/equivalence_tests.py
@@ -236,6 +236,8 @@ class EquivalenceTestsPipeline:
                 "equivalence_tests requires a BootstrapResult (set requires_bootstrap=True "
                 "and let cmd_generate trigger it, or pass one explicitly)"
             )
+        if input.llm is None:
+            raise ValueError("equivalence_tests requires --llm (provider/model)")
         self.input = input
         self.options = options
         self.bootstrap = bootstrap

--- a/src/repo2rlenv/pipelines/mutation_bugs.py
+++ b/src/repo2rlenv/pipelines/mutation_bugs.py
@@ -256,6 +256,8 @@ class MutationBugsPipeline:
                 "mutation_bugs requires a BootstrapResult (set requires_bootstrap=True "
                 "and let cmd_generate trigger it, or pass one explicitly)"
             )
+        if input.llm is None:
+            raise ValueError("mutation_bugs requires --llm (provider/model)")
         self.input = input
         self.options = options
         self.bootstrap = bootstrap

--- a/src/repo2rlenv/pipelines/pr_diff.py
+++ b/src/repo2rlenv/pipelines/pr_diff.py
@@ -188,7 +188,7 @@ class PRDiffPipeline:
             "reference": pr.url,
             "source_access": self.input.repo.access,
             "built_at": datetime.now(UTC).isoformat(),
-            "synthesis_llm": self.input.llm.qualified_name,
+            "synthesis_llm": self.input.llm.qualified_name if self.input.llm else None,
             "pr_diff": {
                 "pr_merged_at": pr.merged_at,
                 "diff_format": self.options.diff_format,

--- a/src/repo2rlenv/pipelines/pr_diff.py
+++ b/src/repo2rlenv/pipelines/pr_diff.py
@@ -188,7 +188,7 @@ class PRDiffPipeline:
             "reference": pr.url,
             "source_access": self.input.repo.access,
             "built_at": datetime.now(UTC).isoformat(),
-            "synthesis_llm": self.input.llm.qualified_name if self.input.llm else None,
+            **({"synthesis_llm": self.input.llm.qualified_name} if self.input.llm else {}),
             "pr_diff": {
                 "pr_merged_at": pr.merged_at,
                 "diff_format": self.options.diff_format,

--- a/src/repo2rlenv/pipelines/pr_runtime.py
+++ b/src/repo2rlenv/pipelines/pr_runtime.py
@@ -789,7 +789,7 @@ class PRRuntimePipeline:
             "reference": pr.url,
             "source_access": self.input.repo.access,
             "built_at": datetime.now(UTC).isoformat(),
-            "synthesis_llm": self.input.llm.qualified_name if self.input.llm else None,
+            **({"synthesis_llm": self.input.llm.qualified_name} if self.input.llm else {}),
             "reward_kinds": ["test_execution", "diff_similarity"],
             "pr_runtime": {
                 "pr_url": pr.url,

--- a/src/repo2rlenv/pipelines/pr_runtime.py
+++ b/src/repo2rlenv/pipelines/pr_runtime.py
@@ -789,7 +789,7 @@ class PRRuntimePipeline:
             "reference": pr.url,
             "source_access": self.input.repo.access,
             "built_at": datetime.now(UTC).isoformat(),
-            "synthesis_llm": self.input.llm.qualified_name,
+            "synthesis_llm": self.input.llm.qualified_name if self.input.llm else None,
             "reward_kinds": ["test_execution", "diff_similarity"],
             "pr_runtime": {
                 "pr_url": pr.url,

--- a/src/repo2rlenv/pipelines/refactor_synthesis.py
+++ b/src/repo2rlenv/pipelines/refactor_synthesis.py
@@ -424,7 +424,7 @@ class RefactorSynthesisPipeline:
             "reference": (f"https://github.com/{owner}/{name}/commit/{commit.sha}"),
             "source_access": self.input.repo.access,
             "built_at": datetime.now(UTC).isoformat(),
-            "synthesis_llm": self.input.llm.qualified_name if self.input.llm else None,
+            **({"synthesis_llm": self.input.llm.qualified_name} if self.input.llm else {}),
             "reward_kinds": ["test_execution", "diff_similarity"],
             "refactor_synthesis": {
                 "refactor_kind": "rename",

--- a/src/repo2rlenv/pipelines/refactor_synthesis.py
+++ b/src/repo2rlenv/pipelines/refactor_synthesis.py
@@ -424,7 +424,7 @@ class RefactorSynthesisPipeline:
             "reference": (f"https://github.com/{owner}/{name}/commit/{commit.sha}"),
             "source_access": self.input.repo.access,
             "built_at": datetime.now(UTC).isoformat(),
-            "synthesis_llm": self.input.llm.qualified_name,
+            "synthesis_llm": self.input.llm.qualified_name if self.input.llm else None,
             "reward_kinds": ["test_execution", "diff_similarity"],
             "refactor_synthesis": {
                 "refactor_kind": "rename",

--- a/src/repo2rlenv/spec/input.py
+++ b/src/repo2rlenv/spec/input.py
@@ -173,7 +173,7 @@ class GenerationInput(BaseModel):
     spec_version: Literal["0.1.0"] = "0.1.0"
     repo: RepoSpec
     pipeline: PipelineSpec
-    llm: LLMSpec
+    llm: LLMSpec | None = None
     output: OutputSpec
     qa: QASpec = Field(default_factory=QASpec)
     sandbox: SandboxSpec = Field(default_factory=SandboxSpec)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -60,3 +60,43 @@ def test_parse_options_dispatches_correctly():
 def test_parse_options_unknown_pipeline():
     with pytest.raises(ValueError):
         parse_options("not_real", {})
+
+
+def test_generation_input_llm_defaults_to_none():
+    g = GenerationInput.model_validate(
+        {
+            "repo": {"url": "huggingface/trl"},
+            "pipeline": {"name": "pr_diff"},
+            "output": {"destination": "./out", "org": "myorg", "dataset_name": "trl-r2e"},
+        }
+    )
+    assert g.llm is None
+
+
+def test_synthesis_pipeline_raises_without_llm():
+    from repo2rlenv.bootstrap.spec import BootstrapResult, LanguageHint
+    from repo2rlenv.pipelines.mutation_bugs import MutationBugsPipeline
+    from repo2rlenv.spec.options import MutationBugsOptions
+
+    gen = GenerationInput.model_validate(
+        {
+            "repo": {"url": "pallets/click"},
+            "pipeline": {"name": "mutation_bugs"},
+            "output": {"destination": "./out", "org": "myorg", "dataset_name": "test"},
+        }
+    )
+    fake_bootstrap = BootstrapResult(
+        image_tag="test",
+        image_digest="sha256:abc",
+        language=LanguageHint.PYTHON,
+        repo="pallets/click",
+        ref="main",
+        rebuild_cmds=[],
+        test_cmds=[],
+        smoke_passed=True,
+        iterations=1,
+        build_time_sec=0.0,
+        llm_provider="none",
+    )
+    with pytest.raises(ValueError, match="mutation_bugs requires --llm"):
+        MutationBugsPipeline(gen, MutationBugsOptions(), bootstrap=fake_bootstrap)


### PR DESCRIPTION
Mining pipelines (pr_diff, pr_runtime, commit_runtime, refactor_synthesis, cve_patches) don't use an LLM to generate tasks, they mine from GitHub history and verify in a sandbox. Requiring `--llm` for them was an unnecessary constraint.

`GenerationInput.llm` is now optional. Synthesis pipelines that do need an LLM (mutation_bugs, code_instruct, equivalence_tests) enforce this at construction time with a clear error. Bootstrap-required pipelines alsovfail early in the CLI if no LLM is configured.