### PR TITLE
v083 Arc 5 (WIP): mutation_bugs ast.parse pre-gate

### DIFF
--- a/docs/release_notes/v0.8.3/findings-mutation_bugs.md
+++ b/docs/release_notes/v0.8.3/findings-mutation_bugs.md
@@ -1,0 +1,81 @@
+# Arc 5 — `mutation_bugs` sweep findings
+
+**Scope.** Procedural AST-mutation bug injection (SWE-smith style),
+Python-only. This arc lands one optimization from plan §4 Arc 5; the
+full 20-Python-repo sweep is deferred pending cost approval.
+
+## Optimization landed: pre-container parseability gate
+
+Plan §4 Arc 5 issue (b): "must compile" gate before emission.
+
+Some mutations produce syntactically-broken Python — e.g. an operator
+that removes a closing bracket, or one that mis-indents a block. Today
+the pipeline still pays a full in-container test run for these. When
+the mutated source doesn't parse, every test "fails" by import error —
+indistinguishable noise from real broken-test signal.
+
+**Fix.** Add `_is_parseable_python(source)`: wraps `ast.parse` and
+returns False on `SyntaxError` / `ValueError`. Wire into the candidate
+loop in `MutationBugsPipeline.run()` so unparseable mutations are
+dropped with `skip_reason=unparseable_mutation` BEFORE the
+`sandbox.exec` call.
+
+Gated by `MutationBugsOptions.skip_unparseable_mutations: bool = True`
+(default on). Disable when you specifically want to study the
+import-error class of failures.
+
+### Why this matters
+
+A typical mutation-bugs cell runs ~50-100 attempts before emitting
+N tasks. Each attempt that goes to the container costs 5-30 s
+depending on test-suite size. The parse gate is ~50 µs in Python. At
+even a 5% unparseable-mutation rate per cell, the gate saves
+~minutes per cell — multiplied by 20 Python repos in the launch, that's
+~30-60 minutes of clock saved per sweep.
+
+## Test coverage
+
+6 new unit tests in `tests/test_pipeline_mutation_bugs.py`:
+
+| Test | Covers |
+|---|---|
+| `test_is_parseable_python_accepts_valid_module` | basic Python parses |
+| `test_is_parseable_python_accepts_empty` | empty string is parseable |
+| `test_is_parseable_python_rejects_syntax_error` | missing bracket |
+| `test_is_parseable_python_rejects_dangling_else` | `else:` at module level |
+| `test_is_parseable_python_accepts_subtle_semantic_bug` | `x[-0]` parses (semantic ≠ syntactic) |
+| `test_skip_unparseable_mutations_default_enabled` | default-on guard |
+
+Suite at **681 passing**, lint + format clean.
+
+## Acceptance criteria check (this PR)
+
+| Gate | Target | Actual | Pass? |
+|---|---|---|---|
+| ≥ 1 optimization landed | yes | parseability gate + new option | ✓ |
+| Existing tests stay green | 100% | 681/681 + 2 skipped | ✓ |
+| Lint + format | clean | clean | ✓ |
+| Full 20-Python-repo sweep | yes | **deferred — pending user OK on cost** | — |
+| HF dataset published | yes | **deferred — once full sweep lands** | — |
+
+## What's pending for full completion of this arc
+
+1. **Full sweep across 20 Python repos** — should yield ~60 verified
+   envs per plan §0. Cost envelope: ~$80-200 (LLM cost for
+   `_author_issue_text` per accepted mutation; pipeline itself only
+   emits when ≥1 test broke).
+2. **HF push** to `AdithyaSK/repo2rlenv-v083-mutation_bugs`.
+3. **Findings update** with concrete T3 yield + operator-yield
+   distribution (informs plan §4 Arc 5 (a) on which operators to
+   weight higher in v0.9).
+4. **Verify Sergio's #24 seed-serialization fix didn't regress** —
+   plan §4 Arc 5 (d). Today's unit tests don't exercise the
+   serialization path; the full sweep does.
+
+## Out of scope for this arc (deferred to v0.9)
+
+- Operator-weight tuning (plan §4 Arc 5 (a)) — needs data from the
+  full sweep to inform.
+- Instruction-text polish (plan §4 Arc 5 (c)) — the LLM prompt
+  `_ISSUE_SYSTEM_PROMPT` is sufficient for the launch.
+- Polyglot mutation via tree-sitter — deferred per CLAUDE.md.

