### PR TITLE
v083 Arc 4 (WIP): cve_patches OSV cache + multi-commit fan-out

### DIFF
--- a/docs/release_notes/v0.8.3/findings-cve_patches.md
+++ b/docs/release_notes/v0.8.3/findings-cve_patches.md
@@ -1,0 +1,94 @@
+# Arc 4 — `cve_patches` sweep findings
+
+**Scope.** OSV-driven CVE→fix-commit mining. This arc lands two
+optimizations from plan §4 Arc 4; the full ~20-repo sweep is deferred
+pending cost approval (envelope ~$80-250).
+
+## Optimizations landed
+
+### 1. OSV file-system cache
+
+Plan §4 Arc 4 issue (a): each invocation of `cve_patches` hit
+`api.osv.dev/v1/query` afresh. For sweep iterations on the same package
+this is wasteful and trips OSV rate limits.
+
+- New `query_vulns_cached()` wrapper in `src/repo2rlenv/osv.py`.
+- Per-`(package, ecosystem)` JSON file keyed on a sha1 of the request,
+  stored under `$REPO2RLENV_OSV_CACHE_DIR` (default
+  `~/.cache/repo2rlenv/osv/`).
+- 7-day TTL default — OSV vuln data accrues but rarely retroactively
+  mutates, so long TTL is safe. Override via
+  `CVEPatchesOptions.osv_cache_ttl_seconds`.
+- Cache miss / expired / malformed entry → fall back to a live query and
+  refresh the entry transparently.
+- Tolerates filesystem write failures (read-only dir → logs the warning
+  and proceeds without caching).
+- Disabled with `osv_cache_enabled=False` for forced fresh queries.
+
+### 2. Multi-commit CVE fan-out
+
+Plan §4 Arc 4 issue (d): some CVEs span 2-3 commits (e.g. fix + a
+regression-test follow-up). The v0.8.1 default picks only the first
+commit.
+
+- New `CVEPatchesOptions.emit_per_fix_commit: bool = False`.
+- When True: a CVE with N referenced commits emits N tasks, each with a
+  distinct task name suffix (`__commit-2`, `__commit-3`).
+- Conservative default (False) preserves the v0.8.1 behavior — opt-in
+  per sweep when you've inspected the CVE's commit list and want the
+  full fan-out.
+
+### 3. New `CVEPatchesOptions`
+
+- `osv_cache_enabled: bool = True`
+- `osv_cache_ttl_seconds: int = 7 * 24 * 3600`
+- `emit_per_fix_commit: bool = False`
+
+## Test coverage
+
+10 new unit tests in `tests/test_osv.py`:
+
+| Test | Covers |
+|---|---|
+| `test_cache_key_stable_per_package_ecosystem` | case-insensitive keying, distinct packages → distinct keys |
+| `test_cache_path_uses_provided_dir` | injection point for tmp_path testing |
+| `test_write_then_read_round_trip` | OSVVuln field round-trips through JSON |
+| `test_read_cache_expired` | TTL gate fires |
+| `test_read_cache_malformed` | corrupt JSON → miss, no crash |
+| `test_read_cache_missing_file_is_miss` | missing file → miss |
+| `test_query_vulns_cached_uses_cache_on_hit` | live `query_vulns` never called on hit |
+| `test_query_vulns_cached_falls_back_to_live` | miss → live call, then second call hits |
+| `test_query_vulns_cached_disabled_always_calls_live` | `cache_enabled=False` bypasses |
+| `test_query_vulns_cached_handles_write_failure` | read-only cache dir doesn't crash |
+
+Full suite at **675 passing**, lint + format clean.
+
+## Acceptance criteria check (this PR)
+
+| Gate | Target | Actual | Pass? |
+|---|---|---|---|
+| ≥ 1 optimization landed | yes | 2 — OSV cache + multi-commit fan-out | ✓ |
+| Existing tests stay green | 100% | 675/675 + 2 skipped | ✓ |
+| Lint + format | clean | clean | ✓ |
+| Full ~20-repo CVE sweep | yes | **deferred — pending user OK on cost** | — |
+| HF dataset published | yes | **deferred — once full sweep lands** | — |
+
+## What's pending for full completion of this arc
+
+1. **Full ~20-repo sweep** across the CVE-rich subset (`pallets/werkzeug`,
+   `psf/requests`, `pyca/cryptography`, `aio-libs/aiohttp`, etc.) —
+   should yield ~30 verified envs per plan §0. Cost: OSV is free; Docker
+   validation + bootstrap LLM dominate (~$50-150).
+2. **HF push** to `AdithyaSK/repo2rlenv-v083-cve_patches`.
+3. **Findings update** with concrete T3 yield + per-CVE commit-count
+   distribution (informs whether `emit_per_fix_commit=true` should be
+   the recommended sweep default).
+
+## Out of scope for this arc (deferred to v0.9)
+
+- LLM-synthesized PoC as part of the instruction (plan §4 Arc 4
+  issue (c)) — interesting but expensive to prototype; defer until
+  Arc 6 (`code_instruct`) gives us a feel for LLM-synthesis quality.
+- OSV SQLite backend — JSON file cache is good enough for the launch.
+- Multi-commit fix concatenation into a single diff — adds complexity
+  to the validate-pr harness (each commit has its own base SHA); defer.

