### PR TITLE
v083 Arc 6 (WIP): code_instruct no-op stub tautology check

### DIFF
--- a/docs/release_notes/v0.8.3/findings-code_instruct.md
+++ b/docs/release_notes/v0.8.3/findings-code_instruct.md
@@ -1,0 +1,82 @@
+# Arc 6 — `code_instruct` sweep findings
+
+**Scope.** OSS-Instruct-style synthesized coding tasks (Python-only).
+This arc lands one optimization from plan §4 Arc 6; the full
+20-Python-repo sweep is deferred pending cost approval.
+
+## Optimization landed: no-op stub tautology check
+
+Plan §4 Arc 6 issue (c): reject verifiers that pass with a no-op patch
+(i.e., the test isn't actually exercising oracle behavior — it only
+asserts importability).
+
+The pipeline already does a 2-stage verifier check:
+
+- **Stage A**: write only the test, run pytest → must FAIL.
+- **Stage B**: write test + oracle, run pytest → must PASS.
+
+The gap: Stage A only fails on `ImportError`. A test that imports the
+oracle but then only checks `from task_module import foo; assert foo`
+(truthiness of the function object, not its behavior) would FAIL stage A
+(import error) but PASS stage B (oracle imports fine) — and STILL be
+useless as a verifier because any function-shaped no-op would also pass.
+
+**Fix.** Insert Stage A.5 between A and B:
+
+1. Build a stub `task_module.py` from the LLM's solution code. Every
+   top-level function becomes `def <name>(*args, **kwargs): return None`;
+   every top-level class becomes `class <Name>: pass`; imports and
+   constants are dropped.
+2. Run pytest against the test file + this stub. If the tests **pass**,
+   reject the candidate with `reason=test_passes_with_noop_stub`.
+
+The verifier now requires that the test exercises the oracle's
+*behavior*, not just its existence.
+
+Gated by `CodeInstructOptions.require_test_fails_with_noop_stub`
+(default `True`). Disable per-arc for higher emission yield at the
+cost of some verifier-quality slack.
+
+## Test coverage
+
+7 new unit tests in `tests/test_pipeline_code_instruct.py`:
+
+| Test | Covers |
+|---|---|
+| `test_noop_stub_function` | single function → no-op stub |
+| `test_noop_stub_multiple_symbols` | mixed funcs + classes |
+| `test_noop_stub_async_function` | async def preserved |
+| `test_noop_stub_drops_imports_and_constants` | only callables / classes in stub |
+| `test_noop_stub_unparseable_returns_empty` | caller can skip stage on bad LLM output |
+| `test_noop_stub_no_callables_returns_empty` | imports/constants-only solution → no stub work |
+| `test_noop_stub_module_is_syntactically_valid` | stub itself round-trips through `ast.parse` |
+
+Plus a flag-default assertion. Suite at **688 passing**, lint + format clean.
+
+## Acceptance criteria check (this PR)
+
+| Gate | Target | Actual | Pass? |
+|---|---|---|---|
+| ≥ 1 optimization landed | yes | no-op stub tautology check | ✓ |
+| Existing tests stay green | 100% | 688/688 + 2 skipped | ✓ |
+| Lint + format | clean | clean | ✓ |
+| Full 20-Python-repo sweep | yes | **deferred — pending user OK on cost** | — |
+| HF dataset published | yes | **deferred — once full sweep lands** | — |
+
+## What's pending for full completion of this arc
+
+1. **Full sweep across 20 Python repos** — should yield ~60 verified
+   envs per plan §0. Cost envelope ~$80-150 (LLM-heavy: each task
+   requires a Sonnet call for problem + test + solution).
+2. **HF push** to `AdithyaSK/repo2rlenv-v083-code_instruct`.
+3. **Findings update** with concrete T3 yield + impact of the new
+   stub stage (count `test_passes_with_noop_stub` skip reasons across
+   cells).
+
+## Out of scope for this arc (deferred to v0.9)
+
+- Haiku-judged verifier-quality second pass (plan §4 Arc 6 (a)) —
+  the stub check covers most tautological patterns; LLM-judged adds
+  marginal value at high cost.
+- Curated instruction-difficulty distribution (plan §4 Arc 6 (b)) —
+  requires sweep data to calibrate.

--- a/src/repo2rlenv/pipelines/code_instruct.py
+++ b/src/repo2rlenv/pipelines/code_instruct.py
@@ -37,6 +37,7 @@ Released under Apache-2.0 along with the rest of Repo2RLEnv.
 
 from __future__ import annotations
 
+import ast
 import base64
 import hashlib
 import logging
@@ -81,6 +82,35 @@ class _VerifyOutcome:
     reason: str = ""
     pre_log: str = ""
     post_log: str = ""
