### PR TITLE
v083 Arc 8 (WIP): refactor_synthesis min-callsite scope filter

### DIFF
--- a/docs/release_notes/v0.8.3/findings-refactor_synthesis.md
+++ b/docs/release_notes/v0.8.3/findings-refactor_synthesis.md
@@ -1,0 +1,64 @@
+# Arc 8 — `refactor_synthesis` sweep findings
+
+**Scope.** Python-native rename-refactor mining. This arc lands one
+optimization from plan §4 Arc 8; the full 20-Python-repo sweep is
+deferred pending cost approval.
+
+## Optimization landed: minimum-callsite scope filter
+
+Plan §4 Arc 8 issue (a): trivial one-symbol renames make weak tasks.
+The agent applies a single-line change and is done — no real reasoning
+exercised.
+
+**Fix.** Add `count_callsite_changes(diff, *, old_name, new_name)` to
+`_rename_detector`: walks the unified diff and counts how many `-` /
+`+` lines mention the old / new name as a **word** (regex word boundary,
+so `foo` doesn't match `foobar`). The def / class signature line is
+excluded from the count — the verifier already requires both ends of
+the rename to be present.
+
+New option `RefactorSynthesisOptions.min_callsites: int = 1` (default).
+A rename whose `added` count falls below this threshold gets skipped
+with `reason=too_few_callsites`. Set 0 to disable the filter; set
+higher per-arc to demand larger-scope refactors (e.g. min_callsites=5
+for "must touch ≥ 5 usages").
+
+## Test coverage
+
+5 new unit tests in `tests/test_rename_detector.py`:
+
+| Test | Covers |
+|---|---|
+| `test_callsite_count_trivial_rename_one_def_no_callsites` | def-only rename → 0/0 |
+| `test_callsite_count_renames_with_two_callsites` | def + 2 changes → (2, 2) |
+| `test_callsite_count_word_boundary` | `foo` ≠ `foobar` |
+| `test_callsite_count_class_rename` | class signature excluded from count |
+| `test_callsite_count_empty_diff` | empty diff → (0, 0) |
+
+Suite at **703 passing**, lint + format clean.
+
+## Acceptance criteria check (this PR)
+
+| Gate | Target | Actual | Pass? |
+|---|---|---|---|
+| ≥ 1 optimization landed | yes | min-callsite scope filter | ✓ |
+| Existing tests stay green | 100% | 703/703 + 2 skipped | ✓ |
+| Lint + format | clean | clean | ✓ |
+| Full 20-Python-repo sweep | yes | **deferred — pending user OK on cost** | — |
+| HF dataset published | yes | **deferred — once full sweep lands** | — |
+
+## What's pending for full completion of this arc
+
+1. **Full sweep across 20 Python repos** — should yield ~55 verified
+   envs per plan §0. Cost envelope ~$50-100 (refactor_synthesis is
+   diff-driven, no per-task LLM; bootstrap LLM only for fresh repos).
+2. **HF push** to `AdithyaSK/repo2rlenv-v083-refactor_synthesis`.
+3. **Findings update** with concrete T3 yield + a callsite-count
+   distribution (informs whether `min_callsites=1` or a higher
+   default makes sense for the launch).
+
+## Out of scope for this arc (deferred to v0.9)
+
+- Instruction wording — describe the WHY (plan §4 Arc 8 (b)).
+- Extract Method / Inline kinds (plan §4 Arc 8 (c), already noted as
+  deferred in plans/CLAUDE.md).

--- a/src/repo2rlenv/pipelines/_rename_detector.py
+++ b/src/repo2rlenv/pipelines/_rename_detector.py
@@ -97,6 +97,49 @@ def _redefines_pattern(name: str) -> re.Pattern[str]:
 class DiffVerifyOutcome:
     ok: bool
     reason: str  # "" when ok; otherwise a short skip reason
+    callsites_removed: int = 0
+    callsites_added: int = 0
+
+
+def count_callsite_changes(unified_diff: str, *, old_name: str, new_name: str) -> tuple[int, int]:
+    """Count rename callsite touches in a unified diff.
+
+    Returns ``(removed_count, added_count)``:
+
+      - removed_count = number of ``-`` lines containing the OLD identifier
+        as a word, EXCLUDING the line that removes the def/class signature.
+      - added_count   = number of ``+`` lines containing the NEW identifier
+        as a word, EXCLUDING the line that adds the new def/class signature.
+
+    The def/class lines are excluded because the rename verifier already
+    requires both ends to be present; we're counting *callsite* touches
+    on top of that. A trivial one-method rename with no other callsites
+    returns ``(0, 0)``.
+    """
+    if not unified_diff:
+        return 0, 0
+    old_word = _bare_word(old_name)
+    new_word = _bare_word(new_name)
+    old_def = _redefines_pattern(old_name)
+    new_def = _redefines_pattern(new_name)
+
+    removed = added = 0
+    for raw_line in unified_diff.splitlines():
+        if raw_line.startswith("---") or raw_line.startswith("+++"):
+            continue
+        if raw_line.startswith("-"):
+            content = raw_line[1:]
+            if old_def.match(content):
+                continue  # the def-removal itself doesn't count as a callsite
+            if old_word.search(content):
+                removed += 1
+        elif raw_line.startswith("+"):
+            content = raw_line[1:]
+            if new_def.match(content):
+                continue
+            if new_word.search(content):
+                added += 1
+    return removed, added
 
 
 def verify_rename_in_diff(unified_diff: str, *, old_name: str, new_name: str) -> DiffVerifyOutcome:

--- a/src/repo2rlenv/pipelines/refactor_synthesis.py
+++ b/src/repo2rlenv/pipelines/refactor_synthesis.py
@@ -340,6 +340,26 @@ class RefactorSynthesisPipeline:
                         self._emit_progress(label, "skip", outcome.reason)
                         continue
 
+                    # v0.8.3 Arc 8: minimum-callsite scope filter. A rename
+                    # that only touches the def site (no other callsites in
+                    # the diff) makes a trivial task — the agent would just
+                    # apply a one-line change. Require ≥ N callsite touches
+                    # on the new-name side.
+                    if self.options.min_callsites > 0:
+                        from repo2rlenv.pipelines._rename_detector import (
+                            count_callsite_changes,
+                        )
+
+                        _removed, added = count_callsite_changes(
+                            diff, old_name=old_name, new_name=new_name
+                        )
+                        if added < self.options.min_callsites:
+                            skip_reasons["too_few_callsites"] = (
+                                skip_reasons.get("too_few_callsites", 0) + 1
+                            )
+                            self._emit_progress(label, "skip", "too_few_callsites")
+                            continue
+
                     # Emit
                     task = self._build_task(
                         commit=commit,

--- a/src/repo2rlenv/spec/options.py
+++ b/src/repo2rlenv/spec/options.py
@@ -273,6 +273,12 @@ class RefactorSynthesisOptions(_BaseOptions):
     # must be fully removed" semantics (will reject most public-API renames).
     require_old_name_gone: bool = False
     require_new_name_present: bool = True
+    # v0.8.3 Arc 8: minimum number of callsite touches required on the new-name
+    # side of the diff (def/class definition itself excluded). A rename that
+    # only touches the def site (zero other callsites) is a trivial one-line
+    # task — set ≥ 1 to require at least one real callsite update. Set 0 to
+    # disable the filter entirely.
+    min_callsites: int = 1
     validation_timeout_sec: int = 300
     skip_validation: bool = False
 

--- a/tests/test_rename_detector.py
+++ b/tests/test_rename_detector.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from repo2rlenv.pipelines._rename_detector import (
+    count_callsite_changes,
     find_rename_in_message,
     verify_rename_in_diff,
 )
@@ -195,3 +196,85 @@ def test_diff_verify_ignores_metadata_lines():
     # Neither side has a real def/class line; we reject for missing old def.
     out = verify_rename_in_diff(diff, old_name="old_name", new_name="new_name")
     assert not out.ok
+
+
+# ---------------------------------------------------------------------------
+# count_callsite_changes — v0.8.3 Arc 8 minimum-callsite scope filter
+# ---------------------------------------------------------------------------
+
+
+def test_callsite_count_trivial_rename_one_def_no_callsites():
+    """Rename-only-the-def → 0 callsite touches on either side."""
+    diff = (
+        "diff --git a/m.py b/m.py\n"
+        "--- a/m.py\n"
+        "+++ b/m.py\n"
+        "@@ -1,2 +1,2 @@\n"
+        "-def foo(x):\n"
+        "+def bar(x):\n"
+        "     return x + 1\n"
+    )
+    removed, added = count_callsite_changes(diff, old_name="foo", new_name="bar")
+    assert removed == 0
+    assert added == 0
+
+
+def test_callsite_count_renames_with_two_callsites():
+    """Def + 2 callsites changed → removed=2, added=2 (def excluded)."""
+    diff = (
+        "diff --git a/m.py b/m.py\n"
+        "--- a/m.py\n"
+        "+++ b/m.py\n"
+        "@@ -1,6 +1,6 @@\n"
+        "-def foo(x):\n"
+        "+def bar(x):\n"
+        "     return x + 1\n"
+        "\n"
+        "-result1 = foo(1)\n"
+        "+result1 = bar(1)\n"
+        "-result2 = foo(2)\n"
+        "+result2 = bar(2)\n"
+    )
+    removed, added = count_callsite_changes(diff, old_name="foo", new_name="bar")
+    assert removed == 2
+    assert added == 2
+
+
+def test_callsite_count_word_boundary():
+    """`foo` should not match `foobar` (substring but not whole word)."""
+    diff = (
+        "diff --git a/m.py b/m.py\n"
+        "--- a/m.py\n"
+        "+++ b/m.py\n"
+        "@@ -1,3 +1,3 @@\n"
+        "-def foo(x): return x\n"
+        "+def bar(x): return x\n"
+        "-foobar = 1\n"
+        "+foobar_new = 1\n"
+    )
+    # The 2nd `-` line contains `foobar` not `foo`; word-boundary regex rejects.
+    removed, _ = count_callsite_changes(diff, old_name="foo", new_name="bar")
+    assert removed == 0  # 0 callsite touches (only foobar, not foo)
+
+
+def test_callsite_count_class_rename():
+    """Works for class-style def too: `class OldFoo:` is excluded from count."""
+    diff = (
+        "diff --git a/m.py b/m.py\n"
+        "--- a/m.py\n"
+        "+++ b/m.py\n"
+        "@@ -1,3 +1,3 @@\n"
+        "-class OldFoo:\n"
+        "+class NewFoo:\n"
+        "-    OldFoo.help()\n"
+        "+    NewFoo.help()\n"
+    )
+    removed, added = count_callsite_changes(diff, old_name="OldFoo", new_name="NewFoo")
+    assert removed == 1
+    assert added == 1
+
+
+def test_callsite_count_empty_diff():
+    removed, added = count_callsite_changes("", old_name="x", new_name="y")
+    assert removed == 0
+    assert added == 0


### PR DESCRIPTION
## Arc 8 — refactor_synthesis (work in progress, FINAL arc)

Per plan §4 Arc 8. Stacked on #37 → … → #30.

**Optimization + tests landed; full 20-Python-repo sweep deferred pending cost approval.** See [`docs/release_notes/v0.8.3/findings-refactor_synthesis.md`](../blob/v083-arc8-refactor_synthesis/docs/release_notes/v0.8.3/findings-refactor_synthesis.md) for context.

## Summary

### Minimum-callsite scope filter

Plan §4 Arc 8 (a): trivial one-symbol renames (def changed, no other callsites) make weak tasks — the agent makes a single-line change and is done.

- Add `count_callsite_changes(diff, *, old_name, new_name)` to `_rename_detector`: counts `-` / `+` lines that mention the old / new name as a **word** (regex word boundary, so `foo` doesn't match `foobar`). The def / class signature line is excluded.
- New `RefactorSynthesisOptions.min_callsites: int = 1` — default requires ≥1 real callsite update in addition to the def. Set 0 to disable; set higher per-arc to demand larger-scope refactors.
- Wired into `RefactorSynthesisPipeline.run` after diff verification — surfaces as `skip_reason=too_few_callsites`.

## Test coverage

**5 new unit tests** in `tests/test_rename_detector.py`:
- Trivial def-only rename / def + 2 callsites / word boundary (foo ≠ foobar) / class-style def excluded / empty diff edge.

Suite at **703 passing**, lint + format clean.

## Acceptance criteria

| Gate | Status |
|---|---|
| ≥ 1 optimization landed | ✓ — min-callsite filter |
| Existing tests stay green | ✓ — 703 passing |
| Lint + format | ✓ |
| Full 20-Python sweep | ⏸ deferred (cost ~\$50-100) |
| HF dataset published | ⏸ deferred |

## What's pending for full Arc 8 completion

1. Full sweep across 20 Python repos → ~55 verified envs per plan §0.
2. HF push to `AdithyaSK/repo2rlenv-v083-refactor_synthesis`.
3. Findings update with callsite-count distribution.

## Out of scope (deferred to v0.9)
- Instruction wording — describe the WHY.
- Extract Method / Inline kinds.

## Notes for reviewer
- Stacked on #37 → … → #30.
- No `pyproject.toml` bump.
- No `Co-Authored-By` trailer.

## After this lands

Once all 8 arcs (#31–#37 + this PR) are merged, the next step is the **release-cut PR**:
- Bump `pyproject.toml` to `0.8.3`
- Aggregate the 8 findings docs into `docs/release_notes/v0.8.3.md`
- Update `CLAUDE.md` test count
- Tag `v0.8.3` → release.yml auto-publishes to PyPI
- (Optional) Run the deferred per-arc sweeps + push aggregated launch dataset