--- a/src/repo2rlenv/osv.py
+++ b/src/repo2rlenv/osv.py
@@ -6,21 +6,75 @@ covers PyPI / npm / crates.io / Go / Maven / NuGet / Debian / Alpine / etc.
 We use it to power the `cve_patches` pipeline: query → extract fix commit
 URLs from `references[]` → map to a (base_commit, patch) pair via the
 standard `gh api repos/.../commits/<sha>` route.
+
+A simple file-system cache lives under ``$REPO2RLENV_OSV_CACHE_DIR`` (default
+``~/.cache/repo2rlenv/osv/``). Cache entries are per ``(package, ecosystem)``
+JSON files keyed on a sha1 of the request; entries expire after the
+``ttl_seconds`` you pass to :func:`query_vulns_cached`.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import os
 import re
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 
 OSV_QUERY_URL = "https://api.osv.dev/v1/query"
+
+
+def _default_cache_dir() -> Path:
+    """Filesystem location for the OSV result cache. Env override:
+    ``REPO2RLENV_OSV_CACHE_DIR``. Default: ``~/.cache/repo2rlenv/osv/``.
+    """
+    if env := os.environ.get("REPO2RLENV_OSV_CACHE_DIR"):
+        return Path(env)
+    return Path.home() / ".cache" / "repo2rlenv" / "osv"
+
+
+def _cache_key(package: str, ecosystem: str) -> str:
+    raw = f"{ecosystem.lower()}::{package.lower()}".encode()
+    return hashlib.sha1(raw).hexdigest()
+
+
+def _cache_path(package: str, ecosystem: str, *, cache_dir: Path | None = None) -> Path:
+    base = cache_dir if cache_dir is not None else _default_cache_dir()
+    return base / f"{_cache_key(package, ecosystem)}.json"
+
+
+def _read_cache(path: Path, *, ttl_seconds: int) -> tuple[list[OSVVuln], bool]:
+    """Return (vulns, fresh): fresh=True only if the file exists AND
+    is younger than ``ttl_seconds``.
+    """
+    if not path.exists():
+        return [], False
+    try:
+        raw = json.loads(path.read_text())
+        stamped_at = float(raw.get("stamped_at", 0))
+        if time.time() - stamped_at > ttl_seconds:
+            return [], False
+        return [_from_raw(v) for v in raw.get("vulns", [])], True
+    except (OSError, json.JSONDecodeError, ValueError, TypeError):
+        # Malformed cache — treat as miss; the caller will refresh.
+        return [], False
+
+
+def _write_cache(path: Path, vulns: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"stamped_at": time.time(), "vulns": vulns}
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(payload))
+    tmp.replace(path)
+
 
 # A `references[].url` that points at a fix commit. We accept either:
 #   https://github.com/<owner>/<repo>/commit/<sha40>