--- a/src/repo2rlenv/pipelines/mutation_bugs.py
+++ b/src/repo2rlenv/pipelines/mutation_bugs.py
@@ -38,6 +38,7 @@ Released under Apache-2.0 along with the rest of Repo2RLEnv.
 
 from __future__ import annotations
 
+import ast
 import base64
 import difflib
 import fnmatch
@@ -99,6 +100,19 @@ class _MutationOutcome:
     test_output: str = ""
     accepted: bool = False
     reason: str = ""
+
+
+def _is_parseable_python(source: str) -> bool:
+    """Cheap pre-validation gate: True iff `source` parses as Python AST.
+
+    Used to filter mutations that produce syntactically-broken code before
+    paying the container roundtrip. SyntaxError / ValueError → unparseable.
+    """
+    try:
+        ast.parse(source)
+    except (SyntaxError, ValueError):
+        return False
+    return True
 
 
 def _make_unified_diff(old: str, new: str, path: str) -> str:
@@ -362,6 +376,20 @@ class MutationBugsPipeline:
                             continue
                         if mutated_source == source:
                             continue  # operator was a no-op for this site
+
+                        # v0.8.3 Arc 5 optimization: drop mutations whose source
+                        # text doesn't parse as Python BEFORE paying for the
+                        # in-container test run. A SyntaxError in the mutated
+                        # file makes every test "fail" by import error — noise,
+                        # not signal. Cheap pre-check saves real time per cell.
+                        if self.options.skip_unparseable_mutations and not _is_parseable_python(
+                            mutated_source
+                        ):
+                            skip_reasons["unparseable_mutation"] = (
+                                skip_reasons.get("unparseable_mutation", 0) + 1
+                            )
+                            self._emit_progress(label, "skip", "unparseable_mutation")
+                            continue
 
                         mutation_diff = _make_unified_diff(source, mutated_source, relative)
                         if not mutation_diff:

--- a/src/repo2rlenv/spec/options.py
+++ b/src/repo2rlenv/spec/options.py
@@ -173,6 +173,12 @@ class MutationBugsOptions(_BaseOptions):
     # --- Mutation filter ---
     min_tests_broken: int = 1
     max_tests_broken: int = 5
+    # Pre-validation gate: when True (default), drop mutations whose source
+    # text doesn't parse as Python before paying for the in-container test
+    # run. Unparseable mutations always make every test fail by import error
+    # — that's noise, not signal. Disable when you specifically want to study
+    # the import-error class of failures.
+    skip_unparseable_mutations: bool = True
     validation_timeout_sec: int = 300
     skip_validation: bool = False  # emit candidates raw (debug / fast iteration)
     # If set, restrict pytest to this path (or space-separated list of paths).

