### PR TITLE
fix: bootstrap saves executable test_cmds; normalize strips -q

### DIFF
--- a/src/repo2rlenv/bootstrap/prompts.py
+++ b/src/repo2rlenv/bootstrap/prompts.py
@@ -49,11 +49,10 @@ Tools:
     Real PRs that we later run will fix the failing tests — your job is
     just to make sure the env can run them at all.
   → DO NOT iterate trying to fix failing tests. Once you've confirmed
-    `pytest --collect-only` works (or one trivial test passes), declare
-    success.
-  → For test_cmds, PREFER non-failing variants like `pytest --collect-only`
-    over `pytest -x` — we just want a command that proves pytest can be
-    invoked, not one that surfaces every test failure.
+    `pytest --collect-only` works, declare success.
+  → For test_cmds, save the ACTUAL execution command (e.g. `python -m pytest -v`),
+    NOT `--collect-only`. Exit code 1 (tests ran but some failed) is fine — downstream
+    pipelines need per-test pass/fail output, which `--collect-only` cannot provide.
 
   ★ STOP CONDITION — read carefully ★
   When `pytest --collect-only` reports a count like "N tests collected"
@@ -71,7 +70,7 @@ Tools:
   state, no activated venv, no exported PATH). If you used a virtualenv
   (uv / venv / poetry), EVERY entry in `test_cmds` must include the
   activation prefix, e.g.:
-      ". /workspace/.venv/bin/activate && python -m pytest --collect-only -q"
+      ". /workspace/.venv/bin/activate && python -m pytest -v"
   Similarly `rebuild_cmds`: if the install requires the venv, prefix it
   with the activation. Prefer system-wide installs (`pip install ...`
   without a venv) when possible — they survive the fresh-shell verify

--- a/src/repo2rlenv/pipelines/pr_runtime.py
+++ b/src/repo2rlenv/pipelines/pr_runtime.py
@@ -341,6 +341,7 @@ def normalize_test_cmds_for_runtime(test_cmds: list[str]) -> list[str]:
     Transforms (per runner):
       pytest:
         - Drop `--collect-only` / `--co` so pytest actually runs tests
+        - Drop `-q` / `--quiet`: suppresses per-test names; cancels `-v` in pytest 9
         - Add `-v` if no verbosity flag is present
       go test:
         - Add `-v` if missing (default `go test` doesn't print --- PASS lines)
@@ -369,6 +370,9 @@ def normalize_test_cmds_for_runtime(test_cmds: list[str]) -> list[str]:
         if re.search(r"\bpytest\b", cleaned):
             cleaned = re.sub(r"\s+--collect-only\b", "", cleaned)
             cleaned = re.sub(r"\s+--co\b", "", cleaned)  # pytest's short form
+            # Strip -q/--quiet: it suppresses per-test names that the log parser needs.
+            # -q and -v cancel each other in pytest 9 (verbosity counter), so -q must go.
+            cleaned = re.sub(r"\s+(?:-q|--quiet)\b", "", cleaned)
             if not re.search(r"\s-v\b|\s--verbose\b|-vv\b", cleaned):
                 cleaned = cleaned.rstrip() + " -v"
 

--- a/tests/test_pipeline_pr_runtime.py
+++ b/tests/test_pipeline_pr_runtime.py
@@ -359,9 +359,23 @@ def test_normalize_strips_trailing_pipe_head_or_tail():
     Regression test for v0.8.2 e2e finding on pallets/click bootstrap.
     """
     assert normalize_test_cmds_for_runtime(["python -m pytest -q 2>&1 | head -50"]) == [
-        "python -m pytest -q -v"
+        "python -m pytest -v"
     ]
     assert normalize_test_cmds_for_runtime(["pytest 2>&1 | tail -n 100"]) == ["pytest -v"]
+
+
+def test_normalize_strips_quiet_flag():
+    """-q suppresses per-test names; -v and -q cancel each other in pytest 9 (verbosity
+    counter). Strip -q so the log parser gets named PASSED/FAILED lines.
+
+    Regression test: bootstrap agents often save `pytest -q` or `pytest --quiet`
+    because --collect-only exits 0 and -q reduces noise during exploration.
+    """
+    assert normalize_test_cmds_for_runtime(["python -m pytest -q"]) == ["python -m pytest -v"]
+    assert normalize_test_cmds_for_runtime(["python -m pytest --quiet tests/"]) == [
+        "python -m pytest tests/ -v"
+    ]
+    assert normalize_test_cmds_for_runtime(["pytest -q --tb=short"]) == ["pytest --tb=short -v"]
 
 
 def test_normalize_strips_dev_null_redirect():


### PR DESCRIPTION
Bootstrap prompt previously instructed the agent to save `--collect-only` as test_cmds. Downstream pipelines (mutation_bugs,  pr_runtime) need actual test execution with per-test pass/fail output to find baseline passing tests and F2P signal — collect-only produces neither.

Two related fixes in normalize_test_cmds_for_runtime: 
- Already stripped --collect-only; now also strips -q/--quiet, which cancels -v in pytest 9's verbosity counter, causing the log parser to see 0 passing tests even when tests ran.

Existing cached bootstraps are safe: normalize handles both flags so no forced rebuild is required.