### PR TITLE
fix: omit seed from task.toml when not set

### DIFF
--- a/src/repo2rlenv/pipelines/mutation_bugs.py
+++ b/src/repo2rlenv/pipelines/mutation_bugs.py
@@ -675,7 +675,7 @@ class MutationBugsPipeline:
                 "lineno": mutation.lineno,
                 "broken_tests": broken_tests,
                 "bootstrap_image": self.bootstrap.image_digest,
-                "seed": self.options.seed,
+                **({"seed": self.options.seed} if self.options.seed is not None else {}),
                 "llm_cost_usd": round(self._llm_cost_usd, 6),
             },
         }


### PR DESCRIPTION
seed is int | None (defaults to None for time-based RNG). Writing None directly to the TOML payload crashes tomli_w with TypeError. Omit the key entirely when seed is not set, consistent with the pattern used for synthesis_llm across other pipelines.