+
+
+def _make_noop_stub_module(solution_code: str) -> str:
+    """Build a stub `task_module.py` whose top-level symbols all no-op.
+
+    For each top-level function we emit ``def <name>(*args, **kwargs): return None``.
+    For each top-level class we emit a bare ``class <Name>: pass``. Other
+    nodes (imports, constants) are dropped — the stub's only job is to make
+    `from task_module import <name>` and `<name>(...)` succeed at import,
+    so the verifier exercises the test's BEHAVIOR rather than mere importability.
+
+    If the solution can't be parsed, returns an empty module (`""`) so callers
+    can choose to skip the stub-test stage.
+    """
+    try:
+        tree = ast.parse(solution_code)
+    except (SyntaxError, ValueError):
+        return ""
+
+    lines: list[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            async_kw = "async " if isinstance(node, ast.AsyncFunctionDef) else ""
+            lines.append(f"{async_kw}def {node.name}(*args, **kwargs):\n    return None")
+        elif isinstance(node, ast.ClassDef):
+            lines.append(f"class {node.name}:\n    pass")
+    if not lines:
+        return ""
+    return "\n\n".join(lines) + "\n"
 
 
 def _make_two_file_diff(*, task_module_code: str, test_code: str, test_filename: str) -> str:
@@ -356,6 +386,36 @@ class CodeInstructPipeline:
             return _VerifyOutcome(
                 accepted=False, reason="test_passes_without_oracle", pre_log=pre_log
             )
+
+        # Stage A.5 — no-op stub oracle (v0.8.3 Arc 6 tautology check).
+        # If the test passes with a stub task_module whose symbols all return
+        # None, then the test doesn't actually exercise the oracle's behavior
+        # — it just checks that imports work. Reject such tasks.
+        if self.options.require_test_fails_with_noop_stub:
+            stub_module = _make_noop_stub_module(parsed.solution_code)
+            if stub_module:
+                enc_stub = base64.b64encode(stub_module.encode("utf-8")).decode("ascii")
+                script_stub = (
+                    "set -uxo pipefail\n"
+                    "cd /workspace\n"
+                    "git reset --hard HEAD\n"
+                    "git clean -fdx -e .venv -e venv -e __pycache__ || true\n"
+                    f"echo {enc_test} | base64 -d > {test_filename}\n"
+                    f"echo {enc_stub} | base64 -d > task_module.py\n"
+                    ": 'START_TEST_OUTPUT'\n"
+                    f"python -m pytest {test_filename} -v --no-header || true\n"
+                    ": 'END_TEST_OUTPUT'\n"
+                    "rm -f task_module.py task_module.pyc || true\n"
+                )
+                s = sandbox.exec(script_stub, timeout=self.options.validation_timeout_sec)
+                stub_log = s.truncated(max_chars=4000)
+                if _all_tests_passed(stub_log):
+                    return _VerifyOutcome(
+                        accepted=False,
+                        reason="test_passes_with_noop_stub",
+                        pre_log=pre_log,
+                        post_log=stub_log,
+                    )
 
         # Stage B — oracle in place
         script_b = (

--- a/src/repo2rlenv/spec/options.py
+++ b/src/repo2rlenv/spec/options.py
@@ -228,6 +228,12 @@ class CodeInstructOptions(_BaseOptions):
     # --- Verification ---
     require_test_fails_without_oracle: bool = True
     require_test_passes_with_oracle: bool = True
+    # v0.8.3 Arc 6 optimization: also verify that tests fail when given a
+    # task_module.py whose symbols are all no-op stubs. Catches "tautological"
+    # tests that only assert importability — not behavior. Default on; disable
+    # for arcs where you want a higher emission yield at the cost of some
+    # verifier-quality slack.
+    require_test_fails_with_noop_stub: bool = True
     validation_timeout_sec: int = 180
     skip_validation: bool = False
 

--- a/tests/test_pipeline_code_instruct.py
+++ b/tests/test_pipeline_code_instruct.py
@@ -11,6 +11,7 @@ import pytest
 from repo2rlenv.pipelines.code_instruct import (
     CodeInstructPipeline,
     _all_tests_passed,
+    _make_noop_stub_module,
     _make_two_file_diff,
     build_code_instruct_dockerfile,
 )
@@ -141,3 +142,66 @@ def test_code_instruct_options_defaults():
     assert opts.seed_max_loc == 200
     assert opts.require_test_fails_without_oracle is True
     assert opts.require_test_passes_with_oracle is True
+    # v0.8.3 Arc 6 — new tautology-check flag defaults on
+    assert opts.require_test_fails_with_noop_stub is True
+
+
+# ---------------------------------------------------------------------------
+# _make_noop_stub_module — v0.8.3 Arc 6 tautology check
+# ---------------------------------------------------------------------------
+
+
+def test_noop_stub_function() -> None:
+    src = "def add(a, b):\n    return a + b\n"
+    stub = _make_noop_stub_module(src)
+    assert "def add(*args, **kwargs):" in stub
+    assert "return None" in stub
+
+
+def test_noop_stub_multiple_symbols() -> None:
+    src = (
+        "def f(x): return x\n"
+        "def g(x, y): return x + y\n"
+        "class Counter:\n    def __init__(self): self.n = 0\n"
+    )
+    stub = _make_noop_stub_module(src)
+    assert "def f(*args, **kwargs):" in stub
+    assert "def g(*args, **kwargs):" in stub
+    assert "class Counter:" in stub
+
+
+def test_noop_stub_async_function() -> None:
+    src = "async def fetch(url):\n    return None\n"
+    stub = _make_noop_stub_module(src)
+    assert "async def fetch(*args, **kwargs):" in stub
+
+
+def test_noop_stub_drops_imports_and_constants() -> None:
+    """Only callable / class symbols stay in the stub."""
+    src = "import os\nfrom typing import Any\nX = 42\ndef real_work(): return X\n"
+    stub = _make_noop_stub_module(src)
+    assert "import" not in stub
+    assert "X = 42" not in stub
+    assert "def real_work(*args, **kwargs):" in stub
+
+
+def test_noop_stub_unparseable_returns_empty() -> None:
+    """Caller can choose to skip the stub stage if the LLM returned bad code."""
+    src = "def broken(\n"  # SyntaxError
+    assert _make_noop_stub_module(src) == ""
+
+
+def test_noop_stub_no_callables_returns_empty() -> None:
+    """A solution with only imports / constants → no stub work to do."""
+    src = "import os\nX = 1\n"
+    assert _make_noop_stub_module(src) == ""
+
+
+def test_noop_stub_module_is_syntactically_valid() -> None:
+    """The stub itself must parse — otherwise the validation harness crashes."""
+    import ast
+
+    src = "def f(): return 1\nclass C:\n    def __init__(self): pass\n"
+    stub = _make_noop_stub_module(src)
+    # Must round-trip through ast.parse
+    ast.parse(stub)


### PR DESCRIPTION
## Arc 6 — code_instruct (work in progress)

Per plan §4 Arc 6. Stacked on #35 → #34 → #33 → #32 → #31 → #30.

**Optimization + tests landed; full 20-Python-repo sweep deferred pending cost approval.** See [`docs/release_notes/v0.8.3/findings-code_instruct.md`](../blob/v083-arc6-code_instruct/docs/release_notes/v0.8.3/findings-code_instruct.md) for context.

## Summary

### No-op stub tautology check (Stage A.5)

Plan §4 Arc 6 (c): reject verifiers that pass with a no-op patch.

The pipeline already does 2-stage verification:
- **Stage A** — test only, no oracle → must FAIL (ImportError class).
- **Stage B** — test + oracle → must PASS.

Gap: a test that just imports the oracle but only checks `assert foo` (truthiness) would pass Stage B with ANY function-shaped no-op. The verifier is tautological.

**Fix.** Insert a Stage A.5 between A and B:

1. Build a stub `task_module.py` from the LLM's solution code. Top-level functions → `def <name>(*args, **kwargs): return None`. Top-level classes → `class <Name>: pass`. Imports + constants dropped.
2. Run pytest against test + stub. If tests **pass**, reject with `reason=test_passes_with_noop_stub`.

The verifier now requires the test to exercise BEHAVIOR, not just existence.

Gated by `CodeInstructOptions.require_test_fails_with_noop_stub: bool = True`.

## Test coverage

**7 new unit tests** in `tests/test_pipeline_code_instruct.py`:
- Function / multi-symbol / async / drops imports & constants / unparseable LLM output / no-callables / stub itself round-trips through ast.parse.

Plus a flag-default-on assertion. Suite at **688 passing**.

## Acceptance criteria

| Gate | Status |
|---|---|
| ≥ 1 optimization landed | ✓ — stub tautology check |
| Existing tests stay green | ✓ — 688 passing |
| Lint + format | ✓ |
| Full 20-Python sweep | ⏸ deferred (cost ~\$80-150) |
| HF dataset published | ⏸ deferred |

## What's pending for full Arc 6 completion

1. Full sweep across 20 Python repos → ~60 verified envs per plan §0.
2. HF push to `AdithyaSK/repo2rlenv-v083-code_instruct`.
3. Findings update with concrete T3 yield + stub-stage skip-reason count.

## Out of scope (deferred to v0.9)
- Haiku-judged verifier-quality second pass.
- Curated instruction-difficulty distribution.

## Notes for reviewer
- Stacked on #35 → … → #30.
- No `pyproject.toml` bump.
- No `Co-Authored-By` trailer.