@@ -125,6 +179,56 @@ def query_vulns(
         raise OSVError(f"OSV returned malformed JSON: {exc}") from exc
     vulns = data.get("vulns") or []
     return [_from_raw(v) for v in vulns]
+
+
+def query_vulns_cached(
+    package: str,
+    ecosystem: str,
+    *,
+    timeout: float = 30.0,
+    cache_enabled: bool = True,
+    ttl_seconds: int = 7 * 24 * 3600,
+    cache_dir: Path | None = None,
+) -> list[OSVVuln]:
+    """Cache-aware variant of :func:`query_vulns`.
+
+    On cache hit (file exists + younger than ``ttl_seconds``) the entry is
+    returned without hitting the network. On cache miss we run the live
+    query, store the raw JSON, and return the parsed list. Disable caching
+    entirely with ``cache_enabled=False``.
+    """
+    if not cache_enabled:
+        return query_vulns(package, ecosystem, timeout=timeout)
+
+    path = _cache_path(package, ecosystem, cache_dir=cache_dir)
+    vulns, fresh = _read_cache(path, ttl_seconds=ttl_seconds)
+    if fresh:
+        logger.info("osv cache hit: %s/%s (%d vulns from %s)", ecosystem, package, len(vulns), path)
+        return vulns
+
+    fetched = query_vulns(package, ecosystem, timeout=timeout)
+    # Store the raw shapes so re-parsing is forward-compatible with
+    # OSVVuln field additions.
+    raw_payload = [
+        {
+            "id": v.id,
+            "aliases": v.aliases,
+            "summary": v.summary,
+            "details": v.details,
+            "database_specific": {
+                "severity": v.severity_text,
+                "cwe_ids": v.cwe_ids,
+            },
+            "published": v.published,
+            "references": v.references,
+        }
+        for v in fetched
+    ]
+    try:
+        _write_cache(path, raw_payload)
+    except OSError as exc:
+        logger.warning("osv cache write failed (%s) — proceeding without cache", exc)
+    return fetched
 
 
 # Lookup tables for repo → (ecosystem, package) auto-detection.

--- a/src/repo2rlenv/pipelines/cve_patches.py
+++ b/src/repo2rlenv/pipelines/cve_patches.py
@@ -52,7 +52,13 @@ from repo2rlenv.github import (
     fetch_commit_diff,
     fetch_commit_parent,
 )
-from repo2rlenv.osv import OSVError, OSVVuln, guess_ecosystem, query_vulns, severity_at_least
+from repo2rlenv.osv import (
+    OSVError,
+    OSVVuln,
+    guess_ecosystem,
+    query_vulns_cached,
+    severity_at_least,
+)
 from repo2rlenv.pipelines.base import PipelineResult
 from repo2rlenv.pipelines.pr_runtime import (
     _files_in_patch,
@@ -143,20 +149,30 @@ class CVEPatchesPipeline:
             name,
         )
         try:
-            vulns = query_vulns(package, ecosystem)
+            vulns = query_vulns_cached(
+                package,
+                ecosystem,
+                cache_enabled=self.options.osv_cache_enabled,
+                ttl_seconds=self.options.osv_cache_ttl_seconds,
+            )
         except OSVError as exc:
             raise RuntimeError(f"OSV query failed: {exc}") from exc
 
-        # Filter by severity + must have at least one fix commit
-        in_scope: list[tuple[OSVVuln, str]] = []
+        # Filter by severity + must have at least one fix commit. When
+        # `emit_per_fix_commit` is set, fan out a (vuln, sha) entry per commit;
+        # otherwise pick the first commit (most often the primary fix).
+        in_scope: list[tuple[OSVVuln, str, int]] = []  # (vuln, sha, ordinal)
         for v in vulns:
             if not severity_at_least(v, self.options.min_severity):
                 continue
             commits = v.fix_commits(owner=owner, repo=name)
             if not commits:
                 continue
-            # If multiple commits, pick the first — usually the primary fix
-            in_scope.append((v, commits[0]))
+            if self.options.emit_per_fix_commit:
+                for i, sha in enumerate(commits, start=1):
+                    in_scope.append((v, sha, i))
+            else:
+                in_scope.append((v, commits[0], 1))
 
         logger.info(
             "cve_patches: %d vulns total, %d in scope (have fix commit in %s/%s)",
@@ -171,10 +187,13 @@ class CVEPatchesPipeline:
         sandbox = None
 
         try:
-            for vuln, fix_sha in in_scope:
+            for vuln, fix_sha, commit_ordinal in in_scope:
                 if emitted >= self.options.limit:
                     break
-                label = f"{label_root}#{vuln.id}"
+                # When fan-out is on, suffix the label so multi-commit CVEs
+                # don't collide on `<cve-id>` alone.
+                label_suffix = f"@{commit_ordinal}" if self.options.emit_per_fix_commit else ""
+                label = f"{label_root}#{vuln.id}{label_suffix}"
 
                 # Resolve parent commit
                 parent_sha = fetch_commit_parent(owner, name, fix_sha, token=token)
@@ -251,6 +270,7 @@ class CVEPatchesPipeline:
                     fail_to_pass=fail_to_pass,
                     pass_to_pass=pass_to_pass,
                     validation_status=validation_status,
+                    commit_ordinal=commit_ordinal,
                 )
                 write_harbor_task(task, out_dir)
                 emitted += 1
@@ -300,11 +320,16 @@ class CVEPatchesPipeline:
         fail_to_pass: list[str],
         pass_to_pass: list[str],
         validation_status: str,
+        commit_ordinal: int = 1,
     ) -> HarborTask:
         owner, name = self.input.repo.owner_name
         # Use the CVE id (or fallback to OSV id) for the task slug — stable + human-readable
         slug_id = (vuln.cve_id or vuln.id).replace("/", "_")
         task_id = f"{owner}__{name}-cve-{slug_id}"
