### PR TITLE
v083 Arc 2 (WIP): pr_runtime F2P-relax + sweep harness fix

### DIFF
--- a/docs/release_notes/v0.8.3/findings-pr_runtime.md
+++ b/docs/release_notes/v0.8.3/findings-pr_runtime.md
@@ -1,0 +1,93 @@
+# Arc 2 — `pr_runtime` sweep findings
+
+**Scope.** SWE-bench-style PR mining with sandbox-verified F2P/P2P sets.
+This arc lands the **optimization + harness bugfix**; the full 38-repo
+sweep is deferred until the user signs off on the Docker / LLM cost
+envelope (plan §6: ~$80-250).
+
+## Optimization landed: opt-in F2P filter relaxation
+
+Plan §4 Arc 2 known issue (b): ~17-27% of candidates drop on
+`no_fail_to_pass` because the PR's test_patch added or modified tests
+that already passed before the fix landed. These PRs are real production
+bug fixes — they merged for a reason — but their test coverage doesn't
+follow the strict "this test fails on base, passes after patch" SWE-bench
+shape.
+
+**Fix.** Add `PRRuntimeOptions.allow_no_f2p_with_test_patch` (default
+`False` — preserves the strict v0.8.1 behavior). When set via
+`--pipeline-opt allow_no_f2p_with_test_patch=true`, the pipeline accepts
+candidates with empty F2P **iff** the test_patch is non-empty AND the
+P2P set has at least one entry. The verifier still gates on post-patch
+behavior, so a no-op model patch would have to pass the modified tests too.
+
+The decision now lives in a pure helper, `_should_skip_no_f2p`, with 6 new
+unit tests covering the strict path + each relaxation guard.
+
+## Harness fix: don't fail cells that emit 0 tasks
+
+The smoke surfaced a separate, important issue in the sweep driver:
+`repo2rlenv generate` exits 1 when `emitted=0` (see `cli.py:275`).
+For `pr_runtime` that is a normal filter outcome — many PRs are
+correctly skipped on `no_test_patch` / `no_fail_to_pass`. The sweep
+was misreading that as a cell failure.
+
+Fix in `scripts/v083/sweep.py`: when the subprocess exits non-zero AND
+the `out_dir` was created AND no task directories landed, treat the
+cell as `done` with `candidates=0`. True crashes (out_dir missing) still
+land as `step=failed`. 3 new unit tests on the option parser, suite at
+**658 passing**.
+
+Also exposed `--pipeline-opt KEY=VALUE` on `sweep.py` so per-arc options
+(`allow_no_f2p_with_test_patch=true`, `limit=...`, etc.) can be passed
+without editing the script.
+
+## Smoke evidence (limited)
+
+| Sweep | Repos | envs/cell | Outcome |
+|---|---|---|---|
+| #1 (pre-harness-fix) | pallets/click | 2 | sweep reported `step=failed` because of the `emitted=0 → exit 1` issue; pipeline itself worked (2 candidates, both filtered). Surfaced the harness bug. |
+| #2 (direct, with flag) | pallets/click | 3 | 3 PRs: 2 `no_test_patch`, 1 `no_fail_to_pass` (P2P also 0 — relaxation correctly didn't rescue) |
+| #3 (post-fix, with flag) | pallets/click, pallets/werkzeug | 5 each | 2/2 cells `step=done`, 0 candidates emitted, $0 cost. Harness fix verified. |
+
+The 10 most-recent PRs in `pallets/click + pallets/werkzeug` happen to
+not include any that match the relaxation pattern (F2P=0 +
+test_patch≠"" + P2P≥1). To exercise the relaxation rescue path requires
+either historical PRs (set `--pipeline-opt since=2024-01-01`) or
+higher-activity repos like `pydantic/pydantic` or `psf/requests`. Both
+are deferred to the full sweep.
+
+## Acceptance criteria check (this PR)
+
+| Gate | Target | Actual | Pass? |
+|---|---|---|---|
+| ≥ 1 optimization landed | yes | F2P-relax flag + `_should_skip_no_f2p` helper + 6 tests | ✓ |
+| ≥ 1 harness bugfix from sweep | — | exit-code-1-with-emitted-0 → `done` not `failed`; `--pipeline-opt` plumbed | ✓ |
+| Existing tests stay green | 100% | **658/658** + 2 skipped | ✓ |
+| Lint + format | clean | clean | ✓ |
+| Smoke against ≥ 1 cached-bootstrap repo | yes | pallets/click + pallets/werkzeug | ✓ |
+| Full 38-repo sweep | yes | **deferred — pending user OK on cost** | — |
+| HF dataset published | yes | **deferred — once full sweep lands** | — |
+
+## What's pending for full completion of this arc
+
+1. **Full sweep across all 38 repos** — should produce ~75-85 verified
+   envs per plan §0. Cost envelope per plan §6: ~$80-250 (bootstrap
+   LLM for any uncached repo + T2 Haiku + optional T4 Sonnet). Wall
+   time: 6-12 h.
+2. **HF push** to `AdithyaSK/repo2rlenv-v083-pr_runtime` once the
+   verified set is ready.
+3. **Findings update** with concrete T2/T3 numbers + the
+   optimization-impact diff (candidate yield with
+   `allow_no_f2p_with_test_patch=true` vs `False`).
+4. **Per-language log-parser polish** for Tier C Go/Rust/Node/TS repos —
+   listed as the secondary optimization in the plan. Deferred to the
+   full-sweep iteration since we need real failure modes from Tier C
+   cells to prioritize parser changes.
+
+## Out of scope for this arc (deferred to v0.9)
+
+- LLM-judged QA gate (SWE-Bench++ recipe).
+- Per-PR test-cmd normalization edge cases beyond what #23 already shipped.
+- Targeted-test command building improvements for unusual `pytest`
+  invocation patterns.

