### PR TITLE
v083 Arc 3 (WIP): commit_runtime bot/chore filters + F2P inherit

### DIFF
--- a/docs/release_notes/v0.8.3/findings-commit_runtime.md
+++ b/docs/release_notes/v0.8.3/findings-commit_runtime.md
@@ -1,0 +1,87 @@
+# Arc 3 — `commit_runtime` sweep findings
+
+**Scope.** Commit-level mining (SWE-Gen-style). This arc lands two
+optimizations from plan §4 Arc 3; the full 38-repo sweep is deferred
+pending cost approval (envelope ~$80-250).
+
+## Optimizations landed
+
+### 1. Bot / chore / merge commit filters
+
+Plan §4 Arc 3 issue (b): commit_runtime currently feeds every merged
+commit through the (expensive) validation harness, including bot bumps
+and merge commits that never have real bug-fix signal. Adds two cheap
+metadata-level filters:
+
+- **`_looks_like_bot_author`** — substring check on `author_name +
+  author_email` for `[bot]`, `dependabot`, `renovate`, `pre-commit-ci`,
+  `github-actions`, `snyk-bot`, `greenkeeper`. Surfaces as
+  `skip_reason=bot_author`.
+- **`_looks_like_chore_subject`** — anchored regex on the commit subject
+  for routine maintenance shapes: `chore:` / `chore(deps):` /
+  `build(deps)` / `Merge pull request` / `Merge branch` / `bump <pkg>` /
+  `release vX` / `[skip ci]` / `version bump`. Surfaces as
+  `skip_reason=chore_message`.
+
+Both gated by new `CommitRuntimeOptions` flags
+(`skip_bot_authors=True`, `skip_chore_messages=True`, both default
+enabled). Disable per-arc when a repo's convention legitimately uses
+one of these tokens (e.g. `chore-board` as a directory name).
+
+**Why anchored**: a substring regex would mis-fire on
+`"Fix the chore-handling code path"`. We use `re.match` against the
+subject line start so only true conventional-commit prefixes / merge
+boilerplate / squash markers are caught.
+
+### 2. Inherit F2P relaxation from pr_runtime
+
+Adds `CommitRuntimeOptions.allow_no_f2p_with_test_patch` and reuses
+`pr_runtime._should_skip_no_f2p` for the gate. Both pipelines now share
+the same F2P semantics + opt-in relaxation. Set via
+`--pipeline-opt allow_no_f2p_with_test_patch=true` to accept commits
+where the modified tests already passed before the fix.
+
+## Test coverage
+
+7 new unit tests added in `tests/test_pipeline_commit_runtime.py`:
+
+| Test | Covers |
+|---|---|
+| `test_looks_like_bot_author_by_name` | author_name match |
+| `test_looks_like_bot_author_by_email` | author_email match (no-reply suffix) |
+| `test_looks_like_bot_author_real_human_passes` | no false-positive on human names |
+| `test_looks_like_chore_subject_positive` | 9 chore-style subjects all match |
+| `test_looks_like_chore_subject_negative` | 4 legitimate-looking subjects all pass through |
+| `test_metadata_filter_dispatch_via_class_method` | filter routes bot → `bot_author`, chore → `chore_message`, real fix → None |
+| `test_metadata_filter_keeps_legacy_behavior_when_flags_off` | turning both flags off reverts to v0.8.1 behavior |
+
+Full suite at **665 passing**, lint + format clean.
+
+## Acceptance criteria check (this PR)
+
+| Gate | Target | Actual | Pass? |
+|---|---|---|---|
+| ≥ 1 optimization landed | yes | 2 optimizations: bot/chore filters + F2P relaxation inherit | ✓ |
+| Existing tests stay green | 100% | 665/665 + 2 skipped | ✓ |
+| Lint + format | clean | clean | ✓ |
+| Full 38-repo sweep | yes | **deferred — pending user OK on cost** | — |
+| HF dataset published | yes | **deferred — once full sweep lands** | — |
+
+## What's pending for full completion of this arc
+
+1. **Full sweep across all 38 repos** — should yield ~55 verified envs
+   per plan §0. Cost envelope ~$80-250 (each commit needs a 2-stage
+   Docker validation; commit_runtime emits more candidates than
+   pr_runtime per repo since it walks `git log` directly).
+2. **HF push** to `AdithyaSK/repo2rlenv-v083-commit_runtime`.
+3. **Findings update** with concrete T2/T3 numbers + the
+   bot-filter-impact metric (count `bot_author` + `chore_message` skip
+   reasons in the sweep aggregate).
+
+## Out of scope for this arc
+
+- Instruction-synthesis prompt quality (plan §4 Arc 3 issue (a)) —
+  defer to v0.9; the v0.8.3 default uses raw commit subject+body which
+  is sufficient for the launch.
+- Per-language log-parser polish — same status as Arc 2; needs real
+  failure modes from Tier C cells.

