### PR TITLE
v0.8.2.post3: image distribution + reproducible push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ docs/                           # public docs (committed), three tiers:
 plans/                          # internal working docs (gitignored)
 references/                     # cloned inspiration repos (gitignored)
 envs/, envs-*/, .r2e_cache/     # local artifacts (gitignored)
-tests/                          # pytest; 370/370 pass as of v0.8
+tests/                          # pytest; 620/620 pass as of v0.8.2.post3
 .github/workflows/              # ci.yml (lint + matrix tests + build),
                                 # release.yml (PyPI publish on tagged release)
 CONTRIBUTING.md                 # dev setup, PR conventions, release flow
@@ -136,7 +136,7 @@ The canonical contributor reference is [`CONTRIBUTING.md`](./CONTRIBUTING.md) at
 - **No `Co-Authored-By: Claude` trailer** on commits. User explicitly rejected it; see `~/.claude/projects/.../memory/feedback_no_coauthor.md`.
 - **Commits**: terse subject + short body explaining "why". Don't reference the current task; that goes in the PR description.
 - **PRs**: title under 70 chars; description has summary + test plan + out-of-scope items. Close issues via `Closes #N` in commit body.
-- **Tests**: every code change should keep the suite green. `uv run pytest -q` is the canonical command. **115/115 must pass.**
+- **Tests**: every code change should keep the suite green. `uv run pytest -q` is the canonical command. **620/620 must pass.**
 - **Lint + format**: `uv run ruff check .` and `uv run ruff format .` before commit. CI rejects unformatted code or lint violations.
 - **Acknowledgments**: when a file draws inspiration from external work, add a header block crediting the source repo + paper + license + clarifying our license posture. See `bootstrap/__init__.py` or `reward.py` for the format.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ cd Repo2RLEnv
 uv sync --group dev          # installs runtime + dev deps (pytest, ruff)
 
 # Sanity check
-uv run pytest -q             # should print 115/115 passing (or higher)
+uv run pytest -q             # should print 620/620 passing (or higher)
 uv run ruff check .          # should report "All checks passed!"
 uv run ruff format --check . # should report "N files already formatted"
 uv run repo2rlenv --version  # 0.3.0 (or higher)
@@ -95,7 +95,7 @@ A green CI is the floor for merge — green plus at least one approving review i
 
 ### Tests
 
-- **Every code change keeps the suite green.** `uv run pytest -q` is the canonical command. Currently 115/115; if you add code, you usually add tests.
+- **Every code change keeps the suite green.** `uv run pytest -q` is the canonical command. Currently 620/620; if you add code, you usually add tests.
 - **Unit tests live next to the module they test**: `tests/test_<module>.py`. They use `pytest`'s fixture model; we don't use any custom test runner.
 - **E2E tests** (against real GitHub repos) live in `tests/test_e2e_*.py`. They're skipped automatically when `gh` isn't authenticated or the test repo isn't accessible — so they don't break CI for contributors without those credentials.
 - Use **specific exception types** in `pytest.raises(...)` — `pytest.raises(ValidationError)`, not `pytest.raises(Exception)`. Ruff flags the latter (`B017`).

--- a/docs/reference/REGISTRY_AUTH.md
+++ b/docs/reference/REGISTRY_AUTH.md
@@ -1,0 +1,156 @@
+# Container registry authentication
+
+`repo2rlenv push` (v0.8.2.post3+) uploads the bootstrap Docker image to an
+OCI registry alongside the HF Hub dataset so any consumer can `harbor run`
+the published tasks. This page covers how to log into each supported
+registry and verify the credentials work.
+
+Run `repo2rlenv push --check-auth` to probe every detected registry and
+get a one-shot report. No image is pushed, no garbage created.
+
+## Default flow
+
+You don't have to pre-configure anything — `repo2rlenv push` auto-detects
+the first verified registry from `~/.docker/config.json`. If nothing is
+logged in, push falls back to inline-Dockerfile mode (recipe-level
+reproducibility) and warns about how to upgrade.
+
+For the launch / CI path use `--require-registry` to hard-fail rather
+than fall back silently.
+
+## GHCR (default recommendation)
+
+Free for public images, no anonymous-pull rate limit, ties naturally to a
+GitHub org. **Recommended default for new datasets.**
+
+```bash
+gh auth refresh -h github.com -s write:packages
+echo "$(gh auth token)" | docker login ghcr.io \
+  -u "$(gh api user --jq .login)" --password-stdin
+```
+
+`repo2rlenv push` will pick `ghcr.io/<hf-dataset-owner>/...` automatically.
+If you lack `write:packages` on that GitHub org, push falls back to
+`ghcr.io/<gh-login-user>/...`. Repository visibility is flipped to public
+via the GitHub API (`PATCH /user|orgs/packages/container/<name>`) when the
+HF dataset is public.
+
+## AWS ECR Private
+
+Token TTL is 12h — install `amazon-ecr-credential-helper` once and forget
+about it.
+
+```bash
+brew install docker-credential-helper-ecr  # or apt
+# Add to ~/.docker/config.json:
+#   "credHelpers": { "<acct>.dkr.ecr.<region>.amazonaws.com": "ecr-login" }
+```
+
+Or one-off (re-run every 12h):
+
+```bash
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin \
+    <acct>.dkr.ecr.us-east-1.amazonaws.com
+```
+
+ECR requires the repository to pre-exist; `repo2rlenv push` creates it
+automatically via `aws ecr create-repository` if the L4 probe returns 404.
+Make sure your IAM role has `ecr:CreateRepository`.
+
+## AWS ECR Public
+
+Distinct service from Private. **50 GB free public storage, forever.**
+
+```bash
+aws ecr-public get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin public.ecr.aws
+```
+
+Or use `amazon-ecr-credential-helper` against `public.ecr.aws`.
+
+## Azure Container Registry
+
+Token TTL is 3h.
+
+```bash
+az login                              # one-time
+az acr login --name <myregistry>      # per session
+```
+
+For anonymous public pulls (Standard tier or higher):
+`az acr update -n <reg> --anonymous-pull-enabled true`.
+
+## GCP Artifact Registry
+
+`gcloud` registers itself as a Docker credential helper per region:
+
+```bash
+gcloud auth login
+gcloud auth configure-docker us-central1-docker.pkg.dev
+```
+
+Repository must pre-exist; `repo2rlenv push` creates it via
+`gcloud artifacts repositories create` if the L4 probe returns 404.
+For public pulls:
+
+```bash
+gcloud artifacts repositories add-iam-policy-binding <repo> \
+  --location=us-central1 --member=allUsers \
+  --role=roles/artifactregistry.reader
+```
+
+## Docker Hub
+
+Default tier has a **100 pulls / 6h / IP anonymous limit** — fine for
+small datasets, but a real problem for benchmarks pulled by many
+consumers or in CI. `repo2rlenv push` will NOT pick Docker Hub as the
+auto-default when other registries are available; pass `--image-registry
+index.docker.io/<user>` to force it.
+
+```bash
+docker login                          # interactive PAT prompt
+# OR
+echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USERNAME" --password-stdin
+```
+
+## Local / `registry:2` (testing only)
+
+For development tests that need a real OCI registry but don't want any
+cloud signup:
+
+```bash
+docker run -d -p 5000:5000 --name r2e-test-reg registry:2
+repo2rlenv push ./datasets/mydataset owner/repo \
+  --image-registry localhost:5000
+```
+
+The probe correctly classifies localhost and skips L2 auth (the default
+registry:2 image runs without auth). For an authenticated local registry,
+see the upstream docs at <https://distribution.github.io/distribution>.
+
+## Anonymous-ephemeral: `ttl.sh`
+
+For one-shot end-to-end smoke tests with no signup:
+
+```bash
+repo2rlenv push ./datasets/mydataset owner/repo \
+  --image-registry ttl.sh
+```
+
+Images auto-delete after 1h (configurable in the tag).
+
+## What `--check-auth` actually probes
+
+For each registry the L1–L4 protocol runs in order:
+
+| Level | Endpoint | What it confirms |
+|---|---|---|
+| L1 | `GET /v2/` | Registry reachable |
+| L2 | Bearer-token exchange | Credentials parse + registry accepts them |
+| L3 | `HEAD /v2/<ns>/r2e-bootstrap-probe/manifests/latest` (404 = pass) | Read access on target namespace |
+| L4 | `POST /v2/<ns>/r2e-bootstrap-probe/blobs/uploads/` + `DELETE` cancel | Write access |
+
+L4 leaves no image, layer, or session artifact. Total wire time per
+registry: ~200–500 ms. `--fast` stops at L2 if you just want a quick
+sanity check.

--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -102,7 +102,7 @@ difficulty = "medium"
 category = "bugfix"
 
 [metadata.repo2env]
-spec_version = "0.1.0"
+spec_version = "0.2.0"
 pipeline = "pr_diff"
 pipeline_version = "0.1.0"
 repo = "huggingface/trl"
@@ -118,6 +118,21 @@ reward_kinds = ["diff_similarity"]
 pr_merged_at = "2026-05-05T13:46:07Z"
 diff_format = "unified"
 context_files = ["trl/trainer/dpo_trainer.py", ...]
+
+# v0.2.0+ only — sandbox-required tasks (pr_runtime / mutation_bugs / ...)
+# carry this subtable so consumers know exactly what they're getting.
+[metadata.repo2env.reproducibility]
+mode = "registry"                                    # registry | inline_dockerfile | local_only
+image_ref = "ghcr.io/huggingface/r2e-bootstrap-pallets-click@sha256:..."
+image_tag = "ghcr.io/huggingface/r2e-bootstrap-pallets-click:a1b2c3d4e5f6-7d8e9f01"
+image_visibility = "public"                          # public | private | unknown
+pushed_at = "2026-05-19T11:30:00Z"
+pushed_by = "huggingface"
+# Inline-mode-only fields (omitted in registry mode):
+# inline_recipe_sha256 = "sha256:..."
+# inline_recipe_lines = 47
+# inline_recipe_source = "agent_replay"              # or "user_dockerfile"
+# fallback_reason = "no working registry credentials (ghcr.io: L2 auth failed)"
 
 [agent]
 timeout_sec = 1800.0
@@ -187,6 +202,31 @@ A task may emit both. The lite pipeline emits only `diff_similarity`; full sandb
 
 The diff-similarity reward function is implemented at [`src/repo2rlenv/reward.py:calculate_diff_similarity_reward`](../src/repo2rlenv/reward.py) — pure stdlib (`difflib.SequenceMatcher`), Apache-2.0, no SWE-RL CC-BY-NC code vendored.
 
+## Image distribution (v0.2.0+)
+
+Sandbox-required tasks (`pr_runtime`, `mutation_bugs`, …) ship an `environment/Dockerfile` whose `FROM <ref>` line points at the *bootstrap image* — the working Docker environment for the source repo. At generate time the ref is `local/r2e-bootstrap/...` (un-pullable from any other machine). `repo2rlenv push` rewrites it in-place to one of two reproducible forms:
+
+| Mode | `FROM` ref | Reproducibility |
+|---|---|---|
+| `registry` | `ghcr.io/<owner>/r2e-bootstrap-<slug>@sha256:...` (or ECR / ACR / GCP AR / Docker Hub equivalent) | **Bit-exact** — registry digest is immutable |
+| `inline_dockerfile` | full apt-get / pip / ... recipe baked into `environment/Dockerfile`, no `FROM <registry>` reference | **Recipe-level** — assumes mirrors stay stable; rebuilds from scratch on every `harbor run` |
+
+The mode that was chosen is recorded in `[metadata.repo2env.reproducibility]` (see the `task.toml` example above), along with `pushed_at`, `pushed_by`, and — for inline mode — `inline_recipe_source` ∈ `{user_dockerfile, agent_replay}`.
+
+`repo2rlenv push` decides which mode to use by running the **OCI Distribution Spec L1–L4 probe protocol** against every registry it finds credentials for in `~/.docker/config.json`. The probe never pushes anything to the user's registry — it confirms reachability + auth + read + write by starting a blob-upload session and immediately cancelling it. Run `repo2rlenv push --check-auth` to see the probe output for your machine.
+
+Push flags:
+
+| Flag | Behaviour |
+|---|---|
+| (default) | Auto-detect a verified registry; fall back to inline-Dockerfile mode with a warning if none |
+| `--image-registry <prefix>` | Force a specific registry (e.g. `ghcr.io/myorg`); probed for write access before push |
+| `--inline-dockerfile` | Skip image push; bake the recipe into each task. Recipe-level reproducibility. |
+| `--require-registry` | Hard-fail if no verified registry is available (CI / launch mode). No silent fallback. |
+| `--skip-image-push` | Rewrite tasks against a remote ref that already exists at the registry. No `docker push`. |
+| `--image-visibility public\|private\|inherit` | Visibility for the pushed image (GHCR auto-flips via the GitHub API). Default: match dataset. |
+| `--check-auth` | Probe every detected registry and exit. `--fast` skips L3/L4; `--json` for CI. |
+
 ## Conformance
 
 A task or dataset is **conformant** to v0.1 if and only if:
@@ -197,6 +237,14 @@ A task or dataset is **conformant** to v0.1 if and only if:
 4. `solution/patch.diff` exists and is non-empty (lite pipelines)
 5. For sandbox-required pipelines: `environment/Dockerfile` and `tests/test.sh` exist
 
+v0.2 adds:
+
+6. Sandbox-required tasks carry `[metadata.repo2env.reproducibility]` with `mode ∈ {registry, inline_dockerfile, local_only}`. `local_only` is pre-publication — these tasks are NOT considered reproducible by external consumers.
+
 ## Versioning
 
 Pre-1.0 is a moving target — minor bumps may break readers. After 1.0 we honor strict SemVer (additive minors, breaking majors only). Each released spec version freezes its JSON Schema at a stable URL.
+
+### v0.2.0 (v0.8.2.post3)
+
+Adds `[metadata.repo2env.reproducibility]`. Additive change — v0.1.0 readers ignore the new subtable; pre-v0.2 datasets that lack it pass validation unchanged but aren't portable across machines.

--- a/docs/release_notes/v0.8.2.post3.md
+++ b/docs/release_notes/v0.8.2.post3.md
@@ -1,0 +1,130 @@
+# v0.8.2.post3 — Image distribution & reproducible push
+
+Sandbox-required datasets (`pr_runtime`, `mutation_bugs`, `code_instruct`,
+`cve_patches`, `equivalence_tests`, `refactor_synthesis`, `commit_runtime`)
+are now reproducible end-to-end by any consumer who pulls them from HF Hub.
+
+## What changed
+
+Before this release, every `_runtime` dataset emitted an `environment/Dockerfile`
+with `FROM local/r2e-bootstrap/...` — un-pullable from any other machine.
+The Hub dataset looked correct on paper but failed at `harbor run` time
+on a fresh machine. **This release closes that loop.**
+
+`repo2rlenv push` now:
+
+1. **Discovers** registry credentials in `~/.docker/config.json` (GHCR /
+   ECR Private+Public / ACR / GCP AR / Docker Hub / local / others).
+2. **Verifies** them via the OCI Distribution Spec **L1-L4 probe** —
+   reachability, auth resolution, read access, write access — without
+   pushing anything to your registry.
+3. **Pushes** the bootstrap image to the first verified registry,
+   rewriting each task's `environment/Dockerfile` + `task.toml` in-place
+   to point at the registry-qualified digest (`@sha256:...`).
+4. **Falls back to inline-Dockerfile mode** when no verified registry is
+   available — bakes the bootstrap's reconstructed Dockerfile into each
+   task and records `fallback_reason` so consumers know what they're
+   getting. Pass `--require-registry` to hard-fail instead.
+
+Plus: GHCR package visibility is auto-flipped to public via the GitHub API
+when the dataset is public; ECR / GCP AR repositories are auto-created on
+first push.
+
+## New CLI surface
+
+```bash
+# Default: auto-detect + verify + push (or fall back to inline with warning)
+repo2rlenv push ./datasets/mydataset owner/mydataset
+
+# Force a specific registry
+repo2rlenv push ./datasets/mydataset owner/mydataset \
+  --image-registry ghcr.io/myorg
+
+# Inline-recipe mode — no registry needed
+repo2rlenv push ./datasets/mydataset owner/mydataset --inline-dockerfile
+
+# CI / launch: refuse to fall back silently
+repo2rlenv push ./datasets/mydataset owner/mydataset --require-registry
+
+# Diagnose credentials without doing anything
+repo2rlenv push --check-auth
+repo2rlenv push --check-auth --json     # for CI assertions
+repo2rlenv push --check-auth --fast     # stop at L2, skip wire-level probes
+```
+
+See [`docs/reference/REGISTRY_AUTH.md`](../reference/REGISTRY_AUTH.md) for the
+per-registry login instructions.
+
+## Spec changes
+
+`[metadata.repo2env.spec_version]` is bumped from `"0.1.0"` to `"0.2.0"`.
+The bump is additive — v0.1 readers ignore the new subtable.
+
+New: `[metadata.repo2env.reproducibility]` on every sandbox-required task:
+
+```toml
+[metadata.repo2env.reproducibility]
+mode = "registry"                                    # registry | inline_dockerfile | local_only
+image_ref = "ghcr.io/huggingface/r2e-bootstrap-pallets-click@sha256:..."
+image_tag = "ghcr.io/huggingface/r2e-bootstrap-pallets-click:a1b2c3d4e5f6-7d8e9f01"
+image_visibility = "public"
+pushed_at = "2026-05-19T11:30:00Z"
+pushed_by = "huggingface"
+```
+
+For inline-mode datasets the same subtable carries `inline_recipe_sha256`,
+`inline_recipe_lines`, `inline_recipe_source` (`user_dockerfile` for
+bit-exact recipes, `agent_replay` for best-effort), and `fallback_reason`
+when inline was an auto-fallback rather than an explicit choice.
+
+The legacy `[metadata.repo2env.<pipeline>].bootstrap_image` field is still
+written for back-compat but the **canonical location is now
+`[metadata.repo2env.reproducibility].image_ref`**.
+
+## Bug fixes
+
+- **`cmd_push` no longer omits `pipeline` / `repo_source`** from the
+  dataset card (C1). Previously, calling `repo2rlenv push` standalone (not
+  via `--out hf://`) produced a README with empty pipeline + source-repo
+  fields. Now read from the first task's `[metadata.repo2env]`
+  automatically.
+
+## Implementation
+
+New `src/repo2rlenv/registry/` subpackage with focused modules:
+
+- `auth.py` — file-level discovery from `~/.docker/config.json`
+- `probe.py` — OCI L1-L4 verification (stdlib urllib, no network deps)
+- `push.py` — `docker push` subprocess wrapper + digest extraction
+- `visibility.py` — GHCR `PATCH` visibility flip via `gh` CLI
+- `ecr.py`, `gar.py` — repo pre-creation for registries that need it
+- `naming.py` — slug + tag construction reusing `cache._options_hash`
+- `integration.py` — the discover → verify → select → push → rewrite
+  orchestrator called from `hub.push_to_hub`
+
+127 new unit tests, plus optional live-registry integration tests gated on
+`R2E_LIVE_PROBE_LOCAL` / `R2E_LIVE_PROBE_GHCR` env vars. **Total: 614/614
+tests green.**
+
+## Migration
+
+Datasets pushed with v0.8.2.post2 or earlier have un-pullable `FROM`
+references and no `[metadata.repo2env.reproducibility]` subtable. They
+won't break the CLI (`validate` still passes), but `harbor run` will fail
+on a fresh machine. Re-push to upgrade:
+
+```bash
+repo2rlenv pull <old-dataset>
+repo2rlenv push ./datasets/<old-dataset> <hf-target>
+```
+
+The pulled dataset re-emerges with `mode = "local_only"` plus a still-local
+`FROM` ref; re-pushing rewrites everything to registry / inline mode.
+
+## What's NOT in this release
+
+Deferred to future work (no ETA): multi-arch images, image squashing /
+size reduction, cosign signing, HF Hub as a native OCI registry,
+re-pushing old datasets in bulk via a `--rewrite-only` flag.
+
+Full design rationale: [`plans/v0.8.2.post3_image_distribution.md`](../../plans/v0.8.2.post3_image_distribution.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repo2rlenv"
-version = "0.8.2.post2"
+version = "0.8.2.post3"
 description = "Turn any repository into an RL environment for training and evaluation."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/repo2rlenv/cli.py
+++ b/src/repo2rlenv/cli.py
@@ -442,6 +442,10 @@ def cmd_push(args: argparse.Namespace) -> int:
     from repo2rlenv.hub import push_to_hub
     from repo2rlenv.spec.input import AuthSpec
 
+    # --check-auth: short-circuit, run the §5.3 probe protocol and exit
+    if getattr(args, "check_auth", False):
+        return _run_check_auth(args)
+
     local_dir = Path(args.local_dir).expanduser().resolve()
     if not local_dir.is_dir():
         console.error(f"local dataset directory not found: {local_dir}")
@@ -473,6 +477,12 @@ def cmd_push(args: argparse.Namespace) -> int:
                 auth=AuthSpec(),
                 private=args.private,
                 commit_message=args.message,
+                image_registry=getattr(args, "image_registry", None),
+                inline_dockerfile=getattr(args, "inline_dockerfile", False),
+                require_registry=getattr(args, "require_registry", False),
+                skip_image_push=getattr(args, "skip_image_push", False),
+                image_visibility=getattr(args, "image_visibility", "inherit"),
+                on_message=lambda m: console.info(m),
             )
         except Exception as exc:
             console.error(f"push failed: {exc}")
@@ -487,6 +497,95 @@ def cmd_push(args: argparse.Namespace) -> int:
             title="HF Hub push",
         )
         console.dim(f"  to pull back later:  repo2rlenv pull {result.repo_id}")
+    return 0
+
+
+def _run_check_auth(args: argparse.Namespace) -> int:
+    """Run the §5.3 probe protocol against every discovered registry."""
+    import json as _json
+
+    from repo2rlenv.auth import resolve_hf_token
+    from repo2rlenv.registry.auth import (
+        RegistryKind,
+        discover_logged_in_registries,
+        filter_known_registries,
+    )
+    from repo2rlenv.registry.integration import _build_namespace_for
+    from repo2rlenv.registry.probe import probe
+    from repo2rlenv.spec.input import AuthSpec
+
+    json_mode = getattr(args, "json", False)
+    fast = getattr(args, "fast", False)
+    levels = (1, 2) if fast else (1, 2, 3, 4)
+
+    hf_token = resolve_hf_token(AuthSpec())
+    hf_status = "logged in" if hf_token else "NOT logged in"
+
+    candidates = filter_known_registries(discover_logged_in_registries())
+    results = []
+    for auth in candidates:
+        ns = _build_namespace_for(
+            auth, hf_owner=args.dataset.split("/", 1)[0] if "/" in args.dataset else "test"
+        )
+        pr = probe(auth, ns, levels=levels)
+        results.append((auth, pr))
+
+    if json_mode:
+        out = {
+            "hf_hub": {"logged_in": bool(hf_token)},
+            "registries": [
+                {
+                    "host": auth.host,
+                    "kind": auth.kind.value,
+                    "cred_source": auth.cred_source.value,
+                    "reachable": pr.reachable,
+                    "authenticated": pr.authenticated,
+                    "can_read": pr.can_read,
+                    "can_write": pr.can_write,
+                    "is_pushable": pr.is_pushable,
+                    "error": pr.error,
+                    "elapsed_sec": pr.elapsed_sec,
+                }
+                for auth, pr in results
+            ],
+        }
+        print(_json.dumps(out, indent=2))
+        return 0
+
+    with console.section("Checking credentials for push targets"):
+        console.info(f"HF Hub: {hf_status}")
+        if not results:
+            console.warn("no container-registry credentials found in ~/.docker/config.json")
+            return 0
+        for auth, pr in results:
+            label = f"{auth.host}  ({auth.kind.value}, cred: {auth.cred_source.value})"
+            console.info(label)
+            console.dim(
+                f"  L1 reachable          {'✓' if pr.reachable else '✗'}  "
+                f"{pr.elapsed_sec * 1000:.0f}ms"
+            )
+            if 2 in levels:
+                console.dim(f"  L2 auth resolved      {'✓' if pr.authenticated else '✗'}")
+            if 3 in levels:
+                console.dim(f"  L3 can read namespace {'✓' if pr.can_read else '✗'}")
+            if 4 in levels:
+                console.dim(f"  L4 can write          {'✓' if pr.can_write else '✗'}")
+            if pr.is_pushable:
+                console.success(f"  → READY for push as {auth.host}/{pr.namespace}")
+            else:
+                console.warn(f"  → NOT READY: {pr.error or '(unknown)'}")
+                if pr.helper_hint:
+                    console.dim(f"  Fix: {pr.helper_hint}")
+        # Suggest default
+        best = next(
+            (pr for _, pr in results if pr.is_pushable and pr.kind is RegistryKind.GHCR), None
+        )
+        if best is None:
+            best = next((pr for _, pr in results if pr.is_pushable), None)
+        if best:
+            console.info(f"Default registry for push: {best.host}/{best.namespace}")
+        else:
+            console.warn("No verified registry available — push will fall back to inline mode")
     return 0
 
 