--- a/scripts/v083/sweep.py
+++ b/scripts/v083/sweep.py
@@ -391,15 +391,25 @@ def run_cell(inputs: CellInputs) -> CellState:
         out_dir=out_dir,
         extra_pipeline_opts=inputs.extra_pipeline_opts,
     )
-    if not ok:
-        state.step = "failed"
-        state.last_error = f"generate: {err}"
-        return state
-
     if out_dir.exists():
         state.candidates = sum(
             1 for p in out_dir.iterdir() if p.is_dir() and (p / "task.toml").exists()
         )
+
+    # `repo2rlenv generate` exits 1 when emitted == 0 — that's a normal
+    # outcome of filters (all candidates failed F2P / no_test_patch / etc.),
+    # not a harness failure. Only treat the cell as failed if generation
+    # crashed before producing any output AND no candidates landed on disk.
+    if not ok and state.candidates == 0:
+        # Did the out_dir get created at all? If yes, generate ran to
+        # completion and just emitted nothing — treat as `done`.
+        if out_dir.exists():
+            state.step = "done"
+            state.last_error = "generate emitted 0 candidates"
+            return state
+        state.step = "failed"
+        state.last_error = f"generate: {err}"
+        return state
 
     if state.candidates == 0:
         state.step = "done"  # zero candidates is not a harness failure