--- a/src/repo2rlenv/pipelines/commit_runtime.py
+++ b/src/repo2rlenv/pipelines/commit_runtime.py
@@ -76,6 +76,49 @@ def _word_count(text: str) -> int:
     return len(re.findall(r"\b\w+\b", text or ""))
 
 
+# Bot author detection — matches `Foo[bot]`, `dependabot`, `renovate`,
+# `pre-commit-ci`, `github-actions`, and the GitHub no-reply suffix variants.
+# Applied to both author_name and author_email (case-insensitive substring).
+_BOT_AUTHOR_NEEDLES: tuple[str, ...] = (
+    "[bot]",
+    "dependabot",
+    "renovate",
+    "pre-commit-ci",
+    "github-actions",
+    "snyk-bot",
+    "greenkeeper",
+)
+
+
+def _looks_like_bot_author(author_name: str, author_email: str) -> bool:
+    hay = f"{author_name or ''}\n{author_email or ''}".lower()
+    return any(needle in hay for needle in _BOT_AUTHOR_NEEDLES)
+
+
+# Chore-style commit subject patterns. We treat the subject (first line) as
+# noise if it matches any of these. The regexes are anchored at the start
+# (or after a conventional-commit prefix) so e.g. "fix the chore foo" isn't
+# accidentally caught.
+_CHORE_SUBJECT_RE = re.compile(
+    r"""
+    ^\s*(?:                                        # leading whitespace
+        chore(?:\([^)]+\))?\s*:                    # chore: / chore(deps):
+      | bump\s                                     # bump <pkg> ...
+      | (?:build|chore)\(deps\)                    # build(deps) / chore(deps)
+      | merge\s+(?:pull\s+request|branch|remote)   # merge pull request|branch
+      | release\s+v?\d                             # release v1.2.3
+      | (?:version|changelog)\s+bump               # version bump / changelog bump
+      | \[skip\s+ci\]                              # [skip ci] prefix
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _looks_like_chore_subject(subject: str) -> bool:
+    return bool(_CHORE_SUBJECT_RE.match(subject or ""))
+
+
 def _files_changed_in_diff(unified_diff: str) -> list[str]:
     """Same `b/` path extractor pr_runtime uses; lifted here for the filter layer."""
     return _files_in_patch(unified_diff)
@@ -259,9 +302,17 @@ class CommitRuntimePipeline:
                         fail_to_pass = outcome.fail_to_pass
                         pass_to_pass = outcome.pass_to_pass
                         validation_status = outcome.status
-                        if (
-                            self.options.require_fail_to_pass
-                            and len(fail_to_pass) < self.options.min_fail_to_pass
+                        # Reuse pr_runtime's helper so both pipelines stay in sync
+                        # on the F2P gate semantics + the opt-in relaxation.
+                        from repo2rlenv.pipelines.pr_runtime import _should_skip_no_f2p
+
+                        if _should_skip_no_f2p(
+                            require_fail_to_pass=self.options.require_fail_to_pass,
+                            min_fail_to_pass=self.options.min_fail_to_pass,
+                            allow_no_f2p_with_test_patch=self.options.allow_no_f2p_with_test_patch,
+                            fail_to_pass=fail_to_pass,
+                            pass_to_pass=pass_to_pass,
+                            test_patch=test_patch,
                         ):
                             skip_reasons["no_fail_to_pass"] = (
                                 skip_reasons.get("no_fail_to_pass", 0) + 1
@@ -309,6 +360,12 @@ class CommitRuntimePipeline:
             return "merge_commit"
         if commit.author_email in self.options.exclude_authors:
             return "excluded_author"
+        if self.options.skip_bot_authors and _looks_like_bot_author(
+            commit.author_name, commit.author_email
+        ):
+            return "bot_author"
+        if self.options.skip_chore_messages and _looks_like_chore_subject(commit.subject):
+            return "chore_message"
         if _word_count(commit.message) < self.options.min_message_words:
             return "short_message"
         if (

--- a/src/repo2rlenv/spec/options.py
+++ b/src/repo2rlenv/spec/options.py
@@ -111,12 +111,25 @@ class CommitRuntimeOptions(_BaseOptions):
     min_message_words: int = 5  # drop "wip", "fmt", "typo" etc.
     max_source_files_per_commit: int = 10
     exclude_authors: list[str] = []  # e.g. ["dependabot[bot]@users.noreply.github.com"]
+    # Pattern-based author filtering for the common bot suffixes (`*[bot]`,
+    # `dependabot`, `renovate`, `pre-commit-ci`, `github-actions`). Matches
+    # either author_name OR author_email (case-insensitive substring).
+    skip_bot_authors: bool = True
+    # Pattern-based commit-message filtering for routine maintenance commits
+    # that almost never contain real bug fixes worth verifying. Subject is
+    # checked against regex patterns (case-insensitive). Disable per-arc when
+    # mining a repo whose convention legitimately uses one of these tokens.
+    skip_chore_messages: bool = True
     require_new_test_funcs: bool = True  # test_patch must add ≥1 new test func
     skip_ci_only: bool = True
 
     # --- Validation (mirrors PRRuntimeOptions) ---
     require_fail_to_pass: bool = True
     min_fail_to_pass: int = 1
+    # Matches `PRRuntimeOptions.allow_no_f2p_with_test_patch` — opt-in
+    # relaxation that accepts F2P=0 candidates when the commit added/modified
+    # tests AND there's ≥1 passing test. See pr_runtime for rationale.
+    allow_no_f2p_with_test_patch: bool = False
     validation_timeout_sec: int = 600
     skip_validation: bool = False
 

--- a/tests/test_pipeline_commit_runtime.py
+++ b/tests/test_pipeline_commit_runtime.py
@@ -16,6 +16,8 @@ import pytest
 from repo2rlenv.git_local import CommitInfo
 from repo2rlenv.pipelines.commit_runtime import (
     CommitRuntimePipeline,
+    _looks_like_bot_author,
+    _looks_like_chore_subject,
     _strip_commit_prefix,
     build_instruction_from_commit,
 )
@@ -197,3 +199,90 @@ def test_commit_runtime_rejects_missing_bootstrap():
     )
     with pytest.raises(RuntimeError, match="requires a BootstrapResult"):
         CommitRuntimePipeline(gen_input, CommitRuntimeOptions(), bootstrap=None)
+
+
+# -------------------------- bot / chore filters (Arc 3) -----------------------
+
+
+def test_looks_like_bot_author_by_name() -> None:
+    assert _looks_like_bot_author("dependabot[bot]", "support@github.com")
+    assert _looks_like_bot_author("renovate[bot]", "")
+    assert _looks_like_bot_author("github-actions[bot]", "")
+
+
+def test_looks_like_bot_author_by_email() -> None:
+    assert _looks_like_bot_author(
+        "Dependabot Bot", "49699333+dependabot[bot]@users.noreply.github.com"
+    )
+    assert _looks_like_bot_author("", "pre-commit-ci@noreply.invalid")
+
+
+def test_looks_like_bot_author_real_human_passes() -> None:
+    assert not _looks_like_bot_author("Alice Doe", "alice@example.com")
+    assert not _looks_like_bot_author("Carol", "carol@robotics.example")  # 'robotics' ≠ bot
+
+
+def test_looks_like_chore_subject_positive() -> None:
+    positives = [
+        "chore: bump deps",
+        "chore(deps): bump foo from 1 to 2",
+        "build(deps): bump bar from 3 to 4",
+        "bump foo to 1.2.3",
+        "Merge pull request #1234 from x/y",
+        "Merge branch 'main' into feature",
+        "release v0.1.0",
+        "version bump",
+        "[skip ci] update changelog",
+    ]
+    for s in positives:
+        assert _looks_like_chore_subject(s), f"expected chore for {s!r}"
+
+
+def test_looks_like_chore_subject_negative() -> None:
+    negatives = [
+        "fix: real bug in parser",
+        "feat: add user-facing flag",
+        "refactor: simplify the loop",
+        "Fix the chore-handling code path",  # word 'chore' is mid-sentence
+    ]
+    for s in negatives:
+        assert not _looks_like_chore_subject(s), f"expected non-chore for {s!r}"
+
+
+def test_metadata_filter_dispatch_via_class_method() -> None:
+    """Call _metadata_filter as an unbound method against a stub holding only
+    `options` — we don't need a real bootstrap to test the routing.
+    """
+    from types import SimpleNamespace
+
+    stub = SimpleNamespace(options=CommitRuntimeOptions())
+
+    bot_commit = _make_commit(
+        subject="chore: bump deps",
+        author_email="49699333+dependabot[bot]@users.noreply.github.com",
+    )
+    bot_commit.author_name = "dependabot[bot]"
+    assert CommitRuntimePipeline._metadata_filter(stub, bot_commit) == "bot_author"
+
+    chore_commit = _make_commit(subject="chore(deps): bump click from 8 to 9")
+    assert CommitRuntimePipeline._metadata_filter(stub, chore_commit) == "chore_message"
+
+    real_fix = _make_commit(subject="fix: handle empty input in normalize_choice")
+    assert CommitRuntimePipeline._metadata_filter(stub, real_fix) is None
+
+
+def test_metadata_filter_keeps_legacy_behavior_when_flags_off() -> None:
+    """Disabling the new flags reverts to the v0.8.1 behavior."""
+    from types import SimpleNamespace
+
+    options = CommitRuntimeOptions(skip_bot_authors=False, skip_chore_messages=False)
+    stub = SimpleNamespace(options=options)
+
+    bot_commit = _make_commit(
+        subject="chore: bump deps",
+        author_email="dependabot[bot]@users.noreply.github.com",
+    )
+    bot_commit.author_name = "dependabot[bot]"
+    # With the new filters off, this passes through (would be caught downstream
+    # by structural / validation gates).
+    assert CommitRuntimePipeline._metadata_filter(stub, bot_commit) is None


### PR DESCRIPTION
## Arc 3 — commit_runtime (work in progress)

Per plan §4 Arc 3. Stacked on #32 → #31 → #30.

**This PR lands the optimizations + tests; full 38-repo sweep deferred pending cost approval.** See [`docs/release_notes/v0.8.3/findings-commit_runtime.md`](../blob/v083-arc3-commit_runtime/docs/release_notes/v0.8.3/findings-commit_runtime.md) for full context.

## Summary

### 1. Bot-author + chore-subject filters

Plan §4 Arc 3 issue (b): \`commit_runtime\` currently feeds every merged commit through the (expensive) validation harness, including bot bumps and merge commits that never have real bug-fix signal.

- `_looks_like_bot_author` — substring check on author_name + author_email for `[bot]`, `dependabot`, `renovate`, `pre-commit-ci`, `github-actions`, `snyk-bot`, `greenkeeper`. Skip reason: `bot_author`.
- `_looks_like_chore_subject` — **anchored regex** on subject for `chore:` / `chore(deps):` / `build(deps)` / `Merge pull request` / `bump <pkg>` / `release vX` / `[skip ci]` / `version bump`. Skip reason: `chore_message`. Anchored so mid-sentence \"chore\" doesn't false-fire.
- Gated by new `CommitRuntimeOptions` flags: `skip_bot_authors=True`, `skip_chore_messages=True`. Disable per-arc as needed.

### 2. F2P relaxation inherit

Adds `CommitRuntimeOptions.allow_no_f2p_with_test_patch` and reuses `pr_runtime._should_skip_no_f2p`. Both pipelines now share the same gate semantics + opt-in relaxation, set via `--pipeline-opt allow_no_f2p_with_test_patch=true`.

## Test coverage

7 new unit tests in `tests/test_pipeline_commit_runtime.py`:
- 3 on `_looks_like_bot_author` (name match, email match, real-human-passes)
- 2 on `_looks_like_chore_subject` (9 positives, 4 negatives)
- 1 on `_metadata_filter` dispatch (bot → `bot_author`, chore → `chore_message`, real-fix → None)
- 1 regression: turning both flags off reverts to v0.8.1 behavior

Suite at **665 / 665 passing**.

## Acceptance criteria

| Gate | Status |
|---|---|
| ≥ 1 optimization landed | ✓ — 2 optimizations |
| Existing tests stay green | ✓ — 665 passing |
| Lint + format | ✓ |
| Full 38-repo sweep | ⏸ deferred (cost ~\$80-250) |
| HF dataset published | ⏸ deferred |

## What's pending for full Arc 3 completion

1. Full 38-repo sweep → ~55 verified envs per plan §0.
2. HF push to `AdithyaSK/repo2rlenv-v083-commit_runtime`.
3. Findings update with concrete T3 yield + bot-filter-impact metric (count `bot_author` + `chore_message` skip reasons across cells).

## Out of scope
- Instruction-synthesis prompt quality (plan §4 Arc 3 issue (a)) — defer to v0.9.
- Per-language log-parser polish — defer until Tier C cells produce real failure modes.

## Notes for reviewer
- Stacked on #32 → #31 → #30. GitHub auto-rebases the base as upstream PRs merge.
- No `pyproject.toml` bump.
- No `Co-Authored-By` trailer.