### PR TITLE
clarify harbor run flags and pr_diff limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ repo2rlenv push ./datasets/<dataset-name> <your-org>/<dataset-name>
 repo2rlenv pull <your-org>/<dataset-name> ./datasets/<dataset-name>
 
 # Run an agent against the spec — Harbor (separate tool) handles execution
+# Note: requires a sandbox-verified pipeline (pr_runtime, commit_runtime, …).
+# Text-only pipelines (pr_diff) don't emit an environment/ dir and can't be run here.
 harbor run --agent oracle --path ./datasets/<dataset-name>/<task-id>
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -92,9 +92,14 @@ Repo2RLEnv emits Harbor-shaped tasks; running them is Harbor's job:
 ```bash
 uv tool install harbor
 
-harbor run -d ./datasets/<dataset-name> -e local-docker -a oracle
-# Or remote: -e modal / -e daytona / -e e2b / -e runloop
+harbor run --path ./datasets/<dataset-name> --env docker --agent oracle
+# Or remote: --env modal / --env daytona / --env e2b / --env runloop
 ```
+
+> **Note:** `harbor run` requires a sandbox-verified pipeline (`pr_runtime`, `commit_runtime`, …).
+> The `pr_diff` pipeline used above is text-only and does not emit an `environment/` directory,
+> so Harbor cannot execute it. Switch to `--pipeline pr_runtime` (requires Docker + `--llm`) to
+> produce runnable tasks.
 
 ## Next steps
 


### PR DESCRIPTION
Fix two errors in the harbor run example: wrong -d/-e/-a short flags (harbor uses --path/--env/--agent), and -e local-docker is not a valid environment name (correct: --env docker).

Add a note in both README and quickstart that harbor run requires a sandbox-verified pipeline — pr_diff tasks have no environment/ dir and cannot be executed by Harbor.