@@ -495,6 +505,7 @@ def run_sweep(
     concurrency: int,
     repo_filter: list[str] | None,
     hard_stop_usd: float,
+    extra_pipeline_opts: dict[str, Any] | None = None,
 ) -> SweepState:
     """Run all (pipeline, repo) cells for one pipeline arc.
 
@@ -529,6 +540,7 @@ def run_sweep(
                 rubric_model=rubric_model,
                 out_root=out_root,
                 skip_t4=skip_t4 or pipeline in TEXT_ONLY,
+                extra_pipeline_opts=dict(extra_pipeline_opts or {}),
             )
         )
 
@@ -617,7 +629,25 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=1500.0,
         help="abort sweep if total cost reaches this (default: 1500)",
     )
+    p.add_argument(
+        "--pipeline-opt",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="extra pipeline option forwarded to `repo2rlenv generate --pipeline-opt`; "
+        "repeat for multiple options (e.g. `--pipeline-opt allow_no_f2p_with_test_patch=true`)",
+    )
     return p.parse_args(argv)
+
+
+def _parse_extra_opts(items: list[str]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for item in items or []:
+        if "=" not in item:
+            raise SystemExit(f"--pipeline-opt expects KEY=VALUE, got {item!r}")
+        k, v = item.split("=", 1)
+        out[k] = v
+    return out
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -645,6 +675,7 @@ def main(argv: list[str] | None = None) -> int:
         concurrency=args.concurrency,
         repo_filter=args.repos,
         hard_stop_usd=args.hard_stop_usd,
+        extra_pipeline_opts=_parse_extra_opts(args.pipeline_opt),
     )
 
     done = sum(1 for c in state.cells.values() if c.step == "done")

--- a/src/repo2rlenv/pipelines/pr_runtime.py
+++ b/src/repo2rlenv/pipelines/pr_runtime.py
@@ -487,6 +487,36 @@ def targeted_test_cmds_for_pr(test_cmds: list[str], test_files: list[str]) -> li
     return out
 
 
+def _should_skip_no_f2p(
+    *,
+    require_fail_to_pass: bool,
+    min_fail_to_pass: int,
+    allow_no_f2p_with_test_patch: bool,
+    fail_to_pass: list[str],
+    pass_to_pass: list[str],
+    test_patch: str,
+) -> bool:
+    """Return True iff the candidate should be skipped for low F2P signal.
+
+    The default (v0.8.1+) behavior: skip when ``require_fail_to_pass`` is True
+    AND the F2P set is below ``min_fail_to_pass``.
+
+    The v0.8.3 relaxation: when ``allow_no_f2p_with_test_patch`` is True AND
+    the PR's test_patch is non-empty AND the P2P set has at least one entry,
+    accept the candidate even with F2P=0. Reasoning: the PR exercised some
+    test surface, and the verifier still gates on the post-patch behavior
+    of those tests. Tradeoff: a no-op patch could pass — only opt in when
+    you've inspected the candidate quality.
+    """
+    if not require_fail_to_pass:
+        return False
+    if len(fail_to_pass) >= min_fail_to_pass:
+        return False
+    # F2P is below the bar — does the relaxation save the candidate?
+    relaxed = allow_no_f2p_with_test_patch and bool(test_patch.strip()) and len(pass_to_pass) >= 1
+    return not relaxed
+
+
 class PRRuntimePipeline:
     """Sandbox-verified PR mining. Implements the `Pipeline` Protocol."""
 
@@ -623,9 +653,13 @@ class PRRuntimePipeline:
                     fail_to_pass = outcome.fail_to_pass
                     pass_to_pass = outcome.pass_to_pass
                     validation_status = outcome.status
-                    if (
-                        self.options.require_fail_to_pass
-                        and len(fail_to_pass) < self.options.min_fail_to_pass
+                    if _should_skip_no_f2p(
+                        require_fail_to_pass=self.options.require_fail_to_pass,
+                        min_fail_to_pass=self.options.min_fail_to_pass,
+                        allow_no_f2p_with_test_patch=self.options.allow_no_f2p_with_test_patch,
+                        fail_to_pass=fail_to_pass,
+                        pass_to_pass=pass_to_pass,
+                        test_patch=test_patch,
                     ):
                         skip_reasons["no_fail_to_pass"] = skip_reasons.get("no_fail_to_pass", 0) + 1
                         self._emit_progress(pr_label, "skip", outcome.reason or "no_fail_to_pass")

--- a/src/repo2rlenv/spec/options.py
+++ b/src/repo2rlenv/spec/options.py
@@ -35,6 +35,13 @@ class PRRuntimeOptions(_BaseOptions):
     # --- Validation ---
     require_fail_to_pass: bool = True  # skip PRs whose F2P set is empty after validation
     min_fail_to_pass: int = 1
+    # When True AND `require_fail_to_pass` is True AND F2P=0, accept the
+    # candidate anyway IF the PR has a non-empty test_patch and a non-empty
+    # P2P set. Reasoning: the PR did exercise some test surface; the verifier
+    # will still gate on the post-patch behavior of those tests. Tradeoff:
+    # the agent could submit a no-op patch and the test would still pass —
+    # so only enable for arcs where you've inspected the candidate quality.
+    allow_no_f2p_with_test_patch: bool = False
     validation_timeout_sec: int = 600  # per-PR cap on the two test runs
     skip_validation: bool = False  # emit candidates without F2P/P2P (debug / fast iteration)
 

--- a/tests/scripts/test_v083_harness.py
+++ b/tests/scripts/test_v083_harness.py
@@ -93,6 +93,27 @@ def test_build_cells_filters_by_repos_arg() -> None:
     assert only_click[0]["repo"] == "pallets/click"
 
 
+def test_parse_extra_opts() -> None:
+    """`--pipeline-opt KEY=VALUE` parser: round-trip basic shapes."""
+    out = sweep._parse_extra_opts(
+        ["limit=10", "allow_no_f2p_with_test_patch=true", "since=2025-01-01"]
+    )
+    assert out == {
+        "limit": "10",
+        "allow_no_f2p_with_test_patch": "true",
+        "since": "2025-01-01",
+    }
+
+
+def test_parse_extra_opts_rejects_bare_keys() -> None:
+    with pytest.raises(SystemExit):
+        sweep._parse_extra_opts(["limit"])
+
+
+def test_parse_extra_opts_empty_list() -> None:
+    assert sweep._parse_extra_opts([]) == {}
+
+
 # ---------------------------------------------------------------------------
 # SweepState persistence
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline_pr_runtime.py
+++ b/tests/test_pipeline_pr_runtime.py
@@ -18,6 +18,7 @@ from repo2rlenv.pipelines.pr_runtime import (
     _count_new_test_funcs,
     _files_in_patch,
     _path_is_test,
+    _should_skip_no_f2p,
     build_environment_dockerfile,
     build_eval_script,
     normalize_test_cmds_for_runtime,
@@ -489,3 +490,77 @@ def test_pr_runtime_rejects_missing_bootstrap():
     options = PRRuntimeOptions()
     with pytest.raises(RuntimeError, match="requires a BootstrapResult"):
         PRRuntimePipeline(gen_input, options, bootstrap=None)
+
+
+# --- F2P gate (v0.8.3 Arc 2 optimization) -----------------------------------
+
+
+def test_should_skip_no_f2p_default_strict() -> None:
+    """When `require_fail_to_pass=True` and F2P=0, default behavior skips."""
+    assert _should_skip_no_f2p(
+        require_fail_to_pass=True,
+        min_fail_to_pass=1,
+        allow_no_f2p_with_test_patch=False,
+        fail_to_pass=[],
+        pass_to_pass=["test_a"],
+        test_patch="--- a/tests/x.py\n+++ b/tests/x.py\n@@\n+def test_y(): pass\n",
+    )
+
+
+def test_should_skip_no_f2p_passes_when_f2p_meets_bar() -> None:
+    assert not _should_skip_no_f2p(
+        require_fail_to_pass=True,
+        min_fail_to_pass=1,
+        allow_no_f2p_with_test_patch=False,
+        fail_to_pass=["test_a"],
+        pass_to_pass=[],
+        test_patch="",
+    )
+
+
+def test_should_skip_no_f2p_passes_when_require_off() -> None:
+    """If the user opts out of F2P requirement, never skip on F2P grounds."""
+    assert not _should_skip_no_f2p(
+        require_fail_to_pass=False,
+        min_fail_to_pass=1,
+        allow_no_f2p_with_test_patch=False,
+        fail_to_pass=[],
+        pass_to_pass=[],
+        test_patch="",
+    )
+
+
+def test_relaxation_accepts_when_test_patch_and_p2p_present() -> None:
+    """F2P=0 + relaxation on + test_patch present + P2P>=1 → accept."""
+    assert not _should_skip_no_f2p(
+        require_fail_to_pass=True,
+        min_fail_to_pass=1,
+        allow_no_f2p_with_test_patch=True,
+        fail_to_pass=[],
+        pass_to_pass=["test_x"],
+        test_patch="--- a/tests/x.py\n+++ b/tests/x.py\n@@\n+def test_new(): pass\n",
+    )
+
+
+def test_relaxation_skips_when_no_test_patch() -> None:
+    """Relaxation does NOT save the candidate if test_patch is empty."""
+    assert _should_skip_no_f2p(
+        require_fail_to_pass=True,
+        min_fail_to_pass=1,
+        allow_no_f2p_with_test_patch=True,
+        fail_to_pass=[],
+        pass_to_pass=["test_x"],
+        test_patch="",
+    )
+
+
+def test_relaxation_skips_when_no_p2p() -> None:
+    """Without at least one passing test the verifier has nothing to gate on."""
+    assert _should_skip_no_f2p(
+        require_fail_to_pass=True,
+        min_fail_to_pass=1,
+        allow_no_f2p_with_test_patch=True,
+        fail_to_pass=[],
+        pass_to_pass=[],
+        test_patch="--- a/tests/x.py\n+++ b/tests/x.py\n@@\n+def test_new(): pass\n",
+    )


### PR DESCRIPTION
## Arc 2 — pr_runtime (work in progress)

Per plan §4 Arc 2. Stacked on #31 (Arc 1 pr_diff) which is stacked on #30 (sweep harness).

**This PR lands the optimization + tests; the full 38-repo sweep is deferred until cost approval.** See the [findings doc](../blob/v083-arc2-pr_runtime/docs/release_notes/v0.8.3/findings-pr_runtime.md) for full context.

## Summary

### Optimization — opt-in F2P filter relaxation

Plan §4 Arc 2 known issue: ~17-27% of candidates drop on `no_fail_to_pass` because the PR's test patch added or modified tests that already passed before the fix landed. These are real production bug fixes whose test coverage doesn't follow the strict SWE-bench shape.

- Add `PRRuntimeOptions.allow_no_f2p_with_test_patch: bool = False`.
  When set via `--pipeline-opt allow_no_f2p_with_test_patch=true`, the pipeline accepts F2P=0 candidates **iff** the test_patch is non-empty AND the P2P set has ≥1 entry.
- Decision lives in a pure helper `_should_skip_no_f2p` for testability.
- 6 new unit tests in `tests/test_pipeline_pr_runtime.py` covering the strict path + each relaxation guard.

### Harness bugfix — discovered by the smoke

Smoke surfaced that \`repo2rlenv generate\` exits 1 when emitted=0 (cli.py:275). For pr_runtime that's a normal filter outcome — the sweep was misreading it as a cell failure.

- `scripts/v083/sweep.py` now treats \"exit non-zero + out_dir exists + no task dirs\" as `step=done, candidates=0`. True crashes (out_dir missing) still land as `failed`.
- Also wires \`--pipeline-opt KEY=VALUE\` through the sweep CLI so arc-specific options flow without code edits.
- 3 new unit tests for the option parser; suite at **658 passing**.

## Smoke evidence (limited)

| Sweep | Repos | envs/cell | Outcome |
|---|---|---|---|
| #1 | pallets/click | 2 | sweep reported `step=failed` because of the exit-code issue; pipeline itself worked. Surfaced the harness bug. |
| #2 | pallets/click | 3 | 3 PRs: 2 `no_test_patch`, 1 `no_fail_to_pass` (P2P=0 → relaxation correctly didn't rescue) |
| #3 | pallets/click + pallets/werkzeug | 5 each | 2/2 cells **step=done**, 0 emitted, \$0 cost. Harness fix verified. |

The 10 most-recent PRs in click+werkzeug happen to not include any matching the relaxation pattern. To exercise the rescue path requires historical PRs (`--pipeline-opt since=2024-01-01`) or higher-activity repos like `pydantic/pydantic` or `psf/requests` — deferred to the full sweep.

## What's pending for full Arc 2 completion

1. **Full 38-repo sweep** — should yield ~75-85 verified envs. Cost envelope: ~\$80-250 (bootstrap LLM + T2 Haiku + optional T4 Sonnet). Wall time: 6-12 h.
2. **HF push** to `AdithyaSK/repo2rlenv-v083-pr_runtime`.
3. **Findings update** with concrete T3 yield + relaxation-impact delta.
4. **Per-language log-parser polish** for Tier C — deferred until we see real Tier C failure modes from the full sweep.

## Test plan
- [x] `uv run pytest -q` — 658 passing, 2 skipped (+6 new F2P-gate tests, +3 new option-parser tests)
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean
- [x] Smoke: `sweep.py --pipeline pr_runtime --repos pallets/click pallets/werkzeug --pipeline-opt allow_no_f2p_with_test_patch=true` → 2/2 cells `step=done`
- [ ] Full 38-repo sweep — **pending user OK on cost**
- [ ] HF push — pending sweep
- [ ] Consumer-side `harbor run --agent oracle` smoke on a random task — pending sweep

## Out of scope
- LLM-judged QA gate (deferred to v0.9 per plan §11).
- Per-PR test-cmd normalization edge cases beyond what #23 already shipped.
- T4 Sonnet agent eval — covered separately once T3 yield lands.

## Notes for reviewer
- Stacked on #31 → #30. When upstream PRs merge, GitHub auto-rebases this base.
- No `pyproject.toml` bump (stays at `0.8.2.post3` per plan §5).
- No `Co-Authored-By` trailer.