+        # When fan-out mode is on AND this CVE has multiple commits, distinguish
+        # the tasks by suffix so they don't collide on the same `name`.
+        if self.options.emit_per_fix_commit and commit_ordinal > 1:
+            task_id = f"{task_id}__commit-{commit_ordinal}"
 
         eval_script = build_eval_script(
             base_commit=parent_sha,

--- a/src/repo2rlenv/spec/options.py
+++ b/src/repo2rlenv/spec/options.py
@@ -281,6 +281,13 @@ class CVEPatchesOptions(_BaseOptions):
     osv_ecosystem: str | None = None  # "PyPI" / "npm" / "crates.io" / ... (None ⇒ auto-guess)
     osv_package: str | None = None  # package name (None ⇒ use repo name)
     min_severity: Literal["low", "medium", "moderate", "high", "critical"] = "low"
+    # File-system cache for OSV query results. Useful when re-running sweeps
+    # against the same package — avoids hammering the OSV endpoint. Set False
+    # to force fresh queries (e.g. when you suspect the OSV catalog changed).
+    osv_cache_enabled: bool = True
+    # Cache TTL in seconds (default 7 days). OSV vuln data accrues but rarely
+    # mutates retroactively, so a long TTL is safe.
+    osv_cache_ttl_seconds: int = 7 * 24 * 3600
 
     # --- Output cap ---
     limit: int = 50
@@ -294,6 +301,14 @@ class CVEPatchesOptions(_BaseOptions):
     # --- Structural filters ---
     require_new_test_funcs: bool = False  # security commits often DON'T add new tests
     max_source_files_per_fix: int = 50
+
+    # --- Multi-commit fix handling ---
+    # Some CVEs span 2-3 commits (e.g. a fix + a regression-test follow-up).
+    # The default takes the first commit (most often the primary fix). When
+    # set True, emit one task per fix commit — useful when the CVE has
+    # genuinely independent fixes (rare, but happens). Each emitted task
+    # gets a distinct task.name suffix (`__commit-2`, `__commit-3`).
+    emit_per_fix_commit: bool = False
 
 
 class EquivalenceTestsOptions(_BaseOptions):

--- a/tests/test_osv.py
+++ b/tests/test_osv.py
@@ -7,10 +7,22 @@ filter-by-repo behavior, and severity comparisons.
 
 from __future__ import annotations
 
+import json
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
 from repo2rlenv.osv import (
     OSVVuln,
+    _cache_key,
+    _cache_path,
     _from_raw,
+    _read_cache,
+    _write_cache,
     guess_ecosystem,
+    query_vulns_cached,
     severity_at_least,
 )
 
@@ -179,3 +191,129 @@ def test_guess_ecosystem_unknown_defaults_pypi():
 
 def test_guess_ecosystem_case_insensitive():
     assert guess_ecosystem("PALLETS") == "PyPI"
+
+
+# ---------------------------------------------------------------------------
+# OSV cache (v0.8.3 Arc 4)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_stable_per_package_ecosystem() -> None:
+    assert _cache_key("click", "PyPI") == _cache_key("Click", "pypi")  # case-insensitive
+    assert _cache_key("click", "PyPI") != _cache_key("flask", "PyPI")
+
+
+def test_cache_path_uses_provided_dir(tmp_path: Path) -> None:
+    p = _cache_path("click", "PyPI", cache_dir=tmp_path)
+    assert p.parent == tmp_path
+    assert p.suffix == ".json"
+
+
+def test_write_then_read_round_trip(tmp_path: Path) -> None:
+    p = _cache_path("foo", "PyPI", cache_dir=tmp_path)
+    raw = [
+        {
+            "id": "CVE-2025-9999",
+            "aliases": [],
+            "summary": "tiny",
+            "details": "",
+            "database_specific": {"severity": "HIGH"},
+            "published": "2025-01-01",
+            "references": [],
+        }
+    ]
+    _write_cache(p, raw)
+    vulns, fresh = _read_cache(p, ttl_seconds=10_000)
+    assert fresh is True
+    assert len(vulns) == 1
+    assert vulns[0].id == "CVE-2025-9999"
+    assert vulns[0].severity_text == "HIGH"
+
+
+def test_read_cache_expired(tmp_path: Path) -> None:
+    p = _cache_path("foo", "PyPI", cache_dir=tmp_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"stamped_at": time.time() - 1000, "vulns": [{"id": "x"}]}))
+    vulns, fresh = _read_cache(p, ttl_seconds=100)
+    assert fresh is False
+    assert vulns == []
+
+
+def test_read_cache_malformed(tmp_path: Path) -> None:
+    p = _cache_path("foo", "PyPI", cache_dir=tmp_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not json")
+    vulns, fresh = _read_cache(p, ttl_seconds=10_000)
+    assert fresh is False
+    assert vulns == []
+
+
+def test_read_cache_missing_file_is_miss(tmp_path: Path) -> None:
+    p = tmp_path / "nope.json"
+    vulns, fresh = _read_cache(p, ttl_seconds=10_000)
+    assert fresh is False
+    assert vulns == []
+
+
+def test_query_vulns_cached_uses_cache_on_hit(tmp_path: Path) -> None:
+    """When the cache is fresh, the live query is NOT called."""
+    raw = [
+        {
+            "id": "CVE-2025-1111",
+            "aliases": [],
+            "summary": "",
+            "details": "",
+            "database_specific": {"severity": "MEDIUM"},
+            "published": "",
+            "references": [],
+        }
+    ]
+    p = _cache_path("foo", "PyPI", cache_dir=tmp_path)
+    _write_cache(p, raw)
+
+    with mock.patch("repo2rlenv.osv.query_vulns") as m:
+        result = query_vulns_cached(
+            "foo", "PyPI", cache_enabled=True, ttl_seconds=10_000, cache_dir=tmp_path
+        )
+    assert m.call_count == 0  # cache hit short-circuited
+    assert [v.id for v in result] == ["CVE-2025-1111"]
+
+
+def test_query_vulns_cached_falls_back_to_live(tmp_path: Path) -> None:
+    """When cache is empty, the live query is called once + result is cached."""
+    fake_vuln = OSVVuln(id="CVE-2025-2222", severity_text="LOW")
+    with mock.patch("repo2rlenv.osv.query_vulns", return_value=[fake_vuln]) as m:
+        first = query_vulns_cached(
+            "bar", "PyPI", cache_enabled=True, ttl_seconds=10_000, cache_dir=tmp_path
+        )
+        assert m.call_count == 1
+        # Second call: should hit the cache from the first call
+        second = query_vulns_cached(
+            "bar", "PyPI", cache_enabled=True, ttl_seconds=10_000, cache_dir=tmp_path
+        )
+        assert m.call_count == 1  # still 1 — cache hit
+    assert [v.id for v in first] == ["CVE-2025-2222"]
+    assert [v.id for v in second] == ["CVE-2025-2222"]
+
+
+def test_query_vulns_cached_disabled_always_calls_live(tmp_path: Path) -> None:
+    fake = [OSVVuln(id="CVE-X")]
+    with mock.patch("repo2rlenv.osv.query_vulns", return_value=fake) as m:
+        query_vulns_cached("baz", "PyPI", cache_enabled=False, cache_dir=tmp_path)
+        query_vulns_cached("baz", "PyPI", cache_enabled=False, cache_dir=tmp_path)
+    assert m.call_count == 2  # cache bypassed both calls
+
+
+def test_query_vulns_cached_handles_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A read-only cache dir shouldn't crash the pipeline."""
+
+    def fail_write(*args, **kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr("repo2rlenv.osv._write_cache", fail_write)
+    fake = [OSVVuln(id="CVE-Y")]
+    with mock.patch("repo2rlenv.osv.query_vulns", return_value=fake):
+        result = query_vulns_cached("qux", "PyPI", cache_enabled=True, cache_dir=tmp_path)
+    assert [v.id for v in result] == ["CVE-Y"]


### PR DESCRIPTION
## Arc 4 — cve_patches (work in progress)

Per plan §4 Arc 4. Stacked on #33 → #32 → #31 → #30.

**This PR lands the optimizations + tests; full ~20-repo CVE sweep deferred pending cost approval.** See [`docs/release_notes/v0.8.3/findings-cve_patches.md`](../blob/v083-arc4-cve_patches/docs/release_notes/v0.8.3/findings-cve_patches.md) for full context.

## Summary

### 1. OSV file-system cache

Plan §4 Arc 4 issue (a): each `cve_patches` invocation hits api.osv.dev anew, wasteful and trips rate limits on sweep re-runs.

- New `query_vulns_cached()` wrapper in `osv.py`, keyed on `(package, ecosystem)`.
- JSON files under `$REPO2RLENV_OSV_CACHE_DIR` (default `~/.cache/repo2rlenv/osv/`).
- 7-day TTL — OSV data accrues but rarely retroactively mutates.
- Cache miss / expired / malformed → live query + refresh, transparent to callers.
- Tolerates filesystem write failures (read-only cache dir → log warning, proceed).
- Disabled via `osv_cache_enabled=False`.

### 2. Multi-commit CVE fan-out

Plan §4 Arc 4 issue (d): some CVEs span multiple fix commits (fix + regression test follow-up). v0.8.1 picks only the first.

- New `CVEPatchesOptions.emit_per_fix_commit: bool = False`.
- When True: N referenced commits → N tasks with `__commit-2`, `__commit-3` name suffixes.
- Conservative default preserves v0.8.1 behavior.

### 3. New `CVEPatchesOptions`

- `osv_cache_enabled: bool = True`
- `osv_cache_ttl_seconds: int = 7 * 24 * 3600`
- `emit_per_fix_commit: bool = False`

## Test coverage

**10 new unit tests** in `tests/test_osv.py`: cache key stability (case-insensitive), path injection, round-trip, TTL expiry, malformed JSON, missing file, hit short-circuit, fallback-then-hit, disabled mode, write-failure tolerance. Suite at **675 passing**.

## Acceptance criteria

| Gate | Status |
|---|---|
| ≥ 1 optimization landed | ✓ — 2 optimizations |
| Existing tests stay green | ✓ — 675 passing |
| Lint + format | ✓ |
| Full ~20-repo CVE sweep | ⏸ deferred (cost ~\$50-150) |
| HF dataset published | ⏸ deferred |

## What's pending for full Arc 4 completion

1. Full ~20-repo sweep → ~30 verified envs per plan §0.
2. HF push to `AdithyaSK/repo2rlenv-v083-cve_patches`.
3. Findings update with concrete T3 yield + per-CVE commit-count distribution.

## Out of scope (deferred to v0.9)
- LLM-synthesized PoC as part of the instruction (plan §4 Arc 4 (c)).
- OSV SQLite backend — JSON file cache is good enough.
- Multi-commit fix concatenation into a single diff.

## Notes for reviewer
- Stacked on #33 → #32 → #31 → #30.
- No `pyproject.toml` bump.
- No `Co-Authored-By` trailer.