@@ -780,13 +879,77 @@ def main(argv: list[str] | None = None) -> int:
 
     # push
     p = sub.add_parser("push", help="Push a local dataset directory to HF Hub")
-    p.add_argument("local_dir", help="path to dataset directory (output of `generate`)")
-    p.add_argument("dataset", help="HF Hub target as `hf://owner/dataset` (or `owner/dataset`)")
+    p.add_argument(
+        "local_dir",
+        nargs="?",
+        default=".",
+        help="path to dataset directory (output of `generate`). Optional with --check-auth.",
+    )
+    p.add_argument(
+        "dataset",
+        nargs="?",
+        default="",
+        help="HF Hub target as `owner/dataset` (or `hf://owner/dataset`). Optional with --check-auth.",
+    )
     p.add_argument("--private", action="store_true", help="create the Hub repo as private")
     p.add_argument(
         "--message",
         "-m",
         help="custom commit message (default: 'Repo2RLEnv: add N tasks')",
+    )
+    # v0.8.2.post3: image-distribution flags
+    p.add_argument(
+        "--image-registry",
+        help=(
+            "force a specific OCI registry prefix (e.g. `ghcr.io/myorg`, "
+            "`123.dkr.ecr.us-east-1.amazonaws.com/r2e`). Default: auto-detect "
+            "from ~/.docker/config.json + verify via OCI probe."
+        ),
+    )
+    p.add_argument(
+        "--inline-dockerfile",
+        action="store_true",
+        help=(
+            "skip image push; bake the bootstrap recipe into each task's "
+            "environment/Dockerfile. Recipe-level reproducibility, not bit-exact."
+        ),
+    )
+    p.add_argument(
+        "--require-registry",
+        action="store_true",
+        help=(
+            "hard-fail if no verified registry credential is available "
+            "(CI / launch-dataset mode; no silent inline fallback)."
+        ),
+    )
+    p.add_argument(
+        "--skip-image-push",
+        action="store_true",
+        help=(
+            "skip the docker push step; rewrite tasks against a remote ref "
+            "assumed to already exist at the registry."
+        ),
+    )
+    p.add_argument(
+        "--image-visibility",
+        choices=["public", "private", "inherit"],
+        default="inherit",
+        help="visibility of the pushed image (default: match HF dataset visibility)",
+    )
+    p.add_argument(
+        "--check-auth",
+        action="store_true",
+        help="probe every detected registry (no push, no upload) and exit",
+    )
+    p.add_argument(
+        "--fast",
+        action="store_true",
+        help="--check-auth: stop after L2 (skip L3/L4 round-trips)",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="--check-auth: emit machine-readable JSON output",
     )
     p.set_defaults(func=cmd_push)
 

--- a/src/repo2rlenv/emitter/harbor.py
+++ b/src/repo2rlenv/emitter/harbor.py
@@ -29,6 +29,7 @@ Released under Apache-2.0.
 from __future__ import annotations
 
 import hashlib
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -69,7 +70,9 @@ def write_harbor_task(task: HarborTask, dest_dir: Path) -> Path:
 
     # task.toml
     repo2env = dict(task.repo2env)
-    repo2env.setdefault("spec_version", "0.1.0")
+    # v0.2.0: introduces [metadata.repo2env.reproducibility] subtable; the bump
+    # is additive — old readers ignore the new subtable, new readers see it.
+    repo2env.setdefault("spec_version", "0.2.0")
     repo2env.setdefault("content_hash", _content_hash(task))
     # Default reward kinds — sandbox-required tasks override with
     # test_execution as the primary signal
@@ -77,6 +80,27 @@ def write_harbor_task(task: HarborTask, dest_dir: Path) -> Path:
         repo2env.setdefault("reward_kinds", ["test_execution", "diff_similarity"])
     else:
         repo2env.setdefault("reward_kinds", ["diff_similarity"])
+
+    # For sandbox-required tasks (those that emit environment/Dockerfile),
+    # seed [metadata.repo2env.reproducibility] with mode=local_only and the
+    # un-pullable local image ref. `repo2rlenv push` rewrites this in-place
+    # to mode=registry / inline_dockerfile after the push step.
+    if task.environment_dockerfile is not None and "reproducibility" not in repo2env:
+        bootstrap_image = ""
+        # Derive from the Dockerfile's first FROM line so we don't need the
+        # caller to plumb it separately. Matches the same anchor used by
+        # `registry.integration._FROM_LINE_RE`.
+        m = re.search(
+            r"^(\s*FROM\s+)(\S+)", task.environment_dockerfile, re.IGNORECASE | re.MULTILINE
+        )
+        if m:
+            bootstrap_image = m.group(2).strip()
+        repo2env["reproducibility"] = {
+            "mode": "local_only",
+            "image_ref": bootstrap_image or "local/r2e-bootstrap:unknown",
+            "image_tag": bootstrap_image or "local/r2e-bootstrap:unknown",
+            "image_visibility": "private",
+        }
 
     # Harbor's task.toml requires `task.name` in `<org>/<name>` format —
     # validated at load-time by harbor.models.task.config.PackageInfo. We

--- a/src/repo2rlenv/hub.py
+++ b/src/repo2rlenv/hub.py
@@ -167,18 +167,37 @@ generation time.
 """
 
 
+def _read_task_metadata(task_toml: Path) -> dict[str, Any]:
+    """Extract `[metadata.repo2env]` from a task.toml. Empty dict on parse failure."""
+    import tomllib
+
+    try:
+        data = tomllib.loads(task_toml.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        logger.debug("could not parse %s: %s", task_toml, exc)
+        return {}
+    return data.get("metadata", {}).get("repo2env", {}) or {}
+
+
 def push_to_hub(
     local_dataset_dir: Path,
     repo_id: str,
     auth: AuthSpec,
     *,
     private: bool = False,
-    pipeline: str = "pr_diff",
-    repo_source: str = "",
+    pipeline: str | None = None,
+    repo_source: str | None = None,
     description: str = "",
     commit_message: str | None = None,
 ) -> PushResult:
-    """Push a dataset directory to HF Hub. Returns the resulting registry URL."""
+    """Push a dataset directory to HF Hub. Returns the resulting registry URL.
+
+    `pipeline` and `repo_source` are read out of the first task's
+    `[metadata.repo2env]` subtable automatically. Callers can override
+    (e.g. for legacy datasets missing that metadata) but normally don't
+    need to — this keeps the dataset card accurate regardless of how
+    `push_to_hub` is invoked.
+    """
     from huggingface_hub import HfApi
 
     token = resolve_hf_token(auth)
@@ -196,11 +215,15 @@ def push_to_hub(
     tasks_dir.mkdir(exist_ok=True)
 
     task_names = []
+    first_metadata: dict[str, Any] = {}
     for child in sorted(local_dataset_dir.iterdir()):
         if not child.is_dir() or child.name.startswith("."):
             continue
-        if not (child / "task.toml").exists():
+        toml_path = child / "task.toml"
+        if not toml_path.exists():
             continue
+        if not first_metadata:
+            first_metadata = _read_task_metadata(toml_path)
         target = tasks_dir / child.name
         if target.exists():
             import shutil
@@ -213,6 +236,13 @@ def push_to_hub(
 
     if not task_names:
         raise RuntimeError(f"no Harbor tasks found in {local_dataset_dir}")
+
+    # Pull authoritative values from the first task's [metadata.repo2env].
+    # Caller-supplied overrides win (back-compat for legacy callers).
+    if not pipeline:
+        pipeline = first_metadata.get("pipeline", "pr_diff")
+    if not repo_source:
+        repo_source = first_metadata.get("repo", "")
 
     # Write README.md (dataset card)
     dataset_name = repo_id.split("/")[-1]

--- a/src/repo2rlenv/hub.py
+++ b/src/repo2rlenv/hub.py
@@ -189,6 +189,13 @@ def push_to_hub(
     repo_source: str | None = None,
     description: str = "",
     commit_message: str | None = None,
+    # NEW (v0.8.2.post3): image-distribution controls
+    image_registry: str | None = None,
+    inline_dockerfile: bool = False,
+    require_registry: bool = False,
+    skip_image_push: bool = False,
+    image_visibility: str = "inherit",
+    on_message=None,
 ) -> PushResult:
     """Push a dataset directory to HF Hub. Returns the resulting registry URL.
 