--- a/tests/test_pipeline_mutation_bugs.py
+++ b/tests/test_pipeline_mutation_bugs.py
@@ -19,6 +19,7 @@ import pytest
 from repo2rlenv.pipelines.mutation_bugs import (
     MutationBugsPipeline,
     _is_excluded,
+    _is_parseable_python,
     _make_unified_diff,
     _slice_test_output,
     _target_pytest_for_tests,
@@ -224,3 +225,38 @@ def test_mutation_bugs_options_defaults():
     assert opts.limit == 50
     assert opts.min_tests_broken == 1
     assert opts.operators is None  # ⇒ use every operator
+
+
+# ---------------------------------------------------------------------------
+# _is_parseable_python — v0.8.3 Arc 5 pre-validation gate
+# ---------------------------------------------------------------------------
+
+
+def test_is_parseable_python_accepts_valid_module() -> None:
+    assert _is_parseable_python("def f(x):\n    return x + 1\n")
+
+
+def test_is_parseable_python_accepts_empty() -> None:
+    assert _is_parseable_python("")
+
+
+def test_is_parseable_python_rejects_syntax_error() -> None:
+    # Closing bracket missing
+    assert not _is_parseable_python("def f(x:\n    return x\n")
+
+
+def test_is_parseable_python_rejects_dangling_else() -> None:
+    assert not _is_parseable_python("else: pass\n")
+
+
+def test_is_parseable_python_accepts_subtle_semantic_bug() -> None:
+    """`x[-0]` is valid Python — should pass parser gate. The point of this
+    gate is to drop SYNTAX-broken mutations, not semantically-broken ones
+    (which the test suite catches downstream).
+    """
+    assert _is_parseable_python("def f(xs):\n    return xs[-0]\n")
+
+
+def test_skip_unparseable_mutations_default_enabled() -> None:
+    """The Arc 5 flag defaults to True so prod sweeps get the cheaper path."""
+    assert MutationBugsOptions().skip_unparseable_mutations is True


### PR DESCRIPTION
## Arc 5 — mutation_bugs (work in progress)

Per plan §4 Arc 5. Stacked on #34 → #33 → #32 → #31 → #30.

**Optimization + tests landed; full 20-Python-repo sweep deferred pending cost approval.** See [`docs/release_notes/v0.8.3/findings-mutation_bugs.md`](../blob/v083-arc5-mutation_bugs/docs/release_notes/v0.8.3/findings-mutation_bugs.md) for context.

## Summary

### Pre-container parseability gate

Plan §4 Arc 5 issue (b): \"must compile\" gate before emission.

Some mutations produce syntactically-broken Python — missing bracket, mis-indented block, etc. Today the pipeline still pays a full in-container test run for these, where every test \"fails\" by import error (noise, not signal).

- New `_is_parseable_python(source)`: wraps `ast.parse`, returns False on `SyntaxError` / `ValueError`.
- Wired into the candidate loop BEFORE the `sandbox.exec` call. Mutations failing the parse gate skip with `reason=unparseable_mutation`.
- Gated by `MutationBugsOptions.skip_unparseable_mutations: bool = True` (default on).

Saves ~minutes per cell at any non-trivial unparseable rate. Parse check is ~50 µs vs container roundtrip 5-30 s.

## Test coverage

**6 new unit tests** in `tests/test_pipeline_mutation_bugs.py`:
- Valid module / empty string / syntax error / dangling else / subtle semantic bug (\`x[-0]\` parses) / default-flag-on guard.

Suite at **681 passing**, lint + format clean.

## Acceptance criteria

| Gate | Status |
|---|---|
| ≥ 1 optimization landed | ✓ — parseability gate |
| Existing tests stay green | ✓ — 681 passing |
| Lint + format | ✓ |
| Full 20-Python sweep | ⏸ deferred (cost ~\$80-200) |
| HF dataset published | ⏸ deferred |

## What's pending for full Arc 5 completion

1. Full 20-Python-repo sweep → ~60 verified envs per plan §0.
2. HF push to `AdithyaSK/repo2rlenv-v083-mutation_bugs`.
3. Operator-yield distribution → informs plan §4 Arc 5 (a) for v0.9.
4. Verify Sergio's #24 seed-serialization fix didn't regress — full sweep exercises that path.

## Out of scope (deferred to v0.9)
- Operator-weight tuning (needs sweep data).
- Instruction-text polish.
- Polyglot mutation via tree-sitter.

## Notes for reviewer
- Stacked on #34 → #33 → #32 → #31 → #30.
- No `pyproject.toml` bump.
- No `Co-Authored-By` trailer.