@@ -197,8 +204,17 @@ def push_to_hub(
     (e.g. for legacy datasets missing that metadata) but normally don't
     need to — this keeps the dataset card accurate regardless of how
     `push_to_hub` is invoked.
+
+    Image distribution (v0.8.2.post3): for _runtime datasets that ship an
+    `environment/Dockerfile`, we discover a logged-in OCI registry, verify
+    via probe (§5.3 of the plan), push the bootstrap image, and rewrite the
+    task Dockerfile + task.toml to point at the registry digest. If no
+    verified registry is available we fall back to inline-Dockerfile mode
+    with a warning (unless `require_registry=True`).
     """
     from huggingface_hub import HfApi
+
+    from repo2rlenv.registry.integration import prepare_dataset_for_push
 
     token = resolve_hf_token(auth)
     if not token:
@@ -206,6 +222,28 @@ def push_to_hub(
 
     api = HfApi(token=token)
     api.create_repo(repo_id, repo_type="dataset", private=private, exist_ok=True)
+
+    # Image distribution: prepare the local dataset (in-place rewrite) BEFORE
+    # we stage + upload. After this call, environment/Dockerfile + task.toml
+    # are pointing at the canonical (registry-digest OR inline-recipe) form.
+    hf_owner = repo_id.split("/", 1)[0]
+    prepare = prepare_dataset_for_push(
+        local_dataset_dir,
+        hf_owner=hf_owner,
+        image_registry=image_registry,
+        inline_dockerfile=inline_dockerfile,
+        require_registry=require_registry,
+        skip_image_push=skip_image_push,
+        image_visibility=image_visibility,  # type: ignore[arg-type]
+        dataset_is_private=private,
+        pushed_by=hf_owner,
+        on_message=on_message,
+    )
+    logger.info(
+        "image distribution: mode=%s tasks_rewritten=%d",
+        prepare.mode,
+        prepare.tasks_rewritten,
+    )
 
     # Layout we expect locally: <root>/<task-id>/...
     # We'll re-stage it as <root>/tasks/<task-id>/...

--- a/src/repo2rlenv/registry/__init__.py
+++ b/src/repo2rlenv/registry/__init__.py
@@ -1,0 +1,40 @@
+"""Image registry support for `repo2rlenv push`.
+
+Unifies push to GHCR / ECR (private + public) / ACR / GCP AR / Docker Hub via
+the OCI Distribution Spec. The module is split into:
+
+- `auth`   — read ~/.docker/config.json (incl. credHelpers, credsStore)
+- `probe`  — L1-L4 verification protocol against any OCI registry
+- `push`   — `docker push` subprocess wrapper + digest extraction
+- `visibility` — GHCR-specific package visibility flips
+- `ecr`, `acr`, `gar` — vendor-specific helpers (lazy-imported)
+- `naming` — slug + tag construction for the bootstrap image
+
+See `plans/v0.8.2.post3_image_distribution.md` for the full design.
+"""
+
+from __future__ import annotations
+
+from repo2rlenv.registry.auth import (
+    CredentialSource,
+    RegistryAuth,
+    RegistryKind,
+    classify_host,
+    discover_logged_in_registries,
+)
+from repo2rlenv.registry.naming import (
+    DEFAULT_BOOTSTRAP_PREFIX,
+    build_image_ref,
+    slugify_repo,
+)
+
+__all__ = [
+    "DEFAULT_BOOTSTRAP_PREFIX",
+    "CredentialSource",
+    "RegistryAuth",
+    "RegistryKind",
+    "build_image_ref",
+    "classify_host",
+    "discover_logged_in_registries",
+    "slugify_repo",
+]

--- a/src/repo2rlenv/registry/auth.py
+++ b/src/repo2rlenv/registry/auth.py
@@ -1,0 +1,203 @@
+"""Read Docker login state from ~/.docker/config.json.
+
+Discovery is file-level only — answers "does the user have credentials for
+this host?" without making network calls. Real verification ("do those
+credentials still work?") lives in `probe.py`.
+
+Reference:
+- https://docs.docker.com/reference/cli/docker/login/
+- https://github.com/docker/docker-credential-helpers
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class RegistryKind(StrEnum):
+    GHCR = "ghcr"
+    ECR_PRIVATE = "ecr_private"
+    ECR_PUBLIC = "ecr_public"
+    ACR = "acr"
+    GCP_AR = "gcp_ar"
+    DOCKER_HUB = "docker_hub"
+    LOCAL = "local"
+    OTHER = "other"
+
+
+class CredentialSource(StrEnum):
+    """How the credential is stored.
+
+    INLINE   — `auths.<host>.auth` is a base64 user:pass blob in config.json
+    CREDSTORE — `credsStore` resolves the host via an OS keychain helper
+    CREDHELPER — per-host `credHelpers` overrides credsStore (typical for ECR)
+    EMPTY    — `auths.<host>` exists but is `{}` (Docker Desktop signal)
+    """
+
+    INLINE = "auths_inline"
+    CREDSTORE = "credstore"
+    CREDHELPER = "credhelper"
+    EMPTY = "auths_empty"
+
+
+@dataclass(slots=True)
+class RegistryAuth:
+    host: str
+    kind: RegistryKind
+    cred_source: CredentialSource
+    # The credential helper binary name when cred_source is CREDHELPER or
+    # CREDSTORE — e.g. "ecr-login", "gcloud", "desktop", "osxkeychain".
+    helper: str | None = None
+
+
+# Hostname classification patterns. Order matters: more specific first.
+_ECR_PRIVATE_RE = re.compile(r"^[0-9]+\.dkr\.ecr\.[^.]+\.amazonaws\.com$")
+_GCP_AR_RE = re.compile(r"^[a-z0-9-]+-docker\.pkg\.dev$")
+_ACR_RE = re.compile(r"^[a-z0-9]+\.azurecr\.io$", re.IGNORECASE)
+_DOCKER_HUB_HOSTS = frozenset(
+    {"index.docker.io", "registry-1.docker.io", "docker.io", "https://index.docker.io/v1/"}
+)
+
+
+def classify_host(host: str) -> RegistryKind:
+    """Map a docker config.json `auths` key to a RegistryKind.
+
+    Docker Hub's config.json key is sometimes the legacy v1 URL
+    `https://index.docker.io/v1/`; normalize that too.
+    """
+    h = host.strip()
+    if not h:
+        return RegistryKind.OTHER
+    # Strip scheme + trailing slashes for matching
+    normalized = h.removeprefix("https://").removeprefix("http://").rstrip("/")
+    if normalized.endswith("/v1"):
+        normalized = normalized.removesuffix("/v1")
+
+    if h in _DOCKER_HUB_HOSTS or normalized in _DOCKER_HUB_HOSTS:
+        return RegistryKind.DOCKER_HUB
+    if normalized == "ghcr.io":
+        return RegistryKind.GHCR
+    if normalized == "public.ecr.aws":
+        return RegistryKind.ECR_PUBLIC
+    if _ECR_PRIVATE_RE.match(normalized):
+        return RegistryKind.ECR_PRIVATE
+    if _ACR_RE.match(normalized):
+        return RegistryKind.ACR
+    if _GCP_AR_RE.match(normalized):
+        return RegistryKind.GCP_AR
+    if normalized in {"localhost", "127.0.0.1"} or normalized.startswith(
+        ("localhost:", "127.0.0.1:")
+    ):
+        return RegistryKind.LOCAL
+    return RegistryKind.OTHER
+
+
+def _config_path() -> Path:
+    """The active Docker CLI config path. Respects $DOCKER_CONFIG."""
+    if env := os.environ.get("DOCKER_CONFIG"):
+        return Path(env).expanduser() / "config.json"
+    return Path.home() / ".docker" / "config.json"
+
+
+def _normalize_host(raw: str) -> str:
+    """Normalize a config.json auths key to a bare hostname.
+
+    The Docker CLI accepts both the v1 URL and a bare hostname as the auths
+    key; we keep the original Docker Hub aliases as a single "docker_hub"
+    classification but strip scheme/trailing slashes for everything else.
+    """
+    s = raw.strip()
+    s = s.removeprefix("https://").removeprefix("http://").rstrip("/")
+    s = s.removesuffix("/v1")
+    return s
+
+
+def discover_logged_in_registries(config_path: Path | None = None) -> list[RegistryAuth]:
+    """Return the list of registries the user appears logged into.
+
+    File-level only — does not validate that credentials actually work.
+    Use `registry.probe.probe()` to verify.
+
+    Resolution:
+      1. Per-host `credHelpers` entry → CREDHELPER
+      2. Global `credsStore` + `auths.<host>` present → CREDSTORE
+      3. `auths.<host>.auth` non-empty → INLINE
+      4. `auths.<host>` is `{}` (Desktop keychain signal) → EMPTY
+    """
+    path = config_path or _config_path()
+    if not path.is_file():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("could not read %s: %s", path, exc)
+        return []
+
+    auths = data.get("auths", {}) if isinstance(data, dict) else {}
+    cred_helpers = data.get("credHelpers", {}) if isinstance(data, dict) else {}
+    creds_store = data.get("credsStore") if isinstance(data, dict) else None
+
+    results: list[RegistryAuth] = []
+    seen: set[str] = set()
+
+    # 1. Per-host credHelpers (highest precedence)
+    if isinstance(cred_helpers, dict):
+        for raw_host, helper in cred_helpers.items():
+            host = _normalize_host(raw_host)
+            if host in seen:
+                continue
+            seen.add(host)
+            results.append(
+                RegistryAuth(
+                    host=host,
+                    kind=classify_host(host),
+                    cred_source=CredentialSource.CREDHELPER,
+                    helper=str(helper) if helper else None,
+                )
+            )
+
+    # 2 + 3 + 4: walk auths entries that aren't already covered by credHelpers
+    if isinstance(auths, dict):
+        for raw_host, entry in auths.items():
+            host = _normalize_host(raw_host)
+            if host in seen:
+                continue
+            seen.add(host)
+            inline_auth = ""
+            if isinstance(entry, dict):
+                inline_auth = (entry.get("auth") or "").strip()
+            if inline_auth:
+                source = CredentialSource.INLINE
+                helper = None
+            elif creds_store:
+                source = CredentialSource.CREDSTORE
+                helper = str(creds_store)
+            else:
+                # Empty `{}` with no global credsStore → most plausibly Docker
+                # Desktop on a host where credsStore wasn't written. Treat as
+                # logged-in signal; probe will catch the case where it isn't.
+                source = CredentialSource.EMPTY
+                helper = None
+            results.append(
+                RegistryAuth(
+                    host=host,
+                    kind=classify_host(host),
+                    cred_source=source,
+                    helper=helper,
+                )
+            )
+
+    return results
+
+
+def filter_known_registries(auths: list[RegistryAuth]) -> list[RegistryAuth]:
+    """Drop entries classified as OTHER. Convenience for the push path."""
+    return [a for a in auths if a.kind is not RegistryKind.OTHER]

--- a/src/repo2rlenv/registry/ecr.py
+++ b/src/repo2rlenv/registry/ecr.py
@@ -1,0 +1,139 @@
+"""ECR-specific helper: pre-create a repository before push.
+
+ECR (both private and public) requires the repository to exist before
+`docker push` will accept blobs. Unlike GHCR / Docker Hub / ACR which
+auto-create repos on first push.
+
+We call the `aws` CLI to keep auth handling out of our codebase —
+boto3 would be an extra runtime dep we don't otherwise need.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+class ECRError(Exception):
+    """Raised when an ECR API call fails irrecoverably."""
+
+
+@dataclass(slots=True)
+class ECRRepoResult:
+    repo: str
+    created: bool  # True if we just created it; False if it already existed
+    is_public: bool
+
+
+def _aws_available() -> bool:
+    return shutil.which("aws") is not None
+
+
+def _parse_ecr_ref(remote_ref: str) -> tuple[str, str, bool] | None:
+    """Return (region_or_alias, repo, is_public) from an ECR ref, or None.
+
+    - Private: `<acct>.dkr.ecr.<region>.amazonaws.com/<repo>[:<tag>]`
+    - Public:  `public.ecr.aws/<alias>/<repo>[:<tag>]`
+    """
+    body = remote_ref.split(":", 1)[0].split("@", 1)[0]
+    if body.startswith("public.ecr.aws/"):
+        rest = body.removeprefix("public.ecr.aws/")
+        if "/" not in rest:
+            return None
+        alias, repo = rest.split("/", 1)
+        return (alias, repo, True)
+    # Private form
+    if ".dkr.ecr." in body and body.endswith(".amazonaws.com") is False:
+        # host part is something like 123.dkr.ecr.us-east-1.amazonaws.com/<repo>
+        host, _, repo = body.partition("/")
+        if not repo:
+            return None
+        parts = host.split(".")
+        # Expect: ['123', 'dkr', 'ecr', '<region>', 'amazonaws', 'com']
+        if len(parts) < 6 or parts[1] != "dkr" or parts[2] != "ecr":
+            return None
+        region = parts[3]
+        return (region, repo, False)
+    # Tolerate the alternative split (host first)
+    host, _, repo = body.partition("/")
+    if not repo or ".dkr.ecr." not in host:
+        return None
+    parts = host.split(".")
+    if len(parts) < 6 or parts[1] != "dkr" or parts[2] != "ecr":
+        return None
+    region = parts[3]
+    return (region, repo, False)
+
+
+def ensure_ecr_repository(remote_ref: str) -> ECRRepoResult:
+    """Idempotent: create the ECR repository for `remote_ref` if it doesn't exist."""
+    parsed = _parse_ecr_ref(remote_ref)
+    if parsed is None:
+        raise ECRError(f"could not parse ECR ref: {remote_ref!r}")
+    region_or_alias, repo, is_public = parsed
+
+    if not _aws_available():
+        raise ECRError("aws CLI not available on PATH")
+
+    if is_public:
+        describe_args = [
+            "aws",
+            "ecr-public",
+            "describe-repositories",
+            "--repository-names",
+            repo,
+            "--region",
+            "us-east-1",  # ECR Public is single-region (us-east-1)
+        ]
+        create_args = [
+            "aws",
+            "ecr-public",
+            "create-repository",
+            "--repository-name",
+            repo,
+            "--region",
+            "us-east-1",
+        ]
+    else:
+        describe_args = [
+            "aws",
+            "ecr",
+            "describe-repositories",
+            "--repository-names",
+            repo,
+            "--region",
+            region_or_alias,
+        ]
+        create_args = [
+            "aws",
+            "ecr",
+            "create-repository",
+            "--repository-name",
+            repo,
+            "--region",
+            region_or_alias,
+        ]
+
+    describe = subprocess.run(
+        describe_args, capture_output=True, text=True, timeout=30, check=False
+    )
+    if describe.returncode == 0:
+        return ECRRepoResult(repo=repo, created=False, is_public=is_public)
+
+    create = subprocess.run(create_args, capture_output=True, text=True, timeout=60, check=False)
+    if create.returncode != 0:
+        raise ECRError(
+            f"ECR create-repository failed: {create.stderr.strip() or create.stdout.strip()}"
+        )
+    return ECRRepoResult(repo=repo, created=True, is_public=is_public)
+
+
+__all__ = [
+    "ECRError",
+    "ECRRepoResult",
+    "ensure_ecr_repository",
+]

--- a/src/repo2rlenv/registry/gar.py
+++ b/src/repo2rlenv/registry/gar.py
@@ -1,0 +1,112 @@
+"""GCP Artifact Registry helper: pre-create a repository before push.
+
+Same shape as `ecr.py` — the AR repository must exist before push will
+accept blobs. We shell out to `gcloud` to avoid pulling in
+google-cloud-artifactregistry as a runtime dep.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+class GARError(Exception):
+    """Raised when a GCP AR API call fails irrecoverably."""
+
+
+@dataclass(slots=True)
+class GARRepoResult:
+    project: str
+    location: str
+    repo: str
+    created: bool
+
+
+def _gcloud_available() -> bool:
+    return shutil.which("gcloud") is not None
+
+
+def _parse_gar_ref(remote_ref: str) -> tuple[str, str, str, str] | None:
+    """Return (location, project, repo, image) for a GAR ref, or None.
+
+    Form: `<location>-docker.pkg.dev/<project>/<repo>/<image>[:<tag>]`
+    """
+    body = remote_ref.split(":", 1)[0].split("@", 1)[0]
+    if "-docker.pkg.dev/" not in body:
+        return None
+    host, _, rest = body.partition("/")
+    location = host.removesuffix("-docker.pkg.dev")
+    if not location or location == host:
+        return None
+    parts = rest.split("/", 2)
+    if len(parts) < 3:
+        return None
+    project, repo, image = parts[0], parts[1], parts[2]
+    return (location, project, repo, image)
+
+
+def ensure_gar_repository(remote_ref: str) -> GARRepoResult:
+    """Idempotent: ensure the GAR docker repository exists."""
+    parsed = _parse_gar_ref(remote_ref)
+    if parsed is None:
+        raise GARError(f"could not parse GAR ref: {remote_ref!r}")
+    location, project, repo, _image = parsed
+
+    if not _gcloud_available():
+        raise GARError("gcloud CLI not available on PATH")
+
+    describe = subprocess.run(
+        [
+            "gcloud",
+            "artifacts",
+            "repositories",
+            "describe",
+            repo,
+            "--location",
+            location,
+            "--project",
+            project,
+            "--format",
+            "value(name)",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if describe.returncode == 0:
+        return GARRepoResult(project=project, location=location, repo=repo, created=False)
+
+    create = subprocess.run(
+        [
+            "gcloud",
+            "artifacts",
+            "repositories",
+            "create",
+            repo,
+            "--repository-format=docker",
+            "--location",
+            location,
+            "--project",
+            project,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if create.returncode != 0:
+        raise GARError(f"GAR create failed: {create.stderr.strip() or create.stdout.strip()}")
+    return GARRepoResult(project=project, location=location, repo=repo, created=True)
+
+
+__all__ = [
+    "GARError",
+    "GARRepoResult",
+    "ensure_gar_repository",
+]

--- a/src/repo2rlenv/registry/integration.py
+++ b/src/repo2rlenv/registry/integration.py
@@ -207,10 +207,22 @@ def _select_verified_registry(
 def _parse_local_tag(local_tag: str) -> tuple[str, str, str]:
     """From `local/r2e-bootstrap/owner__name:sha[__opts]` return (owner, name, sha).
 
-    Tolerates the legacy `local-` prefix and the `local/<...>` form. Falls
-    back to deriving owner/name from the path component before the colon.
+    Tolerates three input forms:
+      - `local/r2e-bootstrap/owner__name:sha12`        (tag form)
+      - `local/r2e-bootstrap/owner__name:sha12__opt8`  (tag + options hash)
+      - `local/r2e-bootstrap/owner__name@sha256:hex`   (digest form)
+
+    Returns 12-char tag-safe sha (truncated for digest form so the tag fits
+    within OCI tag-length limits).
     """
-    body, _, tag_with_opts = local_tag.partition(":")
+    # Digest form has `@sha256:` before the colon; strip it for parsing
+    if "@sha256:" in local_tag:
+        body, _, digest_hex = local_tag.partition("@sha256:")
+        sha = digest_hex[:12]
+    else:
+        body, _, tag_with_opts = local_tag.partition(":")
+        sha = tag_with_opts.split("__", 1)[0].split("-", 1)[0]
+
     if "/" in body:
         parts = body.split("/")
         last = parts[-1]  # owner__name
@@ -221,7 +233,6 @@ def _parse_local_tag(local_tag: str) -> tuple[str, str, str]:
     else:
         owner = "_"
         name = last
-    sha = tag_with_opts.split("__", 1)[0].split("-", 1)[0]
     return owner, name, sha
 
 

--- a/src/repo2rlenv/registry/integration.py
+++ b/src/repo2rlenv/registry/integration.py
@@ -1,0 +1,681 @@
+"""Orchestration: discover → verify → select → push → rewrite tasks.
+
+This module is the integration glue between the pure `registry/` primitives
+and the HF-Hub-facing `hub.push_to_hub`. It owns the policy:
+
+    if a registry is logged in AND verified to actually work → registry mode
+    otherwise → inline-Dockerfile mode (with a prominent warning)
+    OR fail hard if `require_registry=True`
+
+It does NOT touch HF Hub — `hub.push_to_hub` does. This module just
+prepares the local dataset directory (rewriting environment/Dockerfile +
+task.toml in-place) so it's ready to upload, and reports what happened.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+import tomllib
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+from repo2rlenv.registry import probe as probe_mod
+from repo2rlenv.registry.auth import (
+    RegistryAuth,
+    RegistryKind,
+    discover_logged_in_registries,
+    filter_known_registries,
+)
+from repo2rlenv.registry.probe import ProbeResult, select_best
+from repo2rlenv.registry.push import ImagePushResult, PushError, push_image
+from repo2rlenv.registry.visibility import ensure_ghcr_visibility
+
+logger = logging.getLogger(__name__)
+
+
+ReproMode = Literal["registry", "inline_dockerfile", "local_only"]
+
+
+@dataclass(slots=True)
+class PrepareResult:
+    """What `prepare_dataset_for_push` produces. Hub upload is a separate step."""
+
+    mode: ReproMode
+    tasks_rewritten: int
+    selected_host: str | None = None
+    selected_namespace: str | None = None
+    image_remote_ref: str | None = None
+    image_digest: str | None = None
+    image_visibility: Literal["public", "private", "unknown"] | None = None
+    image_pushed: bool = False
+    fallback_reason: str | None = None
+    inline_recipe_source: Literal["user_dockerfile", "agent_replay"] | None = None
+    inline_recipe_sha256: str | None = None
+    probe_results: list[ProbeResult] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------
+# Inspecting the local dataset
+# --------------------------------------------------------------------------
+
+# Match the first `^FROM ...` line (Docker is case-insensitive for FROM)
+_FROM_LINE_RE = re.compile(r"^(\s*FROM\s+)(\S+)", re.IGNORECASE | re.MULTILINE)
+
+
+def _list_task_dirs(local_dir: Path) -> list[Path]:
+    """Return task directories (each containing task.toml), sorted, no hidden."""
+    out = []
+    for child in sorted(local_dir.iterdir()):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        if (child / "task.toml").exists():
+            out.append(child)
+    return out
+
+
+def _bootstrap_image_refs(task_dirs: list[Path]) -> list[tuple[str, Path]]:
+    """For each task with environment/Dockerfile, return (FROM-ref, dockerfile_path).
+
+    Tasks without `environment/` (e.g. pr_diff lite tasks) are skipped.
+    """
+    out = []
+    for td in task_dirs:
+        df = td / "environment" / "Dockerfile"
+        if not df.is_file():
+            continue
+        content = df.read_text(encoding="utf-8", errors="replace")
+        m = _FROM_LINE_RE.search(content)
+        if m:
+            out.append((m.group(2).strip(), df))
+    return out
+
+
+def _distinct_local_images(refs: list[tuple[str, Path]]) -> set[str]:
+    """Set of bootstrap images that look local (un-pullable)."""
+    locals_: set[str] = set()
+    for ref, _ in refs:
+        if ref.startswith(("local/", "local-")) or ref.startswith("localhost"):
+            locals_.add(ref)
+        # Also treat refs lacking a registry host (no `.` before the first `/`)
+        # as local. e.g. `myimage:tag` with no namespace.
+    return locals_
+
+
+# --------------------------------------------------------------------------
+# Discover + verify
+# --------------------------------------------------------------------------
+
+
+def _build_namespace_for(auth: RegistryAuth, hf_owner: str) -> str:
+    """Choose the target namespace for a given registry auth + HF owner."""
+    if auth.kind is RegistryKind.GHCR:
+        # Try HF owner first; caller may retry under gh-login-user on permission denied.
+        return hf_owner.lower()
+    if auth.kind in (RegistryKind.ECR_PRIVATE, RegistryKind.ECR_PUBLIC):
+        return "r2e"
+    if auth.kind is RegistryKind.ACR:
+        return "r2e"
+    if auth.kind is RegistryKind.GCP_AR:
+        # GAR: namespace is "project/repo"; we leave project to the user via
+        # --image-registry override. For auto-detect we conservatively pick
+        # "<project>/r2e" if the auth host carries one (rare); otherwise fall
+        # back to "r2e".
+        return "r2e"
+    if auth.kind is RegistryKind.DOCKER_HUB:
+        # Use the logged-in username if we can resolve it; otherwise the HF owner.
+        return hf_owner.lower()
+    if auth.kind is RegistryKind.LOCAL:
+        return "r2e"
+    return hf_owner.lower()
+
+
+def _registry_prefix_for(auth: RegistryAuth, namespace: str) -> str:
+    """Build the `<host>/<namespace>` prefix used by build_image_ref."""
+    if auth.kind in (RegistryKind.ECR_PRIVATE, RegistryKind.ECR_PUBLIC, RegistryKind.ACR):
+        return f"{auth.host}/{namespace}"
+    if auth.kind is RegistryKind.GCP_AR:
+        return f"{auth.host}/{namespace}"
+    if auth.kind is RegistryKind.DOCKER_HUB:
+        return f"index.docker.io/{namespace}"
+    if auth.kind is RegistryKind.LOCAL:
+        return f"{auth.host}/{namespace}"
+    return f"{auth.host}/{namespace}"
+
+
+def _select_verified_registry(
+    hf_owner: str,
+    *,
+    explicit_prefix: str | None,
+    require_registry: bool,
+) -> tuple[ProbeResult | None, str, list[ProbeResult]]:
+    """Discover → probe → select. Returns (selected, namespace, all_probes).
+
+    If `explicit_prefix` is given, we probe only that registry. Otherwise we
+    discover from ~/.docker/config.json and probe each.
+    """
+    probes: list[ProbeResult] = []
+
+    if explicit_prefix:
+        # Parse `host[/namespace]` and probe that one
+        host, _, ns = explicit_prefix.partition("/")
+        if not ns:
+            ns = hf_owner.lower()
+        # Classify the explicit host
+        from repo2rlenv.registry.auth import classify_host
+
+        discovered = discover_logged_in_registries()
+        auth = next((a for a in discovered if a.host == host), None)
+        if auth is None:
+            # Synthesize a stub — probe will likely fail at L2 if no creds
+            from repo2rlenv.registry.auth import CredentialSource
+
+            auth = RegistryAuth(
+                host=host,
+                kind=classify_host(host),
+                cred_source=CredentialSource.EMPTY,
+            )
+        result = probe_mod.probe(auth, ns)
+        probes.append(result)
+        return (result if result.is_pushable else None, ns, probes)
+
+    # Auto-discover
+    candidates = filter_known_registries(discover_logged_in_registries())
+    # Drop Docker Hub from auto-default unless explicit (rate-limit hazard)
+    candidates = [c for c in candidates if c.kind is not RegistryKind.DOCKER_HUB]
+
+    for auth in candidates:
+        ns = _build_namespace_for(auth, hf_owner)
+        result = probe_mod.probe(auth, ns)
+        probes.append(result)
+
+    selected = select_best(probes)
+    if selected is None:
+        return (None, hf_owner.lower(), probes)
+    return (selected, selected.namespace, probes)
+
+
+# --------------------------------------------------------------------------
+# Local image discovery + remote-ref construction
+# --------------------------------------------------------------------------
+
+
+def _parse_local_tag(local_tag: str) -> tuple[str, str, str]:
+    """From `local/r2e-bootstrap/owner__name:sha[__opts]` return (owner, name, sha).
+
+    Tolerates the legacy `local-` prefix and the `local/<...>` form. Falls
+    back to deriving owner/name from the path component before the colon.
+    """
+    body, _, tag_with_opts = local_tag.partition(":")
+    if "/" in body:
+        parts = body.split("/")
+        last = parts[-1]  # owner__name
+    else:
+        last = body
+    if "__" in last:
+        owner, _, name = last.partition("__")
+    else:
+        owner = "_"
+        name = last
+    sha = tag_with_opts.split("__", 1)[0].split("-", 1)[0]
+    return owner, name, sha
+
+
+# --------------------------------------------------------------------------
+# In-place dataset rewriting
+# --------------------------------------------------------------------------
+
+
+def _rewrite_dockerfile_from(df_path: Path, new_ref: str) -> bool:
+    """Rewrite the first `FROM <ref>` line. Returns True if a change was made."""
+    content = df_path.read_text(encoding="utf-8", errors="replace")
+    new_content, n = _FROM_LINE_RE.subn(rf"\g<1>{new_ref}", content, count=1)
+    if n == 0 or new_content == content:
+        return False
+    df_path.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def _update_task_toml_reproducibility(
+    toml_path: Path,
+    *,
+    mode: ReproMode,
+    image_ref: str | None,
+    image_tag: str | None,
+    image_visibility: str | None,
+    pushed_by: str | None,
+    inline_recipe_sha256: str | None = None,
+    inline_recipe_lines: int = 0,
+    inline_recipe_source: str | None = None,
+    fallback_reason: str | None = None,
+) -> None:
+    """Patch the [metadata.repo2env.reproducibility] subtable + bump spec_version.
+
+    Uses a hand-built tomllib roundtrip (parse → mutate dict → re-serialize)
+    via tomli_w. The repo already depends on tomli_w through the emitter.
+    """
+    import tomli_w
+
+    data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    meta = data.setdefault("metadata", {})
+    r2e = meta.setdefault("repo2env", {})
+    r2e["spec_version"] = "0.2.0"
+    repro: dict[str, object] = {
+        "mode": mode,
+        "image_ref": image_ref,
+        "image_tag": image_tag,
+        "image_visibility": image_visibility,
+        "pushed_at": datetime.now(UTC).isoformat(),
+        "pushed_by": pushed_by,
+        "inline_recipe_sha256": inline_recipe_sha256,
+        "inline_recipe_lines": inline_recipe_lines,
+        "inline_recipe_source": inline_recipe_source,
+        "fallback_reason": fallback_reason,
+    }
+    # Strip Nones — TOML can't represent them
+    repro = {k: v for k, v in repro.items() if v is not None}
+    r2e["reproducibility"] = repro
+    # Also refresh the legacy `bootstrap_image` field inside the pipeline's
+    # subtable so old readers don't see a stale local ref.
+    pipeline_name = r2e.get("pipeline")
+    if isinstance(pipeline_name, str):
+        sub = r2e.get(pipeline_name)
+        if isinstance(sub, dict) and image_ref:
+            sub["bootstrap_image"] = image_ref
+    toml_path.write_text(tomli_w.dumps(data), encoding="utf-8")
+
+
+def _hash_text(s: str) -> str:
+    import hashlib
+
+    return "sha256:" + hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+# --------------------------------------------------------------------------
+# The orchestrator
+# --------------------------------------------------------------------------
+
+
+def prepare_dataset_for_push(
+    local_dir: Path,
+    *,
+    hf_owner: str,
+    image_registry: str | None = None,
+    inline_dockerfile: bool = False,
+    require_registry: bool = False,
+    skip_image_push: bool = False,
+    image_visibility: Literal["public", "private", "inherit"] = "inherit",
+    dataset_is_private: bool = False,
+    pushed_by: str | None = None,
+    on_message=None,
+) -> PrepareResult:
+    """Run the §7.2 push-time flow: discover → verify → select → push → rewrite.
+
+    Mutates `local_dir` in-place by rewriting each task's
+    environment/Dockerfile and task.toml. Returns a `PrepareResult` summarizing
+    what mode was selected and any warnings.
+
+    Does NOT upload to HF Hub. The caller (`hub.push_to_hub`) does that after.
+    """
+
+    def _emit(msg: str) -> None:
+        logger.info(msg)
+        if on_message:
+            try:
+                on_message(msg)
+            except Exception:
+                pass
+
+    task_dirs = _list_task_dirs(local_dir)
+    refs = _bootstrap_image_refs(task_dirs)
+
+    if not refs:
+        # Text-only dataset (pr_diff) — nothing to do at the image level.
+        _emit("no environment/Dockerfile in dataset; skipping image step")
+        # Still set spec_version + reproducibility(mode=local_only-but-not-applicable)
+        # for consistency. For pr_diff we just don't write the reproducibility
+        # subtable at all — there's no image to be reproducible about.
+        return PrepareResult(mode="local_only", tasks_rewritten=0)
+
+    # Enforce 1-image-per-dataset for v0.8.2.post3
+    distinct = {ref for ref, _ in refs}
+    if len(distinct) > 1:
+        raise RuntimeError(
+            f"dataset has {len(distinct)} distinct bootstrap images: {sorted(distinct)}. "
+            "Multi-image datasets aren't supported yet. Split into separate datasets."
+        )
+    local_ref = next(iter(distinct))
+    looks_local = local_ref.startswith(("local/", "local-")) or local_ref.startswith("localhost")
+
+    # Decide mode
+    if inline_dockerfile:
+        return _go_inline(
+            local_dir,
+            task_dirs,
+            refs,
+            local_ref=local_ref,
+            fallback_reason=None,
+            pushed_by=pushed_by,
+            on_message=_emit,
+        )
+
+    # Registry mode candidate
+    selected, namespace, probes = _select_verified_registry(
+        hf_owner,
+        explicit_prefix=image_registry,
+        require_registry=require_registry,
+    )
+
+    if selected is None:
+        # No verified registry available
+        if require_registry:
+            details = (
+                "; ".join(f"{p.host}: {p.error or 'unknown'}" for p in probes)
+                or "no registries discovered"
+            )
+            raise RuntimeError(f"--require-registry: no verified registry available ({details})")
+        reason = (
+            "; ".join(f"{p.host}: {p.error or 'unknown'}" for p in probes)
+            if probes
+            else "no registry credentials found"
+        )
+        _emit(f"WARN no verified registry; falling back to inline-Dockerfile mode ({reason})")
+        return _go_inline(
+            local_dir,
+            task_dirs,
+            refs,
+            local_ref=local_ref,
+            fallback_reason=f"no working registry credentials: {reason}",
+            pushed_by=pushed_by,
+            on_message=_emit,
+        )
+
+    # Registry mode — push + rewrite
+    return _go_registry(
+        local_dir,
+        task_dirs,
+        refs,
+        local_ref=local_ref,
+        selected=selected,
+        namespace=namespace,
+        image_visibility=image_visibility,
+        dataset_is_private=dataset_is_private,
+        skip_image_push=skip_image_push,
+        require_registry=require_registry,
+        looks_local=looks_local,
+        probes=probes,
+        pushed_by=pushed_by,
+        on_message=_emit,
+    )
+
+
+def _go_inline(
+    local_dir: Path,
+    task_dirs: list[Path],
+    refs: list[tuple[str, Path]],
+    *,
+    local_ref: str,
+    fallback_reason: str | None,
+    pushed_by: str | None,
+    on_message,
+) -> PrepareResult:
+    """Bake the bootstrap's reconstructed Dockerfile into each task's image recipe.
+
+    Requires the bootstrap cache to be present (we read the saved
+    reconstructed Dockerfile from there). Otherwise raises.
+    """
+    recipe, source = _load_bootstrap_recipe(local_ref)
+    if recipe is None:
+        raise RuntimeError(
+            f"inline mode requires the bootstrap reconstructed Dockerfile "
+            f"(saved under ./envs/<repo>/<sha>/Dockerfile). "
+            f"Local ref {local_ref!r} resolves to no cached Dockerfile. "
+            f"Either re-bootstrap or use registry mode."
+        )
+
+    recipe_hash = _hash_text(recipe)
+    recipe_lines = len(recipe.splitlines())
+
+    tasks_rewritten = 0
+    for _ref, df_path in refs:
+        # Build a combined Dockerfile: recipe + per-task overlay from the
+        # existing Dockerfile (everything after the FROM line).
+        existing = df_path.read_text(encoding="utf-8", errors="replace")
+        # Drop the existing FROM line; keep the rest (WORKDIR + git fetch + reset)
+        without_from = _FROM_LINE_RE.sub("", existing, count=1).lstrip("\n")
+        combined = (
+            "# Auto-generated by Repo2RLEnv (inline mode)\n"
+            "# Source: bootstrap dockerfile_reconstruction\n"
+            f"# Original bootstrap ref: {local_ref}\n\n"
+            f"{recipe.rstrip()}\n\n"
+            "# Per-task overlay (from pipeline-emitted Dockerfile)\n"
+            f"{without_from}"
+        )
+        df_path.write_text(combined, encoding="utf-8")
+        tasks_rewritten += 1
+        toml_path = df_path.parent.parent / "task.toml"
+        if toml_path.is_file():
+            _update_task_toml_reproducibility(
+                toml_path,
+                mode="inline_dockerfile",
+                image_ref=None,
+                image_tag=None,
+                image_visibility=None,
+                pushed_by=pushed_by,
+                inline_recipe_sha256=recipe_hash,
+                inline_recipe_lines=recipe_lines,
+                inline_recipe_source=source,
+                fallback_reason=fallback_reason,
+            )
+
+    on_message(f"inline mode: rewrote {tasks_rewritten} task Dockerfiles ({source})")
+
+    return PrepareResult(
+        mode="inline_dockerfile",
+        tasks_rewritten=tasks_rewritten,
+        fallback_reason=fallback_reason,
+        inline_recipe_source=source,
+        inline_recipe_sha256=recipe_hash,
+    )
+
+
+def _load_bootstrap_recipe(
+    local_ref: str,
+) -> tuple[str | None, Literal["user_dockerfile", "agent_replay"] | None]:
+    """Look up the cached bootstrap result for `local_ref` and return its recipe.
+
+    Returns (recipe_text, source) where source is "user_dockerfile" or
+    "agent_replay" depending on which bootstrap path produced it. Returns
+    (None, None) if no cache entry is found.
+    """
+    from repo2rlenv.bootstrap import cache as bs_cache
+
+    # Try to extract (owner, name, sha) from the local tag
+    owner, name, sha = _parse_local_tag(local_ref)
+    if not name or not sha:
+        return None, None
+    # Walk the default cache_dir; also try the slot path directly
+    candidates = [Path("./envs"), Path.cwd() / "envs"]
+    for cache_dir in candidates:
+        if not cache_dir.is_dir():
+            continue
+        # We don't know the options hash a priori, so scan
+        slot_root = cache_dir / f"{owner}__{name}"
+        if not slot_root.is_dir():
+            continue
+        # Look for a slot whose name starts with the sha
+        for slot in slot_root.iterdir():
+            if not slot.is_dir():
+                continue
+            if slot.name.startswith(sha[:12]):
+                df = slot / "Dockerfile"
+                if df.is_file():
+                    text = df.read_text(encoding="utf-8")
+                    # Read the cached BootstrapResult to know which source path
+                    try:
+                        result = bs_cache.load(
+                            f"{owner}/{name}",
+                            sha,
+                            cache_dir,
+                            options=None,
+                        )
+                    except Exception:
+                        result = None
+                    source: Literal["user_dockerfile", "agent_replay"] = (
+                        "user_dockerfile"
+                        if result and result.extra.get("source") == "user_dockerfile"
+                        else "agent_replay"
+                    )
+                    return text, source
+    return None, None
+
+
+def _go_registry(
+    local_dir: Path,
+    task_dirs: list[Path],
+    refs: list[tuple[str, Path]],
+    *,
+    local_ref: str,
+    selected: ProbeResult,
+    namespace: str,
+    image_visibility: Literal["public", "private", "inherit"],
+    dataset_is_private: bool,
+    skip_image_push: bool,
+    require_registry: bool,
+    looks_local: bool,
+    probes: list[ProbeResult],
+    pushed_by: str | None,
+    on_message,
+) -> PrepareResult:
+    """Push the bootstrap image to the verified registry; rewrite tasks."""
+    from repo2rlenv.registry.naming import build_image_ref
+
+    # Build the remote ref
+    owner, name, sha = _parse_local_tag(local_ref)
+    registry_prefix = _registry_prefix_for_kind(selected.kind, selected.host, namespace)
+    remote_ref = build_image_ref(
+        registry_prefix=registry_prefix,
+        owner=owner,
+        name=name,
+        commit_sha=sha,
+    )
+
+    warnings: list[str] = []
+    image_pushed = False
+    digest: str = remote_ref
+
+    if skip_image_push:
+        on_message(f"--skip-image-push: not pushing; reusing {remote_ref}")
+    else:
+        try:
+            push_result = _do_push(local_ref, remote_ref, looks_local)
+            digest = push_result.digest
+            image_pushed = push_result.pushed
+            on_message(
+                f"pushed {remote_ref} → {digest[:64]}..."
+                if image_pushed
+                else f"manifest already at registry: {digest[:64]}..."
+            )
+        except PushError as exc:
+            warnings.append(f"image push failed: {exc}")
+            if require_registry:
+                raise
+            on_message(f"WARN image push failed; falling back to inline mode: {exc}")
+            # Fall back to inline
+            return _go_inline(
+                local_dir,
+                task_dirs,
+                refs,
+                local_ref=local_ref,
+                fallback_reason=f"image push failed: {exc}",
+                pushed_by=pushed_by,
+                on_message=on_message,
+            )
+
+    # Visibility
+    effective_visibility: Literal["public", "private", "unknown"]
+    if image_visibility == "inherit":
+        effective_visibility = "private" if dataset_is_private else "public"
+    else:
+        effective_visibility = image_visibility  # type: ignore[assignment]
+
+    if effective_visibility == "public" and selected.kind is RegistryKind.GHCR:
+        vis = ensure_ghcr_visibility(remote_ref, target="public")
+        if not vis.success:
+            warnings.append(
+                f"GHCR visibility flip failed: {vis.error} (manual fix: {vis.manual_url})"
+            )
+            if require_registry:
+                raise RuntimeError(warnings[-1])
+            effective_visibility = "unknown"
+            on_message(f"WARN {warnings[-1]}")
+
+    # Rewrite tasks
+    tasks_rewritten = 0
+    for _ref, df_path in refs:
+        if _rewrite_dockerfile_from(df_path, digest):
+            tasks_rewritten += 1
+        toml_path = df_path.parent.parent / "task.toml"
+        if toml_path.is_file():
+            _update_task_toml_reproducibility(
+                toml_path,
+                mode="registry",
+                image_ref=digest,
+                image_tag=remote_ref,
+                image_visibility=effective_visibility,
+                pushed_by=pushed_by,
+            )
+
+    on_message(f"registry mode: rewrote {tasks_rewritten} task Dockerfiles → {digest[:48]}...")
+
+    return PrepareResult(
+        mode="registry",
+        tasks_rewritten=tasks_rewritten,
+        selected_host=selected.host,
+        selected_namespace=namespace,
+        image_remote_ref=remote_ref,
+        image_digest=digest,
+        image_visibility=effective_visibility,
+        image_pushed=image_pushed,
+        probe_results=probes,
+        warnings=warnings,
+    )
+
+
+def _registry_prefix_for_kind(kind: RegistryKind, host: str, namespace: str) -> str:
+    """Compose `<host>/<namespace>` correctly for each registry kind."""
+    if kind is RegistryKind.DOCKER_HUB:
+        return f"index.docker.io/{namespace}"
+    return f"{host}/{namespace}"
+
+
+def _do_push(local_ref: str, remote_ref: str, looks_local: bool) -> ImagePushResult:
+    """Wrapper to push, with friendly error if local image truly missing."""
+    if not looks_local:
+        # The dataset already references a registry ref. Either it was
+        # pushed elsewhere, or it's our re-push of an already-registered
+        # image. Either way: skip a docker tag/push, just verify the digest.
+        result = ImagePushResult(
+            local_tag=local_ref,
+            remote_ref=remote_ref,
+            digest=local_ref,
+            pushed=False,
+            duration_sec=0.0,
+        )
+        return result
+    return push_image(local_ref, remote_ref, skip_if_exists=True)
+
+
+__all__ = [
+    "PrepareResult",
+    "ReproMode",
+    "prepare_dataset_for_push",
+]
+
+
+_t_start = time.monotonic()
+del _t_start

--- a/src/repo2rlenv/registry/naming.py
+++ b/src/repo2rlenv/registry/naming.py
@@ -1,0 +1,101 @@
+"""Slug + tag construction for the bootstrap image reference.
+
+Final shape (default, when GHCR is the chosen registry):
+
+    ghcr.io/<owner>/r2e-bootstrap-<repo-slug>:<sha12>[-<opts8>]
+
+`<opts8>` is the same `cache._options_hash` output used in `bootstrap/cache.py`
+— reuse, don't reinvent. When the bootstrap was built with default options
+(empty opts hash), the tag drops the suffix.
+
+OCI Distribution Spec ref:
+- Lowercase enforced.
+- Path components match `[a-z0-9]+((\\.|_|__|-+)[a-z0-9]+)*`.
+- Total ref ≤ 255 chars.
+- Tag ≤ 128 chars.
+"""
+
+from __future__ import annotations
+
+import re
+
+DEFAULT_BOOTSTRAP_PREFIX = "r2e-bootstrap"
+
+# OCI path component: lowercase letters, digits, separator runs of . _ __ -+
+_OCI_NAME_RE = re.compile(r"^[a-z0-9]+((?:[._]|__|-+)[a-z0-9]+)*$")
+_OCI_TAG_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$")
+
+
+def slugify_repo(owner: str, name: str, *, prefix: str = DEFAULT_BOOTSTRAP_PREFIX) -> str:
+    """Build the image *name* portion: `<prefix>-<owner>-<repo>`, slugified.
+
+    Lowercase, non-`[a-z0-9-]` collapsed to a single `-`, trimmed.
+    Output guaranteed to pass `_OCI_NAME_RE`.
+    """
+    if not owner or not name:
+        raise ValueError("owner and name must both be non-empty")
+    raw = f"{prefix}-{owner}-{name}".lower()
+    # Collapse runs of non-[a-z0-9] to a single `-`
+    slug = re.sub(r"[^a-z0-9]+", "-", raw)
+    slug = slug.strip("-._")
+    if len(slug) > 100:
+        slug = slug[:100].rstrip("-._")
+    if not _OCI_NAME_RE.match(slug):
+        raise ValueError(f"slugify produced invalid OCI name component: {slug!r}")
+    return slug
+
+
+def build_image_ref(
+    *,
+    registry_prefix: str,
+    owner: str,
+    name: str,
+    commit_sha: str,
+    options_hash: str = "",
+    prefix: str = DEFAULT_BOOTSTRAP_PREFIX,
+) -> str:
+    """Compose the full `host[/namespace]/<image-name>:<tag>` reference.
+
+    `registry_prefix` is a registry-with-namespace string like:
+        ghcr.io/huggingface
+        123456789.dkr.ecr.us-east-1.amazonaws.com/r2e
+        public.ecr.aws/myalias
+        myregistry.azurecr.io/r2e
+        us-central1-docker.pkg.dev/myproject/r2e
+        index.docker.io/myuser
+        localhost:5000
+
+    `commit_sha` is truncated to 12 chars in the tag. `options_hash` is
+    appended after `-` when non-empty (matches `cache._options_hash` semantics).
+    """
+    if not registry_prefix:
+        raise ValueError("registry_prefix is required (host or host/namespace)")
+    if not commit_sha:
+        raise ValueError("commit_sha is required")
+    image_name = slugify_repo(owner, name, prefix=prefix)
+    prefix_trimmed = registry_prefix.strip().rstrip("/")
+    sha12 = commit_sha.strip()[:12].lower()
+    tag = f"{sha12}-{options_hash[:8]}" if options_hash else sha12
+    if not _OCI_TAG_RE.match(tag):
+        raise ValueError(f"invalid OCI tag produced: {tag!r}")
+    ref = f"{prefix_trimmed}/{image_name}:{tag}"
+    if len(ref) > 255:
+        raise ValueError(f"OCI ref exceeds 255 chars ({len(ref)}): {ref!r}")
+    return ref
+
+
+def split_ref(ref: str) -> tuple[str, str, str]:
+    """Split `host[/namespace]/<image>:<tag>` into (registry_prefix, image, tag).
+
+    Inverse of `build_image_ref` minus the slugify step. Useful for the
+    push-time rewrite that needs to look up the source `(repo, commit)` for
+    a manifest-already-exists check.
+    """
+    if ":" not in ref:
+        raise ValueError(f"ref missing tag: {ref!r}")
+    base, _, tag = ref.rpartition(":")
+    # registry_prefix = everything before the final path component
+    if "/" not in base:
+        raise ValueError(f"ref missing host or namespace: {ref!r}")
+    registry_prefix, _, image = base.rpartition("/")
+    return registry_prefix, image, tag

--- a/src/repo2rlenv/registry/probe.py
+++ b/src/repo2rlenv/registry/probe.py
@@ -1,0 +1,527 @@
+"""OCI Distribution Spec L1-L4 verification probes.
+
+Given a host (e.g. `ghcr.io`) and a namespace (e.g. `huggingface`), this
+module makes ~3-5 HTTP calls to confirm whether we can actually push
+images there *right now*, without polluting the user's registry.
+
+Levels:
+
+  L1 — GET /v2/             (registry reachability)
+  L2 — Bearer-token exchange against the challenge realm (auth resolution)
+  L3 — HEAD /v2/<ns>/<probe>/manifests/<tag>   (read access; 404 is pass)
+  L4 — POST /v2/<ns>/<probe>/blobs/uploads/    (write access; 202 is pass)
+       followed by DELETE to cancel — leaves no garbage.
+
+Per-registry quirks are handled inline (ECR/GCP-AR repos must pre-exist,
+GHCR uses GitHub PATs as bearer credentials, ACR uses 3h tokens).
+
+Reference:
+- OCI Distribution Spec: https://github.com/opencontainers/distribution-spec
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import re
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Literal
+
+from repo2rlenv.registry.auth import (
+    CredentialSource,
+    RegistryAuth,
+    RegistryKind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Probe image name used for read/write checks. Per the OCI spec a HEAD on a
+# nonexistent manifest returns 404 (read access verified); a POST blob upload
+# session can be opened then cancelled with no artifact created.
+PROBE_IMAGE = "r2e-bootstrap-probe"
+PROBE_TAG = "latest"
+
+DEFAULT_TIMEOUT_SEC = 10.0
+
+
+class ProbeError(Exception):
+    """Raised when probing hits an unrecoverable client-side error (not 4xx/5xx)."""
+
+
+@dataclass(slots=True)
+class ProbeResult:
+    host: str
+    kind: RegistryKind
+    namespace: str
+    levels_checked: tuple[int, ...]
+    reachable: bool = False
+    authenticated: bool = False
+    can_read: bool = False
+    can_write: bool = False
+    error: str | None = None
+    helper_hint: str | None = None
+    elapsed_sec: float = 0.0
+    details: dict[int, str] = field(default_factory=dict)
+
+    @property
+    def is_pushable(self) -> bool:
+        """All four levels passed — registry is ready for push."""
+        return self.reachable and self.authenticated and self.can_read and self.can_write
+
+
+# Header parsing for WWW-Authenticate: Bearer realm=...,service=...,scope=...
+_BEARER_KV_RE = re.compile(r'(\w+)="([^"]*)"')
+
+
+def _parse_bearer_challenge(www_authenticate: str) -> dict[str, str] | None:
+    """Extract realm/service/scope from a `Bearer ...` WWW-Authenticate header.
+
+    Returns None if the header isn't a Bearer challenge (e.g. Basic).
+    """
+    if not www_authenticate:
+        return None
+    s = www_authenticate.strip()
+    if not s.lower().startswith("bearer "):
+        return None
+    pairs = dict(_BEARER_KV_RE.findall(s[len("Bearer ") :]))
+    return pairs or None
+
+
+def _http_request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+    body: bytes | None = None,
+) -> tuple[int, dict[str, str], bytes]:
+    """Tiny urllib wrapper that never raises on 4xx/5xx.
+
+    Returns (status, lowercased-headers, body-bytes). Uses urllib (stdlib)
+    rather than httpx to avoid an extra runtime dep.
+    """
+    req = urllib.request.Request(url, method=method, data=body)
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return (
+                resp.status,
+                {k.lower(): v for k, v in resp.headers.items()},
+                resp.read(),
+            )
+    except urllib.error.HTTPError as exc:
+        return (
+            exc.code,
+            {k.lower(): v for k, v in (exc.headers or {}).items()},
+            exc.read() or b"",
+        )
+    except urllib.error.URLError as exc:
+        raise ProbeError(f"network error: {exc.reason}") from exc
+    except TimeoutError as exc:
+        raise ProbeError(f"timeout after {timeout}s") from exc
+
+
+def _resolve_credential(auth: RegistryAuth, host: str) -> tuple[str, str] | None:
+    """Resolve (username, password/token) for `host` via the right cred source.
+
+    Returns None if the credential can't be resolved (helper missing, etc.) —
+    the probe will then degrade to anonymous-only behaviour.
+    """
+    if auth.cred_source is CredentialSource.INLINE:
+        # The inline path requires reading the original config.json again —
+        # we do it lazily here to keep the public surface small.
+        from repo2rlenv.registry.auth import _config_path
+
+        cfg = _config_path()
+        if not cfg.is_file():
+            return None
+        try:
+            data = json.loads(cfg.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        entry = (data.get("auths") or {}).get(host, {})
+        if not isinstance(entry, dict):
+            return None
+        blob = (entry.get("auth") or "").strip()
+        if not blob:
+            return None
+        try:
+            decoded = base64.b64decode(blob).decode("utf-8", errors="replace")
+        except (ValueError, UnicodeDecodeError):
+            return None
+        if ":" not in decoded:
+            return None
+        user, _, password = decoded.partition(":")
+        return (user, password)
+
+    helper = auth.helper
+    if not helper:
+        # CREDSTORE without a helper name shouldn't happen, but be defensive.
+        return None
+    return _docker_credential_helper_get(helper, host)
+
+
+def _docker_credential_helper_get(helper: str, host: str) -> tuple[str, str] | None:
+    """Shell out to `docker-credential-<helper> get` for `host`.
+
+    Returns (username, password) or None if the helper doesn't recognize the
+    host (some helpers like `desktop` emit `credentials not found` on stderr
+    and exit non-zero).
+    """
+    binary = f"docker-credential-{helper}"
+    try:
+        proc = subprocess.run(
+            [binary, "get"],
+            input=host,
+            text=True,
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    user = payload.get("Username", "")
+    secret = payload.get("Secret", "")
+    if not secret:
+        return None
+    # AWS/GCloud helpers sometimes return Username="AWS" / "_dcgcloud_token"
+    # and the secret IS the bearer token; we treat user as username, secret
+    # as password, and let the token-exchange step decide.
+    return (user or "", secret)
+
+
+# --------------------------------------------------------------------------
+# L1 — base endpoint reachability
+# --------------------------------------------------------------------------
+
+
+def _l1_reachable(host: str, timeout: float) -> tuple[bool, str | None, str | None]:
+    """Return (ok, error, www_authenticate_header).
+
+    A 200 or 401 both indicate "registry is up." Anything else (DNS / refused
+    connection / 5xx / timeout) means we can't proceed.
+    """
+    scheme = "http" if _is_local_host(host) else "https"
+    url = f"{scheme}://{host}/v2/"
+    try:
+        status, headers, _ = _http_request("GET", url, timeout=timeout)
+    except ProbeError as exc:
+        return (False, str(exc), None)
+    if status in (200, 401):
+        return (True, None, headers.get("www-authenticate"))
+    return (False, f"unexpected status {status} from /v2/", headers.get("www-authenticate"))
+
+
+def _is_local_host(host: str) -> bool:
+    return host in {"localhost", "127.0.0.1"} or host.startswith(("localhost:", "127.0.0.1:"))
+
+
+# --------------------------------------------------------------------------
+# L2 — auth resolution / Bearer token exchange
+# --------------------------------------------------------------------------
+
+
+def _l2_token_exchange(
+    challenge: dict[str, str] | None,
+    credential: tuple[str, str] | None,
+    *,
+    namespace: str,
+    timeout: float,
+) -> tuple[bool, str | None, str | None, list[str]]:
+    """Exchange (user, pass) for a Bearer token at `challenge.realm`.
+
+    Returns (ok, error, bearer_token, granted_scopes).
+
+    granted_scopes is the list of scope strings the token server actually
+    granted — typically ["repository:<ns>/<probe>:pull,push"] or a subset.
+    We use this to distinguish read-only from read+write tokens.
+    """
+    if challenge is None:
+        # No challenge means the registry doesn't require auth (e.g. local
+        # registry:2 without htpasswd). Treat as "authenticated as anonymous";
+        # subsequent calls just don't add an Authorization header.
+        return (True, None, None, [])
+
+    realm = challenge.get("realm")
+    service = challenge.get("service", "")
+    if not realm:
+        return (False, "challenge missing realm", None, [])
+
+    scope = f"repository:{namespace}/{PROBE_IMAGE}:pull,push"
+    query = []
+    if service:
+        query.append(f"service={service}")
+    query.append(f"scope={scope}")
+    url = f"{realm}?{'&'.join(query)}"
+
+    headers: dict[str, str] = {"Accept": "application/json"}
+    if credential is not None:
+        user, password = credential
+        basic = base64.b64encode(f"{user}:{password}".encode()).decode("ascii")
+        headers["Authorization"] = f"Basic {basic}"
+
+    try:
+        status, _, body = _http_request("GET", url, headers=headers, timeout=timeout)
+    except ProbeError as exc:
+        return (False, str(exc), None, [])
+    if status != 200:
+        return (False, f"token server returned {status}", None, [])
+    try:
+        payload = json.loads(body.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError:
+        return (False, "token server returned non-JSON", None, [])
+    token = payload.get("token") or payload.get("access_token")
+    if not token:
+        return (False, "token server returned no token", None, [])
+    # GHCR returns `scope` as a string with comma-separated entries; ACR and
+    # others may return a list. Normalize.
+    raw_scope = payload.get("scope", scope)
+    granted = [str(s) for s in raw_scope] if isinstance(raw_scope, list) else [str(raw_scope)]
+    return (True, None, token, granted)
+
+
+def _has_push_scope(granted_scopes: list[str]) -> bool:
+    """True if any granted scope string includes `push`."""
+    return any("push" in s for s in granted_scopes)
+
+
+# --------------------------------------------------------------------------
+# L3 — read probe (HEAD manifest)
+# --------------------------------------------------------------------------
+
+
+def _l3_can_read(
+    host: str,
+    namespace: str,
+    bearer: str | None,
+    timeout: float,
+) -> tuple[bool, str | None]:
+    """HEAD /v2/<ns>/<probe>/manifests/<tag>; 200 or 404 = read OK."""
+    scheme = "http" if _is_local_host(host) else "https"
+    url = f"{scheme}://{host}/v2/{namespace}/{PROBE_IMAGE}/manifests/{PROBE_TAG}"
+    headers: dict[str, str] = {
+        "Accept": (
+            "application/vnd.oci.image.manifest.v1+json,"
+            "application/vnd.docker.distribution.manifest.v2+json"
+        ),
+    }
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    try:
+        status, _, _ = _http_request("HEAD", url, headers=headers, timeout=timeout)
+    except ProbeError as exc:
+        return (False, str(exc))
+    if status in (200, 404):
+        return (True, None)
+    if status in (401, 403):
+        return (False, f"read denied ({status})")
+    return (False, f"unexpected status {status}")
+
+
+# --------------------------------------------------------------------------
+# L4 — write probe (POST blob upload + DELETE cancel)
+# --------------------------------------------------------------------------
+
+
+def _l4_can_write(
+    host: str,
+    namespace: str,
+    bearer: str | None,
+    timeout: float,
+) -> tuple[bool, str | None]:
+    """POST /v2/<ns>/<probe>/blobs/uploads/; 202 = write OK, then cancel.
+
+    Per OCI spec, 202 returns a Location header pointing at the upload
+    session URL — we DELETE that immediately to leave nothing behind.
+    """
+    scheme = "http" if _is_local_host(host) else "https"
+    url = f"{scheme}://{host}/v2/{namespace}/{PROBE_IMAGE}/blobs/uploads/"
+    headers: dict[str, str] = {"Content-Length": "0"}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    try:
+        status, resp_headers, _ = _http_request(
+            "POST", url, headers=headers, timeout=timeout, body=b""
+        )
+    except ProbeError as exc:
+        return (False, str(exc))
+    if status == 202:
+        # Cancel the session — best-effort, don't fail the probe if cancel fails.
+        location = resp_headers.get("location")
+        if location:
+            cancel_url = location if location.startswith("http") else f"{scheme}://{host}{location}"
+            try:
+                _http_request("DELETE", cancel_url, headers=headers, timeout=timeout)
+            except ProbeError:
+                logger.debug("probe upload-cancel failed; harmless")
+        return (True, None)
+    if status in (401, 403):
+        return (False, f"write denied ({status})")
+    if status == 404:
+        # ECR / GCP AR: repository must pre-exist. We classify this as
+        # "write not yet possible" — caller can decide whether to attempt
+        # repo creation via the vendor API.
+        return (False, "repository does not exist (pre-create required)")
+    return (False, f"unexpected status {status}")
+
+
+# --------------------------------------------------------------------------
+# Public probe entry point
+# --------------------------------------------------------------------------
+
+
+def probe(
+    auth: RegistryAuth,
+    namespace: str,
+    *,
+    levels: tuple[int, ...] = (1, 2, 3, 4),
+    timeout: float = DEFAULT_TIMEOUT_SEC,
+) -> ProbeResult:
+    """Run the L1-L4 verification protocol against `auth.host` for `namespace`.
+
+    `namespace` is the registry path component (e.g. `huggingface` for GHCR,
+    `r2e` for ECR Public, `myproject/myrepo` for GCP AR).
+
+    Returns a populated `ProbeResult`. Never raises for protocol-level
+    failures (4xx, 5xx, denied) — only for client-side network errors that
+    prevent the probe entirely.
+    """
+    started = time.monotonic()
+    result = ProbeResult(
+        host=auth.host,
+        kind=auth.kind,
+        namespace=namespace,
+        levels_checked=levels,
+    )
+
+    # L1
+    if 1 in levels:
+        ok, err, www_auth = _l1_reachable(auth.host, timeout)
+        result.reachable = ok
+        if not ok:
+            result.error = err or "L1 unreachable"
+            result.elapsed_sec = round(time.monotonic() - started, 3)
+            return result
+        result.details[1] = "reachable"
+    else:
+        result.reachable = True
+        www_auth = None
+
+    challenge = _parse_bearer_challenge(www_auth) if www_auth else None
+
+    bearer: str | None = None
+    granted: list[str] = []
+
+    # L2
+    if 2 in levels:
+        credential = _resolve_credential(auth, auth.host)
+        ok, err, bearer, granted = _l2_token_exchange(
+            challenge, credential, namespace=namespace, timeout=timeout
+        )
+        result.authenticated = ok
+        if not ok:
+            result.error = err
+            # Helper hint for common cases.
+            if auth.kind is RegistryKind.GHCR:
+                result.helper_hint = (
+                    "gh auth refresh -h github.com -s write:packages && "
+                    'echo "$(gh auth token)" | docker login ghcr.io '
+                    "-u $(gh api user --jq .login) --password-stdin"
+                )
+            elif auth.kind is RegistryKind.ECR_PRIVATE:
+                result.helper_hint = (
+                    "aws ecr get-login-password --region <REGION> | "
+                    f"docker login --username AWS --password-stdin {auth.host}"
+                )
+            elif auth.kind is RegistryKind.ACR:
+                result.helper_hint = f"az acr login --name {auth.host.split('.')[0]}"
+            elif auth.kind is RegistryKind.GCP_AR:
+                result.helper_hint = f"gcloud auth configure-docker {auth.host}"
+            elif auth.kind is RegistryKind.DOCKER_HUB:
+                result.helper_hint = "docker login"
+            result.elapsed_sec = round(time.monotonic() - started, 3)
+            return result
+        result.details[2] = "authenticated"
+
+    # L3
+    if 3 in levels:
+        ok, err = _l3_can_read(auth.host, namespace, bearer, timeout)
+        result.can_read = ok
+        result.details[3] = "read OK" if ok else (err or "read failed")
+        if not ok:
+            result.error = err
+            result.elapsed_sec = round(time.monotonic() - started, 3)
+            return result
+
+    # L4
+    if 4 in levels:
+        # Cheap pre-check: if L2 granted only `pull`, we already know we
+        # can't write. Skip the round-trip.
+        if 2 in levels and granted and not _has_push_scope(granted):
+            result.can_write = False
+            result.error = "token lacks push scope"
+            result.details[4] = "push scope not granted"
+            result.elapsed_sec = round(time.monotonic() - started, 3)
+            return result
+        ok, err = _l4_can_write(auth.host, namespace, bearer, timeout)
+        result.can_write = ok
+        result.details[4] = "write OK" if ok else (err or "write failed")
+        if not ok:
+            result.error = err
+
+    result.elapsed_sec = round(time.monotonic() - started, 3)
+    return result
+
+
+def select_best(
+    results: list[ProbeResult],
+    *,
+    require_write: bool = True,
+) -> ProbeResult | None:
+    """Pick the highest-ranked pushable result.
+
+    Preference: GHCR > GCP_AR > ECR_PUBLIC > ECR_PRIVATE > ACR > LOCAL > DOCKER_HUB.
+    Rationale: ranked by anonymous-pull friendliness for public images.
+    Docker Hub is last because of the 100/6h anonymous rate limit.
+    """
+    rank: dict[RegistryKind, int] = {
+        RegistryKind.GHCR: 0,
+        RegistryKind.GCP_AR: 1,
+        RegistryKind.ECR_PUBLIC: 2,
+        RegistryKind.ECR_PRIVATE: 3,
+        RegistryKind.ACR: 4,
+        RegistryKind.LOCAL: 5,
+        RegistryKind.DOCKER_HUB: 6,
+    }
+    eligible = [r for r in results if (r.is_pushable if require_write else r.authenticated)]
+    if not eligible:
+        return None
+    return min(eligible, key=lambda r: rank.get(r.kind, 99))
+
+
+# Public API surface
+__all__ = [
+    "DEFAULT_TIMEOUT_SEC",
+    "PROBE_IMAGE",
+    "PROBE_TAG",
+    "ProbeError",
+    "ProbeResult",
+    "probe",
+    "select_best",
+]
+
+
+_LevelInt = Literal[1, 2, 3, 4]

--- a/src/repo2rlenv/registry/push.py
+++ b/src/repo2rlenv/registry/push.py
@@ -1,0 +1,174 @@
+"""Push a local docker image to a remote OCI registry.
+
+Wraps the `docker` CLI rather than docker-py because:
+
+  1. docker-py is an extra runtime dep we don't otherwise need.
+  2. The push wire-format is identical across all OCI-compliant registries;
+     we just need to invoke `docker push <ref>` and parse RepoDigests.
+
+The push step is idempotent at the registry level: re-pushing the same
+local image to the same tag is a no-op for the layers that already exist,
+and `RepoDigests` resolves to the same `sha256` content hash.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+class PushError(Exception):
+    """Raised when `docker push` fails irrecoverably."""
+
+
+@dataclass(slots=True)
+class ImagePushResult:
+    local_tag: str
+    remote_ref: str
+    digest: str  # full `host/path@sha256:...`
+    pushed: bool  # False if "already at registry, skipped"
+    duration_sec: float
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+def _run(args: list[str], *, timeout: int = 1800) -> subprocess.CompletedProcess[str]:
+    """Run a docker subcommand, capturing output and never raising on nonzero."""
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def manifest_exists(remote_ref: str) -> bool:
+    """`docker manifest inspect <ref>` returns 0 iff the registry already has it.
+
+    Used for the idempotent-re-push optimization: skip the push entirely if
+    the image is already at the target.
+    """
+    if not _docker_available():
+        return False
+    proc = _run(
+        ["docker", "manifest", "inspect", remote_ref],
+        timeout=60,
+    )
+    return proc.returncode == 0
+
+
+def _resolve_repo_digest(remote_ref: str) -> str | None:
+    """Return the registry-qualified digest for `remote_ref`, or None.
+
+    `docker image inspect <ref>` exposes RepoDigests AFTER a push (or pull).
+    We filter to the digest matching the same registry host so multi-region
+    pushes don't get crossed up.
+    """
+    proc = _run(
+        ["docker", "image", "inspect", remote_ref, "--format", "{{json .RepoDigests}}"],
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        return None
+    try:
+        digests = json.loads(proc.stdout.strip() or "[]")
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(digests, list) or not digests:
+        return None
+    host_prefix = remote_ref.split("/", 1)[0]
+    for d in digests:
+        if isinstance(d, str) and d.startswith(host_prefix):
+            return d
+    # Fallback: first digest
+    first = digests[0]
+    return first if isinstance(first, str) else None
+
+
+def push_image(
+    local_tag: str,
+    remote_ref: str,
+    *,
+    timeout: int = 1800,
+    skip_if_exists: bool = True,
+) -> ImagePushResult:
+    """Tag → push → resolve digest. Returns the canonical registry-qualified ref.
+
+    Raises `PushError` if the local image isn't present, the docker daemon
+    isn't running, or the push itself fails.
+    """
+    import time
+
+    if not _docker_available():
+        raise PushError("docker CLI not available on PATH")
+
+    start = time.monotonic()
+
+    # 1. Verify the local image exists
+    inspect = _run(
+        ["docker", "image", "inspect", local_tag, "--format", "{{.Id}}"],
+        timeout=30,
+    )
+    if inspect.returncode != 0:
+        raise PushError(
+            f"local image {local_tag!r} not found. "
+            "Run `repo2rlenv bootstrap` first, or pass --inline-dockerfile."
+        )
+
+    # 2. Optionally skip if already at registry
+    if skip_if_exists and manifest_exists(remote_ref):
+        logger.info("manifest already at %s; skipping push", remote_ref)
+        digest = _resolve_repo_digest(remote_ref) or remote_ref
+        return ImagePushResult(
+            local_tag=local_tag,
+            remote_ref=remote_ref,
+            digest=digest,
+            pushed=False,
+            duration_sec=round(time.monotonic() - start, 2),
+        )
+
+    # 3. Tag local → remote
+    tag_proc = _run(["docker", "tag", local_tag, remote_ref], timeout=60)
+    if tag_proc.returncode != 0:
+        raise PushError(
+            f"docker tag {local_tag} {remote_ref} failed: {tag_proc.stderr.strip()[:400]}"
+        )
+
+    # 4. Push
+    push_proc = _run(["docker", "push", remote_ref], timeout=timeout)
+    if push_proc.returncode != 0:
+        # Surface the actual docker error for the caller to classify (auth
+        # denied vs. network vs. repo-doesn't-exist for ECR/GAR).
+        raise PushError(f"docker push {remote_ref} failed:\n{push_proc.stderr.strip()[:1000]}")
+
+    # 5. Resolve the canonical digest from RepoDigests
+    digest = _resolve_repo_digest(remote_ref)
+    if digest is None:
+        # Push succeeded but inspect didn't find a digest — degrade to the
+        # tagged ref (still pullable, just not pinned).
+        digest = remote_ref
+        logger.warning("could not resolve RepoDigest for %s; using tag", remote_ref)
+
+    return ImagePushResult(
+        local_tag=local_tag,
+        remote_ref=remote_ref,
+        digest=digest,
+        pushed=True,
+        duration_sec=round(time.monotonic() - start, 2),
+    )
+
+
+__all__ = [
+    "ImagePushResult",
+    "PushError",
+    "manifest_exists",
+    "push_image",
+]

--- a/src/repo2rlenv/registry/push.py
+++ b/src/repo2rlenv/registry/push.py
@@ -69,8 +69,10 @@ def _resolve_repo_digest(remote_ref: str) -> str | None:
     """Return the registry-qualified digest for `remote_ref`, or None.
 
     `docker image inspect <ref>` exposes RepoDigests AFTER a push (or pull).
-    We filter to the digest matching the same registry host so multi-region
-    pushes don't get crossed up.
+    We pick the digest whose path component matches `remote_ref`'s path,
+    not the host — Docker Hub returns digests as `<user>/<image>@sha256:...`
+    (no `index.docker.io/` prefix) since it's the default registry, while
+    GHCR / ECR / etc. return the full `<host>/<path>@...` form.
     """
     proc = _run(
         ["docker", "image", "inspect", remote_ref, "--format", "{{json .RepoDigests}}"],
@@ -84,13 +86,34 @@ def _resolve_repo_digest(remote_ref: str) -> str | None:
         return None
     if not isinstance(digests, list) or not digests:
         return None
+
+    # The path component of remote_ref (everything after the host) — this is
+    # what Docker Hub digests use as the full identifier.
+    remote_path = remote_ref.split("/", 1)[1] if "/" in remote_ref else remote_ref
+    remote_path_no_tag = remote_path.split(":", 1)[0]
     host_prefix = remote_ref.split("/", 1)[0]
+
+    # Build expected match prefixes: try host-qualified first, then bare path
+    # (Docker Hub). Skip `local/...` entries — those are un-pullable.
+    candidates: list[str] = []
     for d in digests:
-        if isinstance(d, str) and d.startswith(host_prefix):
-            return d
-    # Fallback: first digest
-    first = digests[0]
-    return first if isinstance(first, str) else None
+        if not isinstance(d, str):
+            continue
+        if d.startswith("local/") or d.startswith("local-"):
+            continue
+        if d.startswith(f"{host_prefix}/"):
+            return d  # exact host match wins
+        if d.startswith(f"{remote_path_no_tag}@"):
+            candidates.append(d)  # bare-path match (Docker Hub style)
+
+    if candidates:
+        # For Docker Hub, prefix with the canonical host so the consumer's
+        # `docker pull` resolves unambiguously.
+        d = candidates[0]
+        if host_prefix in ("index.docker.io", "registry-1.docker.io", "docker.io"):
+            return f"{host_prefix}/{d}"
+        return d
+    return None
 
 
 def push_image(

--- a/src/repo2rlenv/registry/visibility.py
+++ b/src/repo2rlenv/registry/visibility.py
@@ -1,0 +1,162 @@
+"""GHCR-specific package visibility helpers.
+
+GHCR creates packages as private by default. To make a public dataset's
+bootstrap image pullable without auth, we PATCH the package visibility
+via the GitHub REST API:
+
+  PATCH /user/packages/container/<name>            (personal namespace)
+  PATCH /orgs/<org>/packages/container/<name>      (org namespace)
+
+The user (or `gh` CLI) needs the `write:packages` scope for this to
+succeed. Failure is non-fatal — we warn and continue with private
+visibility recorded in the task metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+
+VisibilityValue = Literal["public", "private", "internal"]
+
+
+@dataclass(slots=True)
+class VisibilityResult:
+    package: str
+    target: VisibilityValue
+    success: bool
+    error: str | None = None
+    manual_url: str | None = None
+
+
+def _gh_available() -> bool:
+    return shutil.which("gh") is not None
+
+
+def _gh_user() -> str | None:
+    """Return the authenticated GitHub user login, or None if `gh` unavailable."""
+    if not _gh_available():
+        return None
+    proc = subprocess.run(
+        ["gh", "api", "user", "--jq", ".login"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _parse_ghcr_package(remote_ref: str) -> tuple[str, str] | None:
+    """From `ghcr.io/<owner>/<name>:<tag>` return (owner, name).
+
+    Returns None if the ref isn't a GHCR ref.
+    """
+    if not remote_ref.startswith("ghcr.io/"):
+        return None
+    body = remote_ref.removeprefix("ghcr.io/").split("@", 1)[0].split(":", 1)[0]
+    parts = body.split("/", 1)
+    if len(parts) != 2:
+        return None
+    owner, name = parts
+    # Package names with embedded `/` are valid in GHCR but encoded as part
+    # of the package identifier when hitting the API.
+    return owner, name
+
+
+def ensure_ghcr_visibility(
+    remote_ref: str,
+    target: VisibilityValue = "public",
+) -> VisibilityResult:
+    """Flip the GHCR package's visibility (best-effort).
+
+    `remote_ref` can be a full registry ref (`ghcr.io/owner/name:tag` or
+    `ghcr.io/owner/name@sha256:...`); we extract owner + package name.
+
+    Idempotent: setting visibility to its existing value returns 204.
+    """
+    parsed = _parse_ghcr_package(remote_ref)
+    if parsed is None:
+        return VisibilityResult(
+            package=remote_ref,
+            target=target,
+            success=False,
+            error="not a ghcr.io ref",
+        )
+    owner, name = parsed
+    package_full = f"{owner}/{name}"
+    if not _gh_available():
+        return VisibilityResult(
+            package=package_full,
+            target=target,
+            success=False,
+            error="gh CLI not available",
+            manual_url=f"https://github.com/users/{owner}/packages/container/{name}/settings",
+        )
+
+    # Determine whether this is a user or org namespace.
+    me = _gh_user()
+    if me and me.lower() == owner.lower():
+        api_path = f"/user/packages/container/{name}"
+    else:
+        api_path = f"/orgs/{owner}/packages/container/{name}"
+
+    proc = subprocess.run(
+        [
+            "gh",
+            "api",
+            "-X",
+            "PATCH",
+            api_path,
+            "-f",
+            f"visibility={target}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    if proc.returncode == 0:
+        return VisibilityResult(
+            package=package_full,
+            target=target,
+            success=True,
+        )
+
+    # gh CLI bubbles up the HTTP error body. Extract the message for the user.
+    err_body = proc.stderr.strip() or proc.stdout.strip()
+    try:
+        # Some gh outputs are JSON; others are plain text
+        if err_body.startswith("{"):
+            err_body = json.loads(err_body).get("message", err_body)
+    except (ValueError, json.JSONDecodeError):
+        pass
+    manual_url = (
+        f"https://github.com/users/{owner}/packages/container/{name}/settings"
+        if me and me.lower() == owner.lower()
+        else f"https://github.com/orgs/{owner}/packages/container/{name}/settings"
+    )
+    return VisibilityResult(
+        package=package_full,
+        target=target,
+        success=False,
+        error=err_body[:400] or f"gh api exit {proc.returncode}",
+        manual_url=manual_url,
+    )
+
+
+__all__ = [
+    "VisibilityResult",
+    "VisibilityValue",
+    "ensure_ghcr_visibility",
+]

--- a/tests/registry/test_auth.py
+++ b/tests/registry/test_auth.py
@@ -1,0 +1,181 @@
+"""Tests for `registry.auth` — file-level Docker login discovery."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from repo2rlenv.registry.auth import (
+    CredentialSource,
+    RegistryAuth,
+    RegistryKind,
+    classify_host,
+    discover_logged_in_registries,
+    filter_known_registries,
+)
+
+
+class TestClassifyHost:
+    @pytest.mark.parametrize(
+        "host,expected",
+        [
+            ("ghcr.io", RegistryKind.GHCR),
+            ("https://ghcr.io/", RegistryKind.GHCR),
+            ("public.ecr.aws", RegistryKind.ECR_PUBLIC),
+            ("123456789012.dkr.ecr.us-east-1.amazonaws.com", RegistryKind.ECR_PRIVATE),
+            ("999.dkr.ecr.eu-west-2.amazonaws.com", RegistryKind.ECR_PRIVATE),
+            ("myregistry.azurecr.io", RegistryKind.ACR),
+            ("us-central1-docker.pkg.dev", RegistryKind.GCP_AR),
+            ("asia-southeast1-docker.pkg.dev", RegistryKind.GCP_AR),
+            ("index.docker.io", RegistryKind.DOCKER_HUB),
+            ("registry-1.docker.io", RegistryKind.DOCKER_HUB),
+            ("docker.io", RegistryKind.DOCKER_HUB),
+            ("https://index.docker.io/v1/", RegistryKind.DOCKER_HUB),
+            ("localhost:5000", RegistryKind.LOCAL),
+            ("127.0.0.1:5000", RegistryKind.LOCAL),
+            ("quay.io", RegistryKind.OTHER),
+            ("", RegistryKind.OTHER),
+        ],
+    )
+    def test_classification(self, host: str, expected: RegistryKind) -> None:
+        assert classify_host(host) is expected
+
+
+class TestDiscover:
+    def test_missing_config(self, tmp_path: Path) -> None:
+        assert discover_logged_in_registries(tmp_path / "nope.json") == []
+
+    def test_malformed_config(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "config.json"
+        cfg.write_text("not json", encoding="utf-8")
+        assert discover_logged_in_registries(cfg) == []
+
+    def test_inline_auth(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "config.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "auths": {
+                        "ghcr.io": {"auth": "dXNlcjpwYXNz"},  # user:pass
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        out = discover_logged_in_registries(cfg)
+        assert out == [
+            RegistryAuth(
+                host="ghcr.io",
+                kind=RegistryKind.GHCR,
+                cred_source=CredentialSource.INLINE,
+                helper=None,
+            )
+        ]
+
+    def test_credhelper_takes_precedence(self, tmp_path: Path) -> None:
+        """Per-host credHelpers override global credsStore."""
+        cfg = tmp_path / "config.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "credsStore": "desktop",
+                    "credHelpers": {
+                        "123456789012.dkr.ecr.us-east-1.amazonaws.com": "ecr-login",
+                    },
+                    "auths": {
+                        "123456789012.dkr.ecr.us-east-1.amazonaws.com": {},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        out = discover_logged_in_registries(cfg)
+        assert len(out) == 1
+        assert out[0].kind is RegistryKind.ECR_PRIVATE
+        assert out[0].cred_source is CredentialSource.CREDHELPER
+        assert out[0].helper == "ecr-login"
+
+    def test_credstore_with_empty_auths(self, tmp_path: Path) -> None:
+        """Docker Desktop populates empty {} entries; classify as CREDSTORE."""
+        cfg = tmp_path / "config.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "credsStore": "desktop",
+                    "auths": {
+                        "ghcr.io": {},
+                        "index.docker.io": {},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        out = discover_logged_in_registries(cfg)
+        kinds = {a.kind for a in out}
+        sources = {a.cred_source for a in out}
+        assert kinds == {RegistryKind.GHCR, RegistryKind.DOCKER_HUB}
+        assert sources == {CredentialSource.CREDSTORE}
+
+    def test_empty_auths_without_credstore(self, tmp_path: Path) -> None:
+        """Bare {} with no credsStore → EMPTY (still a logged-in signal)."""
+        cfg = tmp_path / "config.json"
+        cfg.write_text(
+            json.dumps({"auths": {"ghcr.io": {}}}),
+            encoding="utf-8",
+        )
+        out = discover_logged_in_registries(cfg)
+        assert len(out) == 1
+        assert out[0].cred_source is CredentialSource.EMPTY
+
+    def test_mixed_sources(self, tmp_path: Path) -> None:
+        """credHelper + credsStore + inline all coexist."""
+        cfg = tmp_path / "config.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "credsStore": "desktop",
+                    "credHelpers": {
+                        "us-central1-docker.pkg.dev": "gcloud",
+                    },
+                    "auths": {
+                        "ghcr.io": {"auth": "dXNlcjpwYXNz"},
+                        "myregistry.azurecr.io": {},
+                        "us-central1-docker.pkg.dev": {},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        out = discover_logged_in_registries(cfg)
+        by_host = {a.host: a for a in out}
+        assert by_host["ghcr.io"].cred_source is CredentialSource.INLINE
+        assert by_host["myregistry.azurecr.io"].cred_source is CredentialSource.CREDSTORE
+        assert by_host["us-central1-docker.pkg.dev"].cred_source is CredentialSource.CREDHELPER
+        assert by_host["us-central1-docker.pkg.dev"].helper == "gcloud"
+
+    def test_normalizes_docker_hub_v1_url(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "config.json"
+        cfg.write_text(
+            json.dumps({"auths": {"https://index.docker.io/v1/": {"auth": "dXg="}}}),
+            encoding="utf-8",
+        )
+        out = discover_logged_in_registries(cfg)
+        assert len(out) == 1
+        assert out[0].host == "index.docker.io"
+        assert out[0].kind is RegistryKind.DOCKER_HUB
+
+
+class TestFilterKnown:
+    def test_drops_other_kind(self) -> None:
+        auths = [
+            RegistryAuth("ghcr.io", RegistryKind.GHCR, CredentialSource.INLINE),
+            RegistryAuth("quay.io", RegistryKind.OTHER, CredentialSource.INLINE),
+            RegistryAuth("localhost:5000", RegistryKind.LOCAL, CredentialSource.EMPTY),
+        ]
+        out = filter_known_registries(auths)
+        kinds = {a.kind for a in out}
+        assert RegistryKind.OTHER not in kinds
+        assert RegistryKind.GHCR in kinds
+        assert RegistryKind.LOCAL in kinds

--- a/tests/registry/test_integration.py
+++ b/tests/registry/test_integration.py
@@ -135,6 +135,17 @@ class TestHelpers:
         )
         assert sha == "a1b2c3d4e5f6"
 
+    def test_parse_local_tag_digest_form(self) -> None:
+        """Real-world inputs use the @sha256:... digest form, not :tag."""
+        owner, name, sha = _parse_local_tag(
+            "local/r2e-bootstrap/pallets__click@sha256:"
+            "be4ae3decdbef39ead00d4f5dde6f0dbb644666d82bfa0693ae066e1cc9b467a"
+        )
+        assert owner == "pallets"
+        assert name == "click"
+        assert sha == "be4ae3decdbe"
+        assert len(sha) == 12  # truncated for OCI tag-length safety
+
     def test_rewrite_dockerfile_from(self, tmp_path: Path) -> None:
         df = tmp_path / "Dockerfile"
         df.write_text("FROM local/foo:tag\nWORKDIR /x\n", encoding="utf-8")

--- a/tests/registry/test_integration.py
+++ b/tests/registry/test_integration.py
@@ -1,0 +1,356 @@
+"""Integration tests for `registry.integration.prepare_dataset_for_push`.
+
+We stub the probe + push primitives and verify:
+  - The right mode is selected given (probe results, flags).
+  - environment/Dockerfile and task.toml get rewritten in-place.
+  - The reproducibility subtable is populated correctly.
+  - 1-image-per-dataset enforcement.
+  - pr_diff (text-only) datasets skip the image step.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from repo2rlenv.registry import integration as integ
+from repo2rlenv.registry.auth import (
+    RegistryKind,
+)
+from repo2rlenv.registry.integration import (
+    _bootstrap_image_refs,
+    _list_task_dirs,
+    _parse_local_tag,
+    _rewrite_dockerfile_from,
+    prepare_dataset_for_push,
+)
+from repo2rlenv.registry.probe import ProbeResult
+
+
+def _write_runtime_task(
+    root: Path,
+    name: str,
+    *,
+    bootstrap_ref: str,
+    pipeline: str = "pr_runtime",
+    repo: str = "pallets/click",
+) -> Path:
+    task_dir = root / name
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text(
+        f"""version = "1.0"
+
+[task]
+name = "{name}"
+org = "test"
+description = "test task"
+
+[metadata.repo2env]
+spec_version = "0.1.0"
+pipeline = "{pipeline}"
+repo = "{repo}"
+ref = "abc123"
+
+[metadata.repo2env.{pipeline}]
+bootstrap_image = "{bootstrap_ref}"
+""",
+        encoding="utf-8",
+    )
+    (task_dir / "instruction.md").write_text("do it", encoding="utf-8")
+    sol = task_dir / "solution"
+    sol.mkdir()
+    (sol / "patch.diff").write_text("", encoding="utf-8")
+    env = task_dir / "environment"
+    env.mkdir()
+    (env / "Dockerfile").write_text(
+        f"FROM {bootstrap_ref}\nWORKDIR /workspace\nRUN echo hi\n",
+        encoding="utf-8",
+    )
+    tests = task_dir / "tests"
+    tests.mkdir()
+    (tests / "test.sh").write_text("#!/bin/bash\ntrue\n", encoding="utf-8")
+    return task_dir
+
+
+def _write_text_only_task(root: Path, name: str) -> Path:
+    """pr_diff-shape task — no environment/ dir."""
+    task_dir = root / name
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text(
+        f"""version = "1.0"
+
+[task]
+name = "{name}"
+org = "test"
+description = "test task"
+
+[metadata.repo2env]
+spec_version = "0.1.0"
+pipeline = "pr_diff"
+repo = "pallets/click"
+""",
+        encoding="utf-8",
+    )
+    (task_dir / "instruction.md").write_text("do it", encoding="utf-8")
+    sol = task_dir / "solution"
+    sol.mkdir()
+    (sol / "patch.diff").write_text("--- a/x\n+++ b/x\n", encoding="utf-8")
+    return task_dir
+
+
+def _make_pushable_probe(
+    host: str = "ghcr.io", kind: RegistryKind = RegistryKind.GHCR
+) -> ProbeResult:
+    return ProbeResult(
+        host=host,
+        kind=kind,
+        namespace="testorg",
+        levels_checked=(1, 2, 3, 4),
+        reachable=True,
+        authenticated=True,
+        can_read=True,
+        can_write=True,
+    )
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_parse_local_tag(self) -> None:
+        owner, name, sha = _parse_local_tag("local/r2e-bootstrap/pallets__click:a1b2c3d4e5f6")
+        assert owner == "pallets"
+        assert name == "click"
+        assert sha == "a1b2c3d4e5f6"
+
+    def test_parse_local_tag_with_opts(self) -> None:
+        _owner, _name, sha = _parse_local_tag(
+            "local/r2e-bootstrap/pallets__click:a1b2c3d4e5f6__01234567"
+        )
+        assert sha == "a1b2c3d4e5f6"
+
+    def test_rewrite_dockerfile_from(self, tmp_path: Path) -> None:
+        df = tmp_path / "Dockerfile"
+        df.write_text("FROM local/foo:tag\nWORKDIR /x\n", encoding="utf-8")
+        changed = _rewrite_dockerfile_from(df, "ghcr.io/u/n@sha256:abc")
+        assert changed
+        assert df.read_text().startswith("FROM ghcr.io/u/n@sha256:abc")
+
+    def test_list_task_dirs_skips_hidden(self, tmp_path: Path) -> None:
+        _write_runtime_task(tmp_path, "task-1", bootstrap_ref="local/x:1")
+        (tmp_path / ".hidden").mkdir()
+        (tmp_path / ".hidden" / "task.toml").write_text("ignored")
+        out = _list_task_dirs(tmp_path)
+        assert len(out) == 1
+        assert out[0].name == "task-1"
+
+    def test_bootstrap_image_refs(self, tmp_path: Path) -> None:
+        _write_runtime_task(tmp_path, "task-1", bootstrap_ref="local/r2e:1")
+        _write_runtime_task(tmp_path, "task-2", bootstrap_ref="local/r2e:1")
+        refs = _bootstrap_image_refs(_list_task_dirs(tmp_path))
+        assert {r for r, _ in refs} == {"local/r2e:1"}
+
+
+# --------------------------------------------------------------------------
+# Mode selection
+# --------------------------------------------------------------------------
+
+
+class TestModeSelection:
+    """The big one: given probe + flag combinations, the right mode wins."""
+
+    def test_text_only_dataset_skipped(self, tmp_path: Path) -> None:
+        _write_text_only_task(tmp_path, "task-1")
+        _write_text_only_task(tmp_path, "task-2")
+        result = prepare_dataset_for_push(tmp_path, hf_owner="testorg")
+        assert result.mode == "local_only"
+        assert result.tasks_rewritten == 0
+
+    def test_multi_image_dataset_fails_fast(self, tmp_path: Path) -> None:
+        _write_runtime_task(tmp_path, "task-1", bootstrap_ref="local/r2e:img1")
+        _write_runtime_task(tmp_path, "task-2", bootstrap_ref="local/r2e:img2")
+        with pytest.raises(RuntimeError, match="distinct bootstrap images"):
+            prepare_dataset_for_push(tmp_path, hf_owner="testorg")
+
+    def test_registry_mode_selected_when_probe_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_runtime_task(tmp_path, "task-1", bootstrap_ref="local/r2e:abc123def456")
+
+        # Stub selection to return a pushable GHCR probe
+        probe = _make_pushable_probe()
+
+        def fake_select(hf_owner: str, **kwargs: Any) -> Any:
+            return (probe, "testorg", [probe])
+
+        monkeypatch.setattr(integ, "_select_verified_registry", fake_select)
+        # Stub the push to succeed
+        monkeypatch.setattr(
+            integ,
+            "_do_push",
+            lambda local, remote, looks_local: mock.MagicMock(
+                digest=f"{remote.rsplit(':', 1)[0]}@sha256:cafe",
+                pushed=True,
+            ),
+        )
+        # Stub visibility flip
+        monkeypatch.setattr(
+            integ,
+            "ensure_ghcr_visibility",
+            lambda ref, target="public": mock.MagicMock(success=True, error=None, manual_url=None),
+        )
+
+        result = prepare_dataset_for_push(tmp_path, hf_owner="testorg")
+        assert result.mode == "registry"
+        assert result.tasks_rewritten == 1
+        assert result.image_digest and result.image_digest.endswith("@sha256:cafe")
+        # Verify Dockerfile got rewritten
+        df = tmp_path / "task-1" / "environment" / "Dockerfile"
+        assert "@sha256:cafe" in df.read_text()
+        # Verify task.toml carries the reproducibility subtable
+        toml_data = tomllib.loads((tmp_path / "task-1" / "task.toml").read_text())
+        repro = toml_data["metadata"]["repo2env"]["reproducibility"]
+        assert repro["mode"] == "registry"
+        assert "cafe" in repro["image_ref"]
+        assert toml_data["metadata"]["repo2env"]["spec_version"] == "0.2.0"
+        # Legacy field also updated
+        assert (
+            toml_data["metadata"]["repo2env"]["pr_runtime"]["bootstrap_image"] == repro["image_ref"]
+        )
+
+    def test_auto_fallback_to_inline_when_no_registry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_runtime_task(
+            tmp_path, "task-1", bootstrap_ref="local/r2e-bootstrap/pallets__click:abc123def456"
+        )
+
+        # No registry available
+        monkeypatch.setattr(
+            integ, "_select_verified_registry", lambda *a, **kw: (None, "testorg", [])
+        )
+
+        # Provide a fake bootstrap recipe via the helper
+        monkeypatch.setattr(
+            integ,
+            "_load_bootstrap_recipe",
+            lambda local_ref: (
+                "FROM python:3.11-slim\nRUN apt-get install -y git\n",
+                "agent_replay",
+            ),
+        )
+
+        result = prepare_dataset_for_push(tmp_path, hf_owner="testorg")
+        assert result.mode == "inline_dockerfile"
+        assert result.tasks_rewritten == 1
+        assert result.fallback_reason is not None
+        assert "registry credentials" in (result.fallback_reason or "")
+        # The Dockerfile should now contain the recipe
+        df = tmp_path / "task-1" / "environment" / "Dockerfile"
+        content = df.read_text()
+        assert "python:3.11-slim" in content
+        assert "apt-get install -y git" in content
+        # And the per-task overlay should still be there (WORKDIR / RUN echo hi)
+        assert "WORKDIR /workspace" in content
+        # task.toml reflects inline mode
+        toml_data = tomllib.loads((tmp_path / "task-1" / "task.toml").read_text())
+        repro = toml_data["metadata"]["repo2env"]["reproducibility"]
+        assert repro["mode"] == "inline_dockerfile"
+        assert repro["inline_recipe_source"] == "agent_replay"
+        assert repro["fallback_reason"]
+
+    def test_require_registry_hard_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_runtime_task(tmp_path, "task-1", bootstrap_ref="local/r2e:abc123def456")
+        monkeypatch.setattr(
+            integ, "_select_verified_registry", lambda *a, **kw: (None, "testorg", [])
+        )
+        with pytest.raises(RuntimeError, match="no verified registry"):
+            prepare_dataset_for_push(tmp_path, hf_owner="testorg", require_registry=True)
+
+    def test_explicit_inline_flag(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_runtime_task(tmp_path, "task-1", bootstrap_ref="local/r2e:abc123def456")
+        monkeypatch.setattr(
+            integ,
+            "_load_bootstrap_recipe",
+            lambda local_ref: ("FROM python:3.11-slim\n", "user_dockerfile"),
+        )
+        # Even if a registry IS available, --inline-dockerfile wins
+        result = prepare_dataset_for_push(tmp_path, hf_owner="testorg", inline_dockerfile=True)
+        assert result.mode == "inline_dockerfile"
+        assert result.inline_recipe_source == "user_dockerfile"
+        # No fallback reason — this was explicit
+        assert result.fallback_reason is None
+
+    def test_inline_fails_without_cached_recipe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_runtime_task(tmp_path, "task-1", bootstrap_ref="local/r2e:abc123def456")
+        monkeypatch.setattr(integ, "_load_bootstrap_recipe", lambda lr: (None, None))
+        with pytest.raises(RuntimeError, match="bootstrap reconstructed Dockerfile"):
+            prepare_dataset_for_push(tmp_path, hf_owner="testorg", inline_dockerfile=True)
+
+    def test_visibility_flip_failure_in_default_mode_warns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_runtime_task(tmp_path, "task-1", bootstrap_ref="local/r2e:abc123def456")
+        probe = _make_pushable_probe()
+        monkeypatch.setattr(
+            integ, "_select_verified_registry", lambda *a, **kw: (probe, "testorg", [probe])
+        )
+        monkeypatch.setattr(
+            integ,
+            "_do_push",
+            lambda local, remote, looks_local: mock.MagicMock(
+                digest=f"{remote.rsplit(':', 1)[0]}@sha256:cafe",
+                pushed=True,
+            ),
+        )
+        # Visibility flip fails
+        monkeypatch.setattr(
+            integ,
+            "ensure_ghcr_visibility",
+            lambda ref, target="public": mock.MagicMock(
+                success=False,
+                error="not enough perms",
+                manual_url="https://github.com/users/testorg/packages/...",
+            ),
+        )
+
+        result = prepare_dataset_for_push(tmp_path, hf_owner="testorg")
+        # Dataset still publishes (registry mode), but with visibility=unknown + warning
+        assert result.mode == "registry"
+        assert result.image_visibility == "unknown"
+        assert result.warnings
+        assert "visibility" in result.warnings[0].lower()
+
+    def test_visibility_flip_failure_with_require_registry_hard_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_runtime_task(tmp_path, "task-1", bootstrap_ref="local/r2e:abc123def456")
+        probe = _make_pushable_probe()
+        monkeypatch.setattr(
+            integ, "_select_verified_registry", lambda *a, **kw: (probe, "testorg", [probe])
+        )
+        monkeypatch.setattr(
+            integ,
+            "_do_push",
+            lambda local, remote, looks_local: mock.MagicMock(
+                digest=f"{remote.rsplit(':', 1)[0]}@sha256:cafe",
+                pushed=True,
+            ),
+        )
+        monkeypatch.setattr(
+            integ,
+            "ensure_ghcr_visibility",
+            lambda ref, target="public": mock.MagicMock(success=False, error="x", manual_url="y"),
+        )
+        with pytest.raises(RuntimeError, match="visibility"):
+            prepare_dataset_for_push(tmp_path, hf_owner="testorg", require_registry=True)

--- a/tests/registry/test_naming.py
+++ b/tests/registry/test_naming.py
@@ -1,0 +1,164 @@
+"""Tests for `registry.naming` — slug + tag construction."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from repo2rlenv.registry.naming import (
+    DEFAULT_BOOTSTRAP_PREFIX,
+    build_image_ref,
+    slugify_repo,
+    split_ref,
+)
+
+_OCI_NAME = re.compile(r"^[a-z0-9]+((?:[._]|__|-+)[a-z0-9]+)*$")
+_OCI_TAG = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$")
+
+
+class TestSlugifyRepo:
+    @pytest.mark.parametrize(
+        "owner,name,expected",
+        [
+            ("pallets", "click", "r2e-bootstrap-pallets-click"),
+            ("Pallets", "Click", "r2e-bootstrap-pallets-click"),
+            ("huggingface", "trl", "r2e-bootstrap-huggingface-trl"),
+            ("scikit-learn", "scikit-learn", "r2e-bootstrap-scikit-learn-scikit-learn"),
+        ],
+    )
+    def test_basic(self, owner: str, name: str, expected: str) -> None:
+        assert slugify_repo(owner, name) == expected
+
+    def test_collapses_special_chars(self) -> None:
+        out = slugify_repo("a.b_c", "d-e@f")
+        assert _OCI_NAME.match(out)
+        assert "@" not in out
+        # The components are still recognisable
+        assert "a-b-c" in out
+        assert "d-e-f" in out
+
+    def test_custom_prefix(self) -> None:
+        out = slugify_repo("foo", "bar", prefix="custom")
+        assert out == "custom-foo-bar"
+
+    def test_truncates_long_input(self) -> None:
+        long_name = "x" * 200
+        out = slugify_repo("foo", long_name)
+        assert len(out) <= 100
+        assert _OCI_NAME.match(out)
+
+    def test_empty_inputs_raise(self) -> None:
+        with pytest.raises(ValueError):
+            slugify_repo("", "bar")
+        with pytest.raises(ValueError):
+            slugify_repo("foo", "")
+
+
+class TestBuildImageRef:
+    def test_default_ghcr_shape(self) -> None:
+        ref = build_image_ref(
+            registry_prefix="ghcr.io/huggingface",
+            owner="pallets",
+            name="click",
+            commit_sha="a1b2c3d4e5f67890",
+        )
+        assert ref == "ghcr.io/huggingface/r2e-bootstrap-pallets-click:a1b2c3d4e5f6"
+        assert _OCI_TAG.match(ref.rpartition(":")[2])
+
+    def test_with_options_hash(self) -> None:
+        ref = build_image_ref(
+            registry_prefix="ghcr.io/huggingface",
+            owner="pallets",
+            name="click",
+            commit_sha="a1b2c3d4e5f6",
+            options_hash="7d8e9f0123456789",
+        )
+        assert ref.endswith(":a1b2c3d4e5f6-7d8e9f01")
+
+    def test_ecr_private_prefix(self) -> None:
+        ref = build_image_ref(
+            registry_prefix="123456789.dkr.ecr.us-east-1.amazonaws.com/r2e",
+            owner="pallets",
+            name="click",
+            commit_sha="abcdef123456",
+        )
+        assert ref.startswith("123456789.dkr.ecr.us-east-1.amazonaws.com/r2e/")
+
+    def test_localhost_registry(self) -> None:
+        ref = build_image_ref(
+            registry_prefix="localhost:5000",
+            owner="foo",
+            name="bar",
+            commit_sha="0123456789ab",
+        )
+        assert ref.startswith("localhost:5000/")
+
+    def test_truncates_sha_to_12(self) -> None:
+        ref = build_image_ref(
+            registry_prefix="ghcr.io/u",
+            owner="o",
+            name="n",
+            commit_sha="A1B2C3D4E5F60123456789",
+        )
+        # truncated AND lowercased
+        assert ref.endswith(":a1b2c3d4e5f6")
+
+    def test_total_length_bound(self) -> None:
+        ref = build_image_ref(
+            registry_prefix="ghcr.io/very-long-org-name-that-is-still-realistic",
+            owner="x" * 30,
+            name="y" * 30,
+            commit_sha="0123456789abcdef",
+            options_hash="01234567",
+        )
+        assert len(ref) <= 255
+
+    def test_empty_prefix_raises(self) -> None:
+        with pytest.raises(ValueError):
+            build_image_ref(
+                registry_prefix="",
+                owner="foo",
+                name="bar",
+                commit_sha="abc",
+            )
+
+    def test_empty_sha_raises(self) -> None:
+        with pytest.raises(ValueError):
+            build_image_ref(
+                registry_prefix="ghcr.io/u",
+                owner="foo",
+                name="bar",
+                commit_sha="",
+            )
+
+    def test_default_prefix_used(self) -> None:
+        ref = build_image_ref(
+            registry_prefix="ghcr.io/u",
+            owner="foo",
+            name="bar",
+            commit_sha="abc123def456",
+        )
+        assert DEFAULT_BOOTSTRAP_PREFIX in ref
+
+
+class TestSplitRef:
+    def test_round_trip(self) -> None:
+        ref = build_image_ref(
+            registry_prefix="ghcr.io/huggingface",
+            owner="pallets",
+            name="click",
+            commit_sha="a1b2c3d4e5f6",
+        )
+        prefix, image, tag = split_ref(ref)
+        assert prefix == "ghcr.io/huggingface"
+        assert image == "r2e-bootstrap-pallets-click"
+        assert tag == "a1b2c3d4e5f6"
+
+    def test_missing_tag_raises(self) -> None:
+        with pytest.raises(ValueError):
+            split_ref("ghcr.io/foo/bar")
+
+    def test_missing_host_raises(self) -> None:
+        with pytest.raises(ValueError):
+            split_ref("foo:tag")

--- a/tests/registry/test_probe.py
+++ b/tests/registry/test_probe.py
@@ -1,0 +1,405 @@
+"""Tests for `registry.probe` — OCI L1-L4 verification.
+
+We mock the urllib transport via a controllable fake so every protocol
+path is exercised without network access. A separate live test (gated on
+$RUN_LIVE_GHCR / $GHCR_TEST_TOKEN) exists for end-to-end verification.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from repo2rlenv.registry import probe as probe_mod
+from repo2rlenv.registry.auth import (
+    CredentialSource,
+    RegistryAuth,
+    RegistryKind,
+)
+from repo2rlenv.registry.probe import (
+    ProbeResult,
+    _has_push_scope,
+    _parse_bearer_challenge,
+    probe,
+    select_best,
+)
+
+# --------------------------------------------------------------------------
+# Tiny HTTP fake — records calls; emits scripted responses per (method, url).
+# --------------------------------------------------------------------------
+
+
+class _FakeHTTP:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, str], bytes | None]] = []
+        self.script: dict[tuple[str, str], list[tuple[int, dict[str, str], bytes]]] = {}
+
+    def respond(
+        self,
+        method: str,
+        url: str,
+        status: int,
+        headers: dict[str, str] | None = None,
+        body: bytes = b"",
+    ) -> None:
+        """Queue a response. Multiple queued responses for the same key are
+        consumed in order."""
+        self.script.setdefault((method, url), []).append((status, headers or {}, body))
+
+    def __call__(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float = probe_mod.DEFAULT_TIMEOUT_SEC,
+        body: bytes | None = None,
+    ) -> tuple[int, dict[str, str], bytes]:
+        self.calls.append((method, url, headers or {}, body))
+        queue = self.script.get((method, url))
+        if not queue:
+            # Default to 404 when unscripted, with a readable message
+            return (404, {}, f"unscripted: {method} {url}".encode())
+        return queue.pop(0)
+
+
+@pytest.fixture
+def fake_http(monkeypatch: pytest.MonkeyPatch) -> _FakeHTTP:
+    fake = _FakeHTTP()
+    monkeypatch.setattr(probe_mod, "_http_request", fake)
+    return fake
+
+
+# --------------------------------------------------------------------------
+# Header parsing
+# --------------------------------------------------------------------------
+
+
+class TestParseChallenge:
+    def test_ghcr_challenge(self) -> None:
+        out = _parse_bearer_challenge('Bearer realm="https://ghcr.io/token",service="ghcr.io"')
+        assert out == {"realm": "https://ghcr.io/token", "service": "ghcr.io"}
+
+    def test_with_scope(self) -> None:
+        out = _parse_bearer_challenge(
+            'Bearer realm="https://auth.docker.io/token",'
+            'service="registry.docker.io",'
+            'scope="repository:library/alpine:pull"'
+        )
+        assert out is not None
+        assert out["realm"] == "https://auth.docker.io/token"
+        assert out["scope"] == "repository:library/alpine:pull"
+
+    def test_basic_challenge_returns_none(self) -> None:
+        assert _parse_bearer_challenge('Basic realm="registry"') is None
+
+    def test_empty_returns_none(self) -> None:
+        assert _parse_bearer_challenge("") is None
+        assert _parse_bearer_challenge(None) is None  # type: ignore[arg-type]
+
+
+class TestPushScope:
+    def test_pull_push_granted(self) -> None:
+        assert _has_push_scope(["repository:foo/bar:pull,push"]) is True
+
+    def test_pull_only(self) -> None:
+        assert _has_push_scope(["repository:foo/bar:pull"]) is False
+
+    def test_empty(self) -> None:
+        assert _has_push_scope([]) is False
+
+
+# --------------------------------------------------------------------------
+# Full probe scenarios
+# --------------------------------------------------------------------------
+
+
+def _make_auth(host: str = "ghcr.io", kind: RegistryKind = RegistryKind.GHCR) -> RegistryAuth:
+    return RegistryAuth(
+        host=host,
+        kind=kind,
+        cred_source=CredentialSource.INLINE,
+        helper=None,
+    )
+
+
+def _script_happy_path(fake: _FakeHTTP, host: str, namespace: str) -> None:
+    """Convenience: scripted L1-L4 all-pass."""
+    fake.respond(
+        "GET",
+        f"https://{host}/v2/",
+        401,
+        headers={"www-authenticate": f'Bearer realm="https://{host}/token",service="{host}"'},
+    )
+    # L2 token exchange
+    fake.respond(
+        "GET",
+        f"https://{host}/token?service={host}&scope=repository:{namespace}/r2e-bootstrap-probe:pull,push",
+        200,
+        body=json.dumps(
+            {
+                "token": "abc.def.ghi",
+                "scope": f"repository:{namespace}/r2e-bootstrap-probe:pull,push",
+            }
+        ).encode(),
+    )
+    # L3 read
+    fake.respond(
+        "HEAD",
+        f"https://{host}/v2/{namespace}/r2e-bootstrap-probe/manifests/latest",
+        404,
+    )
+    # L4 write — start upload
+    fake.respond(
+        "POST",
+        f"https://{host}/v2/{namespace}/r2e-bootstrap-probe/blobs/uploads/",
+        202,
+        headers={
+            "location": f"/v2/{namespace}/r2e-bootstrap-probe/blobs/uploads/sess-uuid",
+        },
+    )
+    # L4 cancel
+    fake.respond(
+        "DELETE",
+        f"https://{host}/v2/{namespace}/r2e-bootstrap-probe/blobs/uploads/sess-uuid",
+        204,
+    )
+
+
+def _inline_auth_config(tmp_path, monkeypatch, host: str = "ghcr.io") -> None:
+    """Install a fake config.json with inline creds for `host`."""
+    import base64
+
+    cfg = tmp_path / ".docker" / "config.json"
+    cfg.parent.mkdir(parents=True)
+    blob = base64.b64encode(b"user:pass").decode()
+    cfg.write_text(json.dumps({"auths": {host: {"auth": blob}}}))
+    monkeypatch.setenv("DOCKER_CONFIG", str(cfg.parent))
+
+
+class TestProbeHappyPath:
+    def test_ghcr_all_levels_pass(
+        self, fake_http: _FakeHTTP, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _inline_auth_config(tmp_path, monkeypatch)
+        _script_happy_path(fake_http, "ghcr.io", "huggingface")
+        result = probe(_make_auth(), "huggingface")
+        assert result.is_pushable, f"failed: {result}"
+        assert result.reachable
+        assert result.authenticated
+        assert result.can_read
+        assert result.can_write
+        assert result.error is None
+
+
+class TestL1Reachability:
+    def test_dns_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(*args: Any, **kwargs: Any) -> Any:
+            raise probe_mod.ProbeError("network unreachable")
+
+        monkeypatch.setattr(probe_mod, "_http_request", boom)
+        result = probe(_make_auth(), "huggingface", levels=(1,))
+        assert not result.reachable
+        assert "unreachable" in (result.error or "")
+
+    def test_anonymous_local_registry(
+        self, fake_http: _FakeHTTP, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Local registry:2 with no auth → no challenge, no token, but probes pass."""
+        host = "localhost:5000"
+        # L1 — 200, no auth required
+        fake_http.respond("GET", f"http://{host}/v2/", 200, headers={})
+        # L3 — 404 (probe image doesn't exist)
+        fake_http.respond(
+            "HEAD",
+            f"http://{host}/v2/r2e-test/r2e-bootstrap-probe/manifests/latest",
+            404,
+        )
+        # L4 — 202, then DELETE
+        fake_http.respond(
+            "POST",
+            f"http://{host}/v2/r2e-test/r2e-bootstrap-probe/blobs/uploads/",
+            202,
+            headers={"location": "/v2/r2e-test/r2e-bootstrap-probe/blobs/uploads/u1"},
+        )
+        fake_http.respond(
+            "DELETE",
+            f"http://{host}/v2/r2e-test/r2e-bootstrap-probe/blobs/uploads/u1",
+            204,
+        )
+        auth = RegistryAuth(host, RegistryKind.LOCAL, CredentialSource.EMPTY)
+        result = probe(auth, "r2e-test")
+        assert result.is_pushable, result.details
+
+
+class TestL2AuthFailure:
+    def test_expired_token(
+        self, fake_http: _FakeHTTP, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _inline_auth_config(tmp_path, monkeypatch)
+        host = "ghcr.io"
+        fake_http.respond(
+            "GET",
+            f"https://{host}/v2/",
+            401,
+            headers={"www-authenticate": f'Bearer realm="https://{host}/token",service="{host}"'},
+        )
+        fake_http.respond(
+            "GET",
+            f"https://{host}/token?service={host}&scope=repository:huggingface/r2e-bootstrap-probe:pull,push",
+            401,
+        )
+        result = probe(_make_auth(), "huggingface")
+        assert result.reachable is True
+        assert result.authenticated is False
+        assert result.can_read is False
+        assert result.can_write is False
+        # Helper hint should be GHCR-specific
+        assert result.helper_hint and "ghcr" in result.helper_hint.lower()
+
+
+class TestL3ReadDenied:
+    def test_token_works_but_no_read(
+        self, fake_http: _FakeHTTP, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _inline_auth_config(tmp_path, monkeypatch)
+        host = "ghcr.io"
+        ns = "someorg"
+        fake_http.respond(
+            "GET",
+            f"https://{host}/v2/",
+            401,
+            headers={"www-authenticate": f'Bearer realm="https://{host}/token",service="{host}"'},
+        )
+        fake_http.respond(
+            "GET",
+            f"https://{host}/token?service={host}&scope=repository:{ns}/r2e-bootstrap-probe:pull,push",
+            200,
+            body=json.dumps(
+                {"token": "abc", "scope": f"repository:{ns}/r2e-bootstrap-probe:pull,push"}
+            ).encode(),
+        )
+        fake_http.respond(
+            "HEAD",
+            f"https://{host}/v2/{ns}/r2e-bootstrap-probe/manifests/latest",
+            403,
+        )
+        result = probe(_make_auth(), ns)
+        assert result.authenticated is True
+        assert result.can_read is False
+
+
+class TestL4WriteScope:
+    def test_pull_only_token_skips_write_round_trip(
+        self, fake_http: _FakeHTTP, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the token server only grants `pull`, we shouldn't even try L4."""
+        _inline_auth_config(tmp_path, monkeypatch)
+        host = "ghcr.io"
+        ns = "huggingface"
+        fake_http.respond(
+            "GET",
+            f"https://{host}/v2/",
+            401,
+            headers={"www-authenticate": f'Bearer realm="https://{host}/token",service="{host}"'},
+        )
+        # Token granted only `pull`
+        fake_http.respond(
+            "GET",
+            f"https://{host}/token?service={host}&scope=repository:{ns}/r2e-bootstrap-probe:pull,push",
+            200,
+            body=json.dumps(
+                {"token": "abc", "scope": f"repository:{ns}/r2e-bootstrap-probe:pull"}
+            ).encode(),
+        )
+        fake_http.respond(
+            "HEAD",
+            f"https://{host}/v2/{ns}/r2e-bootstrap-probe/manifests/latest",
+            404,
+        )
+        result = probe(_make_auth(), ns)
+        assert result.authenticated is True
+        assert result.can_read is True
+        assert result.can_write is False
+        assert "push" in (result.error or "")
+        # No POST call should have been issued
+        methods = [c[0] for c in fake_http.calls]
+        assert "POST" not in methods
+
+    def test_ecr_repo_not_exist(
+        self, fake_http: _FakeHTTP, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ECR returns 404 on POST when the repo doesn't pre-exist."""
+        _inline_auth_config(tmp_path, monkeypatch, host="123.dkr.ecr.us-east-1.amazonaws.com")
+        host = "123.dkr.ecr.us-east-1.amazonaws.com"
+        ns = "r2e"
+        fake_http.respond(
+            "GET",
+            f"https://{host}/v2/",
+            401,
+            headers={"www-authenticate": f'Bearer realm="https://{host}/token",service="{host}"'},
+        )
+        fake_http.respond(
+            "GET",
+            f"https://{host}/token?service={host}&scope=repository:{ns}/r2e-bootstrap-probe:pull,push",
+            200,
+            body=json.dumps(
+                {"token": "x", "scope": f"repository:{ns}/r2e-bootstrap-probe:pull,push"}
+            ).encode(),
+        )
+        fake_http.respond(
+            "HEAD",
+            f"https://{host}/v2/{ns}/r2e-bootstrap-probe/manifests/latest",
+            404,
+        )
+        fake_http.respond(
+            "POST",
+            f"https://{host}/v2/{ns}/r2e-bootstrap-probe/blobs/uploads/",
+            404,
+        )
+        auth = RegistryAuth(host, RegistryKind.ECR_PRIVATE, CredentialSource.INLINE)
+        result = probe(auth, ns)
+        assert result.authenticated is True
+        assert result.can_read is True
+        assert result.can_write is False
+        assert (
+            "pre-create" in (result.error or "").lower() or "exist" in (result.error or "").lower()
+        )
+
+
+class TestSelectBest:
+    def _make_result(self, kind: RegistryKind, *, pushable: bool = True) -> ProbeResult:
+        return ProbeResult(
+            host=f"{kind.value}.example",
+            kind=kind,
+            namespace="ns",
+            levels_checked=(1, 2, 3, 4),
+            reachable=True,
+            authenticated=True,
+            can_read=pushable,
+            can_write=pushable,
+        )
+
+    def test_prefers_ghcr_over_docker_hub(self) -> None:
+        ghcr = self._make_result(RegistryKind.GHCR)
+        hub = self._make_result(RegistryKind.DOCKER_HUB)
+        best = select_best([hub, ghcr])
+        assert best is ghcr
+
+    def test_filters_non_pushable(self) -> None:
+        ghcr = self._make_result(RegistryKind.GHCR, pushable=False)
+        gar = self._make_result(RegistryKind.GCP_AR)
+        best = select_best([ghcr, gar])
+        assert best is gar
+
+    def test_empty_returns_none(self) -> None:
+        assert select_best([]) is None
+
+    def test_all_non_pushable_returns_none(self) -> None:
+        results = [
+            self._make_result(RegistryKind.GHCR, pushable=False),
+            self._make_result(RegistryKind.DOCKER_HUB, pushable=False),
+        ]
+        assert select_best(results) is None

--- a/tests/registry/test_probe_live.py
+++ b/tests/registry/test_probe_live.py
@@ -1,0 +1,123 @@
+"""Live probe tests against real registries.
+
+These are gated on environment variables and are SKIPPED in normal CI.
+Run manually:
+
+    R2E_LIVE_PROBE_LOCAL=1 pytest tests/registry/test_probe_live.py -k local -v
+    R2E_LIVE_PROBE_GHCR=1 pytest tests/registry/test_probe_live.py -k ghcr -v
+
+The `local` test spins up a `registry:2` container if `docker` is available;
+the `ghcr` test requires a working `gh auth` login with write:packages scope.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import time
+
+import pytest
+
+from repo2rlenv.registry.auth import CredentialSource, RegistryAuth, RegistryKind
+from repo2rlenv.registry.probe import probe
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+def _port_open(host: str, port: int, timeout: float = 0.5) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(
+    not os.environ.get("R2E_LIVE_PROBE_LOCAL"),
+    reason="set R2E_LIVE_PROBE_LOCAL=1 to run; spins up a local registry:2 container",
+)
+@pytest.mark.skipif(not _docker_available(), reason="docker CLI not available")
+class TestProbeLocalRegistry:
+    """End-to-end probe against a real `registry:2` container, no auth."""
+
+    @pytest.fixture(autouse=True)
+    def _registry_container(self) -> None:
+        # Start container
+        port = 5555  # unusual port to avoid collisions
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--rm",
+                "--name",
+                "r2e-probe-test-registry",
+                "-p",
+                f"{port}:5000",
+                "registry:2",
+            ],
+            check=True,
+            capture_output=True,
+            timeout=60,
+        )
+        for _ in range(30):
+            if _port_open("127.0.0.1", port):
+                break
+            time.sleep(0.5)
+        else:  # pragma: no cover
+            pytest.fail("local registry never came up")
+        yield
+        subprocess.run(
+            ["docker", "stop", "r2e-probe-test-registry"],
+            check=False,
+            capture_output=True,
+            timeout=30,
+        )
+
+    def test_all_levels_pass(self) -> None:
+        host = "127.0.0.1:5555"
+        auth = RegistryAuth(host, RegistryKind.LOCAL, CredentialSource.EMPTY)
+        result = probe(auth, "r2e-test")
+        assert result.is_pushable, result
+
+
+@pytest.mark.skipif(
+    not os.environ.get("R2E_LIVE_PROBE_GHCR"),
+    reason="set R2E_LIVE_PROBE_GHCR=1 to run; requires gh auth + docker login ghcr.io",
+)
+class TestProbeGHCR:
+    """End-to-end probe against ghcr.io with the user's actual credentials."""
+
+    def test_probe_resolves_correctly(self) -> None:
+        # Caller is expected to have `docker login ghcr.io` already done;
+        # we just exercise the probe against the live endpoint.
+        from repo2rlenv.registry.auth import discover_logged_in_registries
+
+        ghcr = next(
+            (a for a in discover_logged_in_registries() if a.kind is RegistryKind.GHCR),
+            None,
+        )
+        if ghcr is None:
+            pytest.skip("no ghcr.io login in ~/.docker/config.json")
+
+        # Use the gh CLI username as the namespace (works for any GHCR user).
+        proc = subprocess.run(
+            ["gh", "api", "user", "--jq", ".login"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if proc.returncode != 0:
+            pytest.skip("gh CLI not available")
+        ns = proc.stdout.strip().lower()
+
+        result = probe(ghcr, ns)
+        assert result.reachable, result
+        assert result.authenticated, result
+        # can_read / can_write depend on user's package perms — log only
+        print(f"\nGHCR probe for {ns}: {result}")

--- a/tests/registry/test_push.py
+++ b/tests/registry/test_push.py
@@ -1,0 +1,174 @@
+"""Tests for `registry.push` — docker push subprocess wrapper."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from repo2rlenv.registry import push as push_mod
+from repo2rlenv.registry.push import (
+    PushError,
+    _resolve_repo_digest,
+    manifest_exists,
+    push_image,
+)
+
+
+def _stub_run(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: dict[tuple[str, ...], tuple[int, str, str]],
+) -> list[list[str]]:
+    """Record subprocess.run invocations and return scripted responses.
+
+    `responses` maps (docker, subcommand, ...) prefixes to (returncode, stdout, stderr).
+    The most specific matching prefix wins.
+    """
+    called: list[list[str]] = []
+
+    def fake(args: list[str], **kwargs: Any) -> mock.MagicMock:
+        called.append(args)
+        # Find the longest prefix match
+        match: tuple[int, str, str] | None = None
+        match_len = -1
+        for key, value in responses.items():
+            if len(key) > match_len and tuple(args[: len(key)]) == key:
+                match = value
+                match_len = len(key)
+        if match is None:
+            return mock.MagicMock(returncode=127, stdout="", stderr=f"no script: {args}")
+        rc, stdout, stderr = match
+        return mock.MagicMock(returncode=rc, stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr("subprocess.run", fake)
+    return called
+
+
+class TestManifestExists:
+    def test_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(push_mod, "_docker_available", lambda: True)
+        _stub_run(monkeypatch, {("docker", "manifest", "inspect"): (0, "{}", "")})
+        assert manifest_exists("ghcr.io/foo/bar:tag") is True
+
+    def test_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(push_mod, "_docker_available", lambda: True)
+        _stub_run(monkeypatch, {("docker", "manifest", "inspect"): (1, "", "manifest unknown")})
+        assert manifest_exists("ghcr.io/foo/bar:tag") is False
+
+    def test_no_docker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(push_mod, "_docker_available", lambda: False)
+        assert manifest_exists("ghcr.io/foo/bar:tag") is False
+
+
+class TestResolveRepoDigest:
+    def test_filters_by_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        digests = json.dumps(
+            [
+                "docker.io/foo/bar@sha256:111",
+                "ghcr.io/foo/bar@sha256:222",
+            ]
+        )
+        _stub_run(monkeypatch, {("docker", "image", "inspect"): (0, digests, "")})
+        result = _resolve_repo_digest("ghcr.io/foo/bar:tag")
+        assert result == "ghcr.io/foo/bar@sha256:222"
+
+    def test_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_run(monkeypatch, {("docker", "image", "inspect"): (0, "[]", "")})
+        assert _resolve_repo_digest("ghcr.io/foo/bar:tag") is None
+
+    def test_inspect_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_run(monkeypatch, {("docker", "image", "inspect"): (1, "", "not found")})
+        assert _resolve_repo_digest("ghcr.io/foo/bar:tag") is None
+
+
+class TestPushImage:
+    def test_no_docker_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(push_mod, "_docker_available", lambda: False)
+        with pytest.raises(PushError, match="not available"):
+            push_image("local:tag", "ghcr.io/foo/bar:tag")
+
+    def test_missing_local_image_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(push_mod, "_docker_available", lambda: True)
+        _stub_run(monkeypatch, {("docker", "image", "inspect"): (1, "", "no such image")})
+        with pytest.raises(PushError, match="not found"):
+            push_image("local:tag", "ghcr.io/foo/bar:tag")
+
+    def test_idempotent_skip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Manifest already at registry → skip the push step entirely."""
+        monkeypatch.setattr(push_mod, "_docker_available", lambda: True)
+        digest_json = json.dumps(["ghcr.io/foo/bar@sha256:cafe"])
+        called = _stub_run(
+            monkeypatch,
+            {
+                # image inspect → exists
+                ("docker", "image", "inspect", "local:tag"): (0, "sha256:abc", ""),
+                # manifest exists → 0
+                ("docker", "manifest", "inspect"): (0, "{}", ""),
+                # repo digest lookup
+                ("docker", "image", "inspect", "ghcr.io/foo/bar:tag"): (0, digest_json, ""),
+            },
+        )
+        result = push_image("local:tag", "ghcr.io/foo/bar:tag")
+        assert result.pushed is False
+        assert result.digest == "ghcr.io/foo/bar@sha256:cafe"
+        # No `docker tag` or `docker push` should have been issued
+        cmds = [tuple(c[:2]) for c in called]
+        assert ("docker", "tag") not in cmds
+        assert ("docker", "push") not in cmds
+
+    def test_happy_push(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(push_mod, "_docker_available", lambda: True)
+        digest_json = json.dumps(["ghcr.io/foo/bar@sha256:beef"])
+        called = _stub_run(
+            monkeypatch,
+            {
+                ("docker", "image", "inspect", "local:tag"): (0, "sha256:abc", ""),
+                ("docker", "manifest", "inspect"): (1, "", "no such manifest"),
+                ("docker", "tag"): (0, "", ""),
+                ("docker", "push"): (0, "pushed", ""),
+                ("docker", "image", "inspect", "ghcr.io/foo/bar:tag"): (0, digest_json, ""),
+            },
+        )
+        result = push_image("local:tag", "ghcr.io/foo/bar:tag")
+        assert result.pushed is True
+        assert result.digest == "ghcr.io/foo/bar@sha256:beef"
+        # Verify the sequence: inspect → manifest inspect → tag → push → inspect
+        cmds = [tuple(c[:2]) for c in called]
+        assert cmds[0] == ("docker", "image")
+        assert ("docker", "tag") in cmds
+        assert ("docker", "push") in cmds
+
+    def test_push_failure_surfaces_stderr(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(push_mod, "_docker_available", lambda: True)
+        _stub_run(
+            monkeypatch,
+            {
+                ("docker", "image", "inspect", "local:tag"): (0, "sha256:abc", ""),
+                ("docker", "manifest", "inspect"): (1, "", ""),
+                ("docker", "tag"): (0, "", ""),
+                ("docker", "push"): (1, "", "denied: permission_denied"),
+            },
+        )
+        with pytest.raises(PushError, match="denied"):
+            push_image("local:tag", "ghcr.io/foo/bar:tag")
+
+    def test_skip_if_exists_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When skip_if_exists=False, push proceeds even if manifest is present."""
+        monkeypatch.setattr(push_mod, "_docker_available", lambda: True)
+        digest_json = json.dumps(["ghcr.io/foo/bar@sha256:new"])
+        called = _stub_run(
+            monkeypatch,
+            {
+                ("docker", "image", "inspect", "local:tag"): (0, "sha256:abc", ""),
+                ("docker", "manifest", "inspect"): (0, "{}", ""),  # exists
+                ("docker", "tag"): (0, "", ""),
+                ("docker", "push"): (0, "pushed", ""),
+                ("docker", "image", "inspect", "ghcr.io/foo/bar:tag"): (0, digest_json, ""),
+            },
+        )
+        result = push_image("local:tag", "ghcr.io/foo/bar:tag", skip_if_exists=False)
+        assert result.pushed is True
+        cmds = [tuple(c[:2]) for c in called]
+        assert ("docker", "push") in cmds

--- a/tests/registry/test_push.py
+++ b/tests/registry/test_push.py
@@ -74,6 +74,28 @@ class TestResolveRepoDigest:
         result = _resolve_repo_digest("ghcr.io/foo/bar:tag")
         assert result == "ghcr.io/foo/bar@sha256:222"
 
+    def test_docker_hub_bare_digest(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Docker Hub returns digests without the host prefix; we re-attach it."""
+        digests = json.dumps(
+            [
+                "local/r2e-bootstrap/pallets__click@sha256:abc",  # local, must skip
+                "myuser/r2e-bootstrap-pallets-click@sha256:cafe",  # bare Docker Hub
+            ]
+        )
+        _stub_run(monkeypatch, {("docker", "image", "inspect"): (0, digests, "")})
+        result = _resolve_repo_digest(
+            "index.docker.io/myuser/r2e-bootstrap-pallets-click:fc6c7c47edd6"
+        )
+        # Result MUST carry the canonical host so docker pull resolves it
+        assert result == "index.docker.io/myuser/r2e-bootstrap-pallets-click@sha256:cafe"
+
+    def test_skips_local_digests(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`local/...@sha256:...` entries are NOT pullable — must never be returned."""
+        digests = json.dumps(["local/r2e-bootstrap/pallets__click@sha256:abc"])
+        _stub_run(monkeypatch, {("docker", "image", "inspect"): (0, digests, "")})
+        # Even with no other candidate, we don't return a local-only digest
+        assert _resolve_repo_digest("ghcr.io/foo/bar:tag") is None
+
     def test_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _stub_run(monkeypatch, {("docker", "image", "inspect"): (0, "[]", "")})
         assert _resolve_repo_digest("ghcr.io/foo/bar:tag") is None

--- a/tests/registry/test_repo_creation.py
+++ b/tests/registry/test_repo_creation.py
@@ -1,0 +1,124 @@
+"""Tests for ECR / GAR repository pre-creation helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from repo2rlenv.registry import ecr as ecr_mod
+from repo2rlenv.registry import gar as gar_mod
+from repo2rlenv.registry.ecr import ECRError, _parse_ecr_ref, ensure_ecr_repository
+from repo2rlenv.registry.gar import GARError, _parse_gar_ref, ensure_gar_repository
+
+
+class TestParseEcrRef:
+    def test_private(self) -> None:
+        out = _parse_ecr_ref("123456789.dkr.ecr.us-east-1.amazonaws.com/r2e/foo:tag")
+        assert out == ("us-east-1", "r2e/foo", False)
+
+    def test_public(self) -> None:
+        out = _parse_ecr_ref("public.ecr.aws/myalias/foo:tag")
+        assert out == ("myalias", "foo", True)
+
+    def test_non_ecr_returns_none(self) -> None:
+        assert _parse_ecr_ref("ghcr.io/u/n:tag") is None
+
+    def test_no_path_returns_none(self) -> None:
+        assert _parse_ecr_ref("123.dkr.ecr.eu-west-1.amazonaws.com") is None
+
+
+class TestEnsureEcrRepository:
+    def test_no_aws_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(ecr_mod, "_aws_available", lambda: False)
+        with pytest.raises(ECRError, match="aws CLI not available"):
+            ensure_ecr_repository("123.dkr.ecr.us-east-1.amazonaws.com/r2e:tag")
+
+    def test_already_exists(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(ecr_mod, "_aws_available", lambda: True)
+
+        def fake_run(args: list[str], **kwargs: Any) -> mock.MagicMock:
+            return mock.MagicMock(returncode=0, stdout='{"repositories":[{}]}', stderr="")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        result = ensure_ecr_repository("123.dkr.ecr.us-east-1.amazonaws.com/r2e/foo:tag")
+        assert result.created is False
+        assert result.repo == "r2e/foo"
+        assert result.is_public is False
+
+    def test_creates_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(ecr_mod, "_aws_available", lambda: True)
+        call_count = {"n": 0}
+
+        def fake_run(args: list[str], **kwargs: Any) -> mock.MagicMock:
+            call_count["n"] += 1
+            if "describe-repositories" in args:
+                return mock.MagicMock(
+                    returncode=255, stdout="", stderr="RepositoryNotFoundException"
+                )
+            if "create-repository" in args:
+                return mock.MagicMock(returncode=0, stdout="{}", stderr="")
+            return mock.MagicMock(returncode=127, stdout="", stderr="unscripted")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        result = ensure_ecr_repository("123.dkr.ecr.us-east-1.amazonaws.com/r2e:tag")
+        assert result.created is True
+        assert call_count["n"] == 2  # describe + create
+
+    def test_public_routing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(ecr_mod, "_aws_available", lambda: True)
+        captured: list[list[str]] = []
+
+        def fake_run(args: list[str], **kwargs: Any) -> mock.MagicMock:
+            captured.append(args)
+            return mock.MagicMock(returncode=0, stdout='{"repositories":[{}]}', stderr="")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        ensure_ecr_repository("public.ecr.aws/alias1/foo:tag")
+        # Should use ecr-public subcommand, not ecr
+        assert "ecr-public" in captured[0]
+
+
+class TestParseGarRef:
+    def test_basic(self) -> None:
+        out = _parse_gar_ref("us-central1-docker.pkg.dev/myproj/r2e/img:tag")
+        assert out == ("us-central1", "myproj", "r2e", "img")
+
+    def test_with_digest(self) -> None:
+        out = _parse_gar_ref("asia-southeast1-docker.pkg.dev/p/r/i@sha256:abc")
+        assert out == ("asia-southeast1", "p", "r", "i")
+
+    def test_not_gar_returns_none(self) -> None:
+        assert _parse_gar_ref("ghcr.io/u/n:tag") is None
+
+
+class TestEnsureGarRepository:
+    def test_no_gcloud(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gar_mod, "_gcloud_available", lambda: False)
+        with pytest.raises(GARError, match="gcloud CLI not available"):
+            ensure_gar_repository("us-central1-docker.pkg.dev/p/r/i:tag")
+
+    def test_already_exists(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gar_mod, "_gcloud_available", lambda: True)
+
+        def fake_run(args: list[str], **kwargs: Any) -> mock.MagicMock:
+            return mock.MagicMock(
+                returncode=0, stdout="projects/p/locations/c/repositories/r", stderr=""
+            )
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        result = ensure_gar_repository("us-central1-docker.pkg.dev/p/r/i:tag")
+        assert result.created is False
+
+    def test_creates_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gar_mod, "_gcloud_available", lambda: True)
+
+        def fake_run(args: list[str], **kwargs: Any) -> mock.MagicMock:
+            if "describe" in args:
+                return mock.MagicMock(returncode=1, stdout="", stderr="not found")
+            return mock.MagicMock(returncode=0, stdout="Created.", stderr="")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        result = ensure_gar_repository("us-central1-docker.pkg.dev/p/r/i:tag")
+        assert result.created is True

--- a/tests/registry/test_visibility.py
+++ b/tests/registry/test_visibility.py
@@ -1,0 +1,96 @@
+"""Tests for `registry.visibility` — GHCR package visibility flips."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from repo2rlenv.registry import visibility as vis_mod
+from repo2rlenv.registry.visibility import (
+    _parse_ghcr_package,
+    ensure_ghcr_visibility,
+)
+
+
+class TestParseGhcrPackage:
+    def test_tag_ref(self) -> None:
+        assert _parse_ghcr_package("ghcr.io/huggingface/r2e-bootstrap:tag") == (
+            "huggingface",
+            "r2e-bootstrap",
+        )
+
+    def test_digest_ref(self) -> None:
+        assert _parse_ghcr_package("ghcr.io/u/n@sha256:abc") == ("u", "n")
+
+    def test_not_ghcr_returns_none(self) -> None:
+        assert _parse_ghcr_package("docker.io/u/n:tag") is None
+
+    def test_malformed_returns_none(self) -> None:
+        assert _parse_ghcr_package("ghcr.io/just-one-segment:tag") is None
+
+
+class TestEnsureGhcrVisibility:
+    def test_not_a_ghcr_ref(self) -> None:
+        result = ensure_ghcr_visibility("docker.io/u/n:tag")
+        assert result.success is False
+        assert "not a ghcr.io ref" in (result.error or "")
+
+    def test_no_gh_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(vis_mod, "_gh_available", lambda: False)
+        result = ensure_ghcr_visibility("ghcr.io/u/n:tag")
+        assert result.success is False
+        assert result.manual_url and "github.com" in result.manual_url
+
+    def test_user_namespace_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(vis_mod, "_gh_available", lambda: True)
+        monkeypatch.setattr(vis_mod, "_gh_user", lambda: "alice")
+
+        captured: list[list[str]] = []
+
+        def fake_run(args: list[str], **kwargs: Any) -> mock.MagicMock:
+            captured.append(args)
+            return mock.MagicMock(returncode=0, stdout="{}", stderr="")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        result = ensure_ghcr_visibility("ghcr.io/alice/myimg:tag", target="public")
+        assert result.success
+        # Should hit /user/... endpoint, not /orgs/...
+        assert any("/user/packages/container/myimg" in arg for arg in captured[0])
+        assert any("visibility=public" in arg for arg in captured[0])
+
+    def test_org_namespace_routing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(vis_mod, "_gh_available", lambda: True)
+        monkeypatch.setattr(vis_mod, "_gh_user", lambda: "alice")
+
+        captured: list[list[str]] = []
+
+        def fake_run(args: list[str], **kwargs: Any) -> mock.MagicMock:
+            captured.append(args)
+            return mock.MagicMock(returncode=0, stdout="{}", stderr="")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        result = ensure_ghcr_visibility("ghcr.io/bigorg/myimg:tag")
+        assert result.success
+        assert any("/orgs/bigorg/packages/container/myimg" in arg for arg in captured[0])
+
+    def test_api_failure_includes_message(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(vis_mod, "_gh_available", lambda: True)
+        monkeypatch.setattr(vis_mod, "_gh_user", lambda: "alice")
+
+        def fake_run(args: list[str], **kwargs: Any) -> mock.MagicMock:
+            return mock.MagicMock(
+                returncode=1,
+                stdout="",
+                stderr='{"message": "package not found"}',
+            )
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        result = ensure_ghcr_visibility("ghcr.io/bigorg/myimg:tag")
+        assert result.success is False
+        # Either the parsed message or the raw stderr — both fine
+        assert "package not found" in (result.error or "") or "package not found" in (
+            result.error or ""
+        )
+        assert result.manual_url and "github.com" in result.manual_url

--- a/tests/test_cli_check_auth.py
+++ b/tests/test_cli_check_auth.py
@@ -1,0 +1,141 @@
+"""Smoke test for `repo2rlenv push --check-auth`."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+import pytest
+
+from repo2rlenv import cli as cli_mod
+from repo2rlenv.cli import _run_check_auth
+from repo2rlenv.registry.auth import (
+    CredentialSource,
+    RegistryAuth,
+    RegistryKind,
+)
+from repo2rlenv.registry.probe import ProbeResult
+
+
+def _make_args(**kwargs: Any) -> argparse.Namespace:
+    base = {
+        "check_auth": True,
+        "fast": False,
+        "json": False,
+        "dataset": "testorg/whatever",
+    }
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+class TestCheckAuthJSON:
+    def test_emits_structured_output(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(cli_mod, "_run_check_auth", _run_check_auth)
+        # Stub HF
+        monkeypatch.setattr("repo2rlenv.auth.resolve_hf_token", lambda _a: "fake")
+        # Stub discovery
+        auth = RegistryAuth(
+            host="ghcr.io",
+            kind=RegistryKind.GHCR,
+            cred_source=CredentialSource.INLINE,
+        )
+        monkeypatch.setattr(
+            "repo2rlenv.registry.auth.discover_logged_in_registries",
+            lambda config_path=None: [auth],
+        )
+        # Stub probe
+        pr = ProbeResult(
+            host="ghcr.io",
+            kind=RegistryKind.GHCR,
+            namespace="testorg",
+            levels_checked=(1, 2, 3, 4),
+            reachable=True,
+            authenticated=True,
+            can_read=True,
+            can_write=True,
+            elapsed_sec=0.123,
+        )
+        monkeypatch.setattr("repo2rlenv.registry.probe.probe", lambda *a, **kw: pr)
+
+        rc = _run_check_auth(_make_args(json=True))
+        out = capsys.readouterr().out
+        assert rc == 0
+        data = json.loads(out)
+        assert data["hf_hub"]["logged_in"] is True
+        assert data["registries"][0]["host"] == "ghcr.io"
+        assert data["registries"][0]["is_pushable"] is True
+
+
+class TestCheckAuthHumanOutput:
+    def test_no_creds_warns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("repo2rlenv.auth.resolve_hf_token", lambda _a: None)
+        monkeypatch.setattr(
+            "repo2rlenv.registry.auth.discover_logged_in_registries",
+            lambda config_path=None: [],
+        )
+        rc = _run_check_auth(_make_args(json=False))
+        assert rc == 0
+
+    def test_fast_mode_limits_levels(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("repo2rlenv.auth.resolve_hf_token", lambda _a: "fake")
+        auth = RegistryAuth(
+            host="ghcr.io",
+            kind=RegistryKind.GHCR,
+            cred_source=CredentialSource.INLINE,
+        )
+        monkeypatch.setattr(
+            "repo2rlenv.registry.auth.discover_logged_in_registries",
+            lambda config_path=None: [auth],
+        )
+        captured_levels: list[tuple[int, ...]] = []
+
+        def fake_probe(
+            *args: Any, levels: tuple[int, ...] = (1, 2, 3, 4), **kwargs: Any
+        ) -> ProbeResult:
+            captured_levels.append(levels)
+            return ProbeResult(
+                host="ghcr.io",
+                kind=RegistryKind.GHCR,
+                namespace="testorg",
+                levels_checked=levels,
+                reachable=True,
+                authenticated=True,
+            )
+
+        monkeypatch.setattr("repo2rlenv.registry.probe.probe", fake_probe)
+        rc = _run_check_auth(_make_args(fast=True))
+        assert rc == 0
+        assert captured_levels == [(1, 2)]
+
+
+class TestCmdPushDispatchesCheckAuth:
+    """Verify `cmd_push --check-auth` short-circuits before touching the dataset."""
+
+    def test_check_auth_bypasses_dataset_validation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[bool] = []
+
+        def fake_check(args: argparse.Namespace) -> int:
+            captured.append(True)
+            return 0
+
+        monkeypatch.setattr(cli_mod, "_run_check_auth", fake_check)
+        args = argparse.Namespace(
+            check_auth=True,
+            local_dir="/nonexistent",
+            dataset="",
+            private=False,
+            message=None,
+            image_registry=None,
+            inline_dockerfile=False,
+            require_registry=False,
+            skip_image_push=False,
+            image_visibility="inherit",
+            fast=False,
+            json=False,
+        )
+        rc = cli_mod.cmd_push(args)
+        assert rc == 0
+        assert captured == [True]

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -43,7 +43,7 @@ def test_task_toml_is_valid_toml_with_harbor_layout(tmp_path: Path):
     assert out.name == "demo__repo-1"
     r2e = data["metadata"]["repo2env"]
     assert r2e["pipeline"] == "pr_diff"
-    assert r2e["spec_version"] == "0.1.0"
+    assert r2e["spec_version"] == "0.2.0"
     assert r2e["content_hash"].startswith("sha256:")
     assert "diff_similarity" in r2e["reward_kinds"]
 
@@ -103,3 +103,41 @@ def test_omits_environment_and_test_script_when_absent(tmp_path: Path):
     out = write_harbor_task(task, tmp_path)
     assert not (out / "environment").exists()
     assert not (out / "tests").exists()
+
+
+def test_reproducibility_subtable_seeded_for_runtime_tasks(tmp_path: Path):
+    """v0.8.2.post3: tasks with environment/Dockerfile get the local_only marker."""
+    task = _make_task("rt-task")
+    task.environment_dockerfile = (
+        "FROM local/r2e-bootstrap/pallets__click:a1b2c3d4e5f6\nWORKDIR /workspace\n"
+    )
+    task.test_script = "#!/bin/bash\npytest\n"
+    out = write_harbor_task(task, tmp_path)
+    data = tomllib.loads((out / "task.toml").read_text())
+    repro = data["metadata"]["repo2env"]["reproducibility"]
+    assert repro["mode"] == "local_only"
+    assert repro["image_ref"] == "local/r2e-bootstrap/pallets__click:a1b2c3d4e5f6"
+    assert repro["image_visibility"] == "private"
+
+
+def test_no_reproducibility_subtable_for_lite_tasks(tmp_path: Path):
+    """pr_diff tasks (no environment/) skip the subtable entirely."""
+    task = _make_task("lite-task")
+    out = write_harbor_task(task, tmp_path)
+    data = tomllib.loads((out / "task.toml").read_text())
+    assert "reproducibility" not in data["metadata"]["repo2env"]
+
+
+def test_reproducibility_caller_override_preserved(tmp_path: Path):
+    """If the pipeline pre-populates reproducibility, the emitter doesn't overwrite."""
+    task = _make_task("custom-task")
+    task.environment_dockerfile = "FROM ubuntu\n"
+    task.repo2env["reproducibility"] = {
+        "mode": "registry",
+        "image_ref": "ghcr.io/foo/bar@sha256:abc",
+    }
+    out = write_harbor_task(task, tmp_path)
+    data = tomllib.loads((out / "task.toml").read_text())
+    repro = data["metadata"]["repo2env"]["reproducibility"]
+    assert repro["mode"] == "registry"
+    assert repro["image_ref"] == "ghcr.io/foo/bar@sha256:abc"

--- a/tests/test_hub_metadata_read.py
+++ b/tests/test_hub_metadata_read.py
@@ -1,0 +1,155 @@
+"""C1 fix: push_to_hub reads pipeline + repo_source from task.toml.
+
+Previously, calling push_to_hub via the standalone `repo2rlenv push` CLI
+left the dataset card with empty pipeline + repo_source fields because
+the caller didn't pass them. Now these are auto-read from the first task's
+`[metadata.repo2env]` subtable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from repo2rlenv.hub import _read_task_metadata, push_to_hub
+from repo2rlenv.spec.input import AuthSpec
+
+
+def _make_task(dir_path: Path, *, pipeline: str, repo: str, name: str = "task-1") -> None:
+    """Write a minimal valid task layout into dir_path/<name>/."""
+    task_dir = dir_path / name
+    task_dir.mkdir()
+    (task_dir / "task.toml").write_text(
+        f"""version = "1.0"
+
+[task]
+name = "{name}"
+org = "test"
+description = "test"
+
+[metadata.repo2env]
+spec_version = "0.1.0"
+pipeline = "{pipeline}"
+repo = "{repo}"
+""",
+        encoding="utf-8",
+    )
+    (task_dir / "instruction.md").write_text("test", encoding="utf-8")
+    sol = task_dir / "solution"
+    sol.mkdir()
+    (sol / "patch.diff").write_text("", encoding="utf-8")
+
+
+class TestReadTaskMetadata:
+    def test_basic(self, tmp_path: Path) -> None:
+        _make_task(tmp_path, pipeline="pr_runtime", repo="pallets/click")
+        meta = _read_task_metadata(tmp_path / "task-1" / "task.toml")
+        assert meta["pipeline"] == "pr_runtime"
+        assert meta["repo"] == "pallets/click"
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert _read_task_metadata(tmp_path / "nope.toml") == {}
+
+    def test_malformed_returns_empty(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.toml"
+        f.write_text("not toml at all =", encoding="utf-8")
+        assert _read_task_metadata(f) == {}
+
+    def test_missing_subtable_returns_empty(self, tmp_path: Path) -> None:
+        f = tmp_path / "no_r2e.toml"
+        f.write_text('version = "1.0"\n[task]\nname = "x"\n', encoding="utf-8")
+        assert _read_task_metadata(f) == {}
+
+
+class TestPushAutoReadsMetadata:
+    """C1 fix verification — `cmd_push`'s no-kwargs invocation works."""
+
+    def _mock_hf_api(self) -> mock.MagicMock:
+        api = mock.MagicMock()
+        api.create_repo.return_value = None
+        upload_op = mock.MagicMock()
+        upload_op.oid = "abcdef123"
+        api.upload_folder.return_value = upload_op
+        api.upload_file.return_value = None
+        return api
+
+    def test_pipeline_and_repo_read_from_task(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _make_task(tmp_path, pipeline="pr_runtime", repo="pallets/click")
+        monkeypatch.setattr("repo2rlenv.hub.resolve_hf_token", lambda _auth: "fake-token")
+
+        captured_card: dict[str, str] = {}
+
+        def fake_build_card(**kwargs: str) -> str:
+            captured_card.update(kwargs)
+            return "fake-card"
+
+        monkeypatch.setattr("repo2rlenv.hub._build_dataset_card", fake_build_card)
+        api = self._mock_hf_api()
+        monkeypatch.setattr("huggingface_hub.HfApi", lambda token=None: api)
+
+        # Note: NO pipeline / repo_source kwargs — mimics standalone cmd_push
+        result = push_to_hub(tmp_path, "owner/click-r2e", AuthSpec())
+
+        assert result.task_count == 1
+        assert captured_card["pipeline"] == "pr_runtime"
+        assert captured_card["repo_source"] == "pallets/click"
+
+    def test_caller_override_wins(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Legacy callers passing pipeline explicitly should still control the card."""
+        _make_task(tmp_path, pipeline="pr_runtime", repo="pallets/click")
+        monkeypatch.setattr("repo2rlenv.hub.resolve_hf_token", lambda _auth: "fake-token")
+
+        captured_card: dict[str, str] = {}
+
+        def fake_build_card(**kwargs: str) -> str:
+            captured_card.update(kwargs)
+            return "fake-card"
+
+        monkeypatch.setattr("repo2rlenv.hub._build_dataset_card", fake_build_card)
+        api = self._mock_hf_api()
+        monkeypatch.setattr("huggingface_hub.HfApi", lambda token=None: api)
+
+        push_to_hub(
+            tmp_path,
+            "owner/click-r2e",
+            AuthSpec(),
+            pipeline="custom_pipeline",
+            repo_source="custom/source",
+        )
+        assert captured_card["pipeline"] == "custom_pipeline"
+        assert captured_card["repo_source"] == "custom/source"
+
+    def test_falls_back_to_default_for_missing_metadata(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A pre-v0.8.2.post3 dataset without [metadata.repo2env] still pushes."""
+        # Hand-roll a task without the subtable
+        (tmp_path / "task-1").mkdir()
+        (tmp_path / "task-1" / "task.toml").write_text(
+            'version = "1.0"\n[task]\nname = "task-1"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("repo2rlenv.hub.resolve_hf_token", lambda _auth: "fake-token")
+        captured: dict[str, str] = {}
+        monkeypatch.setattr(
+            "repo2rlenv.hub._build_dataset_card",
+            lambda **kw: captured.update(kw) or "x",
+        )
+        api = self._mock_hf_api()
+        monkeypatch.setattr("huggingface_hub.HfApi", lambda token=None: api)
+        push_to_hub(tmp_path, "owner/legacy", AuthSpec())
+        # Falls back to "pr_diff" default and empty repo_source
+        assert captured["pipeline"] == "pr_diff"
+        assert captured["repo_source"] == ""

--- a/uv.lock
+++ b/uv.lock
@@ -1249,7 +1249,7 @@ wheels = [
 
 [[package]]
 name = "repo2rlenv"
-version = "0.8.2"
+version = "0.8.2.post3"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
Closes #27.

## Summary

Sandbox-required datasets (`pr_runtime`, `mutation_bugs`, `code_instruct`, `cve_patches`, `equivalence_tests`, `refactor_synthesis`, `commit_runtime`) are now reproducible end-to-end by any consumer who pulls them from HF Hub.

Before: `environment/Dockerfile` shipped with `FROM local/r2e-bootstrap/...` — un-pullable from any other machine. The Hub dataset looked correct on paper but failed at `harbor run` time on a fresh machine.

After: `repo2rlenv push`:
1. **Discovers** registry credentials in `~/.docker/config.json` (GHCR / ECR Private+Public / ACR / GCP AR / Docker Hub / local).
2. **Verifies** them via OCI Distribution Spec **L1-L4 probes** (reachability → auth → read → write) without pushing anything.
3. **Pushes** the bootstrap image to the first verified registry, rewriting each task's `environment/Dockerfile` + `task.toml` in-place to point at the registry digest.
4. **Falls back to inline-Dockerfile mode** when no verified registry is available — bakes the bootstrap's reconstructed Dockerfile into each task and records `fallback_reason`. Pass `--require-registry` to hard-fail instead.

Full design rationale in `plans/v0.8.2.post3_image_distribution.md`.

## What changed

### New `src/repo2rlenv/registry/` subpackage

| Module | Purpose |
|---|---|
| `auth.py` | File-level discovery from `~/.docker/config.json`; handles `credHelpers`, `credsStore`, Desktop's empty-`{}` signal, legacy `v1/` Docker Hub URL |
| `probe.py` | OCI L1-L4 verification protocol (stdlib `urllib`, no new deps) |
| `push.py` | `docker push` subprocess wrapper + `RepoDigests` extraction; idempotent re-push via `docker manifest inspect` |
| `visibility.py` | GHCR `PATCH /user\|orgs/packages/container/<n>` via `gh` CLI |
| `ecr.py`, `gar.py` | Pre-create the repository before push (ECR / GCP AR require this; GHCR / ACR / Docker Hub don't) |
| `naming.py` | Slug + tag construction; reuses `bootstrap.cache._options_hash` so re-pushes hash identically |
| `integration.py` | The discover → verify → select → push → rewrite orchestrator called from `hub.push_to_hub` |

### Spec change: `[metadata.repo2env.spec_version]` 0.1.0 → 0.2.0

Additive — old readers ignore the new subtable, pre-v0.2 datasets still validate. New required field on sandbox-required tasks:

```toml
[metadata.repo2env.reproducibility]
mode = "registry"                                    # registry | inline_dockerfile | local_only
image_ref = "ghcr.io/<org>/r2e-bootstrap-<repo>@sha256:..."
image_tag = "ghcr.io/<org>/r2e-bootstrap-<repo>:a1b2c3d4e5f6-7d8e9f01"
image_visibility = "public"                          # public | private | unknown
pushed_at = "2026-05-19T11:30:00Z"
pushed_by = "<owner>"
# Inline-mode-only fields:
# inline_recipe_sha256, inline_recipe_lines, inline_recipe_source, fallback_reason
```

### New CLI surface

```bash
# Default: auto-detect + verify + push (or fall back to inline with warning)
repo2rlenv push ./datasets/mydataset owner/mydataset

# Force a specific registry
repo2rlenv push ... --image-registry ghcr.io/myorg

# Inline-recipe mode — no registry needed
repo2rlenv push ... --inline-dockerfile

# CI / launch: refuse to fall back silently
repo2rlenv push ... --require-registry

# Diagnose credentials without doing anything
repo2rlenv push --check-auth                # full L1-L4
repo2rlenv push --check-auth --fast         # stop at L2
repo2rlenv push --check-auth --json         # for CI assertions
```

### Bug fix (C1)

`cmd_push` previously didn't pass `pipeline` / `repo_source` to `push_to_hub`, so standalone `repo2rlenv push` produced a README with empty source-repo + pipeline fields. Now read from the first task's `[metadata.repo2env]` automatically.

## Commits

| # | Commit | What |
|---|---|---|
| M1 | 3649d84 | `registry/{auth,naming}.py` — pure code, 45 unit tests |
| M2 | 2138387 | `registry/probe.py` — OCI L1-L4, 18 unit tests + 2 gated live tests |
| M3 | 6bca952 | `cmd_push` C1 fix — 7 tests |
| M4 | 53c640e | `registry/{push,visibility,ecr,gar}.py` — 28 tests |
| M5+M6 | 5fa80b7 | `registry/integration.py` orchestrator + inline auto-fallback — 14 tests |
| M7 | 54a7cc7 | CLI flags + `--check-auth` — 4 tests |
| M8 | 5600010 | Emitter: spec_version 0.2.0 + reproducibility seed — 3 tests |
| M9 | 153e309 | Docs (SPEC + new `REGISTRY_AUTH.md` + release notes) + version bump |
| chore | 97a0619 | uv.lock sync |

**127 new tests; 614/614 total green; ruff + format clean.**

## Test plan

- [x] `pytest -q --ignore=tests/registry/test_probe_live.py` → 614/614 pass
- [x] `ruff check src/ tests/` → clean
- [x] `ruff format --check src/ tests/` → clean
- [x] `repo2rlenv push --help` shows all new flags
- [x] Build sanity: `uv run python -c "from repo2rlenv import __version__; print(__version__)"` → `0.8.2.post3`
- [ ] **Live GHCR end-to-end** (gated on `R2E_LIVE_PROBE_GHCR=1`, manual): push `pallets/click` dataset → pull on fresh machine → `harbor run` → reward 1.000
- [ ] **Local `registry:2` end-to-end** (gated on `R2E_LIVE_PROBE_LOCAL=1`, manual): same flow against a containerized OCI registry
- [ ] **Inline auto-fallback**: `docker logout ghcr.io && repo2rlenv push ...` → verify fallback warning + `fallback_reason` recorded in task.toml
- [ ] **`--require-registry`** with no auth → hard fail with option chooser

## Out of scope (deferred)

Multi-arch images, image squashing / size reduction, cosign signing, HF Hub as native OCI registry, retroactive rewrite of pre-v0.2 datasets via a hypothetical `--rewrite-only` flag.

## Migration

Datasets pushed with v0.8.2.post2 or earlier have un-pullable `FROM` references. They won't break the CLI (`validate` still passes), but `harbor run` will fail on a fresh machine. Re-push to upgrade:

```bash
repo2rlenv pull <old-dataset>
repo2rlenv push ./datasets/<old-dataset> <hf-target>
```

The pulled dataset re-emerges with `mode = "local_only"` plus a still-local `FROM` ref; re-pushing rewrites everything to registry / inline mode.