### PR TITLE
Arc 3: commit_runtime — 52 verified envs + filter/leak/artifact fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ A pipeline turns a repo into Harbor tasks. **Two are stable** and recommended fo
 
 > These run normally but emit a warning first — pin a release if you depend on them. Each links to its own page; the gist:
 
-- **[`commit_runtime`](./docs/pipelines/commit_runtime.md)** — mines commit history directly, catching fixes that never went through a PR.
+- **[`commit_runtime`](./docs/pipelines/commit_runtime.md)** — mines commit history directly, catching fixes that never went through a PR. Reference dataset: [`AdithyaSK/repo2rlenv-commit-runtime`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-commit-runtime) (52 oracle-verified envs).
 - **[`cve_patches`](./docs/pipelines/cve_patches.md)** — security tasks from public CVEs, mapped to their fix commits.
 - **[`mutation_bugs`](./docs/pipelines/mutation_bugs.md)** — injects synthetic bugs into real code; the agent must restore the tests to green.
 - **[`code_instruct`](./docs/pipelines/code_instruct.md)** — generates a problem + executable verifier from a real source file.

--- a/docs/pipelines/commit_runtime.md
+++ b/docs/pipelines/commit_runtime.md
@@ -1,66 +1,83 @@
 # `commit_runtime`
 
-R2E-Gym SWE-GEN-style: walk **commits**, not PRs. Trades signal quality for yield — no PR-review filter, much larger candidate pool.
+R2E-Gym SWE-GEN-style PR mining: walk **commits**, not PRs. Trades signal quality for yield, and catches drive-by fixes that never went through a PR — repos that squash-merge or commit directly to main aren't reachable from `pr_runtime` at all.
+
+**As of v0.8.3 the instruction is sourced the same leak-resistant way `pr_runtime` does** (Arc 3 findings: [`findings-commit_runtime`](../release_notes/v0.8.3/findings-commit_runtime.md)). When a commit links an issue with `Closes #N`, the GitHub issue body becomes the problem statement (less leak-prone than the commit message, which often names the function being fixed). Otherwise the commit subject + body are leak-stripped and reflowed.
+
+**Reference dataset**: [`AdithyaSK/repo2rlenv-commit-runtime`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-commit-runtime) — 52 oracle-verified envs across 12 repos (Python + Go).
 
 | | |
 |---|---|
-| Status | **shipped (v0.5)** |
-| Sandbox required at gen | Yes |
-| LLM required at gen | Yes (synthesizes instruction text since there's no PR description) |
-| Reward kinds emitted | `test_execution`, `diff_similarity` |
-| Inspiration | [R2E-Gym (SWE-GEN)](https://github.com/R2E-Gym/R2E-Gym) (UC Berkeley + ANU, COLM '25) |
-| Reference clone | `references/R2E-Gym/` |
+| Status | **experimental** (will promote once the no-linked-issue tail is improved) |
+| Sandbox at generation | Yes — reuses the bootstrap image from `pr_runtime` |
+| LLM use | bootstrap-time only (one-time env build, cached). **No** per-task synthesis — the prompt is the real issue or commit message, not generated. |
+| Reward | Graded F2P/P2P (`reward = f2p_rate × p2p_rate`) via the in-container verifier, identical to `pr_runtime`. Tracked / `command_resolved` / `eval_grade` split documented in [`pr_runtime`](./pr_runtime.md). |
+| Languages | Any (commit_runtime inherits language-agnostic bootstrap from `pr_runtime`) |
+| Inspired by | [R2E-Gym (SWE-GEN)](https://github.com/R2E-Gym/R2E-Gym) (Jain et al., COLM '25) |
 
 ## Why commits, not PRs
 
-R2E-Gym's paper finding: *"instead of using human-written PRs, good-quality execution environments can directly be curated from commits."* They reach 34.4% on SWE-Bench Verified using SWE-GEN data alone — no PR-review-filtered tasks. Commit-based curation:
+R2E-Gym's headline finding: *"instead of using human-written PRs, good-quality execution environments can directly be curated from commits."* Commit-based curation:
 
-- Has no PR-review bottleneck (works on any repo with commit history, even ones that never use PRs)
-- Yields a much larger candidate pool
-- Has noisier signal per task (no human reviewed it)
+- **No PR-review bottleneck.** Works on any repo with commit history, including ones that never use PRs (research / internal / solo-maintained).
+- **Larger candidate pool.** 3-10× bigger than the PR list for most repos.
+- **Noisier signal.** No reviewer signed off; filters have to do all the work.
 
-`commit_runtime` is a **sibling** of `pr_runtime`, not a replacement. They produce complementary task pools.
+`commit_runtime` is a **sibling** of `pr_runtime`, not a replacement. Each works best on different repo shapes:
 
-## Algorithm sketch
+| Repo style | Better fit |
+|---|---|
+| Squash-merge + PR-first (pallets, Django, etc.) | `pr_runtime` — every fix is a PR; commits look like a wall of merge commits |
+| Direct-commit + squash-merge (Go projects, single-maintainer crates, internal repos) | `commit_runtime` — fixes land as plain commits, not behind PR merges |
 
-```mermaid
-flowchart TD
-    A[Repo URL] --> B[git log<br/>filter: touches tests,<br/>file count bounded]
-    B --> C{For each commit}
-    C --> D[harbor: build env<br/>at parent commit]
-    D --> E[Apply commit]
-    E --> F[Run tests, diff behavior]
-    F --> G{Tests change?}
-    G -- no --> Z[Skip]
-    G -- yes --> H[LLM: synthesize<br/>issue text<br/>no PR description exists]
-    H --> I[QA gate]
-    I -- pass --> J[Emit Harbor task]
-    I -- fail --> Z
-```
+Arc 3's 52-env dataset is **Go-heavy** for exactly this reason: `urfave/cli` (15), `gin` (8), `mux` (6) are commit-friendly; `pallets/click` (7) is the Python exception with enough non-PR commits to mine.
 
-1. Clone repo at HEAD
-2. Walk commits in date range matching filters (touches tests, file-count bounded)
-3. For each commit: parent = pre-fix state, HEAD = post-fix state
-4. Build env at parent, apply commit, identify which tests change behavior
-5. **LLM authors a plausible "issue"** describing the symptom (no human PR text exists)
-6. Emit Harbor task
-7. QA gate (4 layers)
+## Algorithm
 
-## Options
+1. `git clone --depth N` (default `clone_depth=200`; bump for monthly mining).
+2. `git log --first-parent <since>..<until>` ⇒ candidate commit list.
+3. **Metadata filter** (`_metadata_filter`):
+   - Drop merge commits (`skip_merge_commits`)
+   - Drop excluded authors (bots)
+   - Drop short messages (< `min_message_words`, default 5)
+   - **Reject non-bugfix conventional-commit types** (`chore:` / `docs:` / `feat:` / `refactor:` / `style:` / `test:` / `ci:` / `build:` / `perf:` / `revert:`)
+   - **Require a bugfix-positive signal**: `fix:` prefix OR `Closes #N` issue trailer OR a bugfix keyword in the subject (`fix` / `bug` / `regression` / `crash` / `broken` / `incorrect` / `wrong` / `fail` / …)
+4. `git show <sha>` ⇒ split into `(source_patch, test_patch)` using `_split_patch_and_test_patch` from `pr_runtime`.
+5. **Structural filter** (`_structural_filter`): skip CI-only diffs, sweeping refactors (file count > `max_source_files_per_commit`), and commits without ≥1 new test function (`require_new_test_funcs`).
+6. **Validate inside the bootstrap sandbox** (`pr_runtime`'s `validate_pr` harness): pre-fix run discovers `FAIL_TO_PASS` + `PASS_TO_PASS` sets; post-fix run confirms the flip.
+7. **Build instruction** (`build_instruction_from_commit`):
+   - If `Closes #N` is present ⇒ fetch the GitHub issue body via `github.fetch_issue` and use it as the problem statement.
+   - Otherwise ⇒ commit subject + body, run through `_strip_info_leak` + `_reflow_pr_body` to remove cross-refs (SHAs, fix-PR links, `(#NNNN)` squash trailers, `repo#N` cross-repo refs) and trim template noise.
+8. Emit a Harbor task with the same shape as `pr_runtime`: `environment/Dockerfile`, `tests/test.sh`, `tests/verifier.py`, `tests/f2p.json`, `tests/p2p.json`, `solution/patch.diff`, and the full `[metadata.repo2env]` block including `reward_calibration` (`f2p_count`, `p2p_count`, `source_files`, `loc_changed`, `difficulty`).
+
+## Options (`CommitRuntimeOptions`)
 
 ```python
-class CommitMiningOptions(BaseModel):
-    limit: int = 500
-    since: date | None = None
-    until: date | None = None
-    require_test_changes: bool = True   # commit must touch test files
-    min_changed_files: int = 1
-    max_changed_files: int = 10         # filter sweeping refactors
-    languages: list[str] = ["python"]
+limit: int = 50                    # max candidate commits to walk
+since: date | None = None
+until: date | None = None
+branch: str = "HEAD"
+clone_depth: int = 200             # bump for monthly mining
+
+# Metadata filters (cheap, applied before validation)
+skip_merge_commits: bool = True
+min_message_words: int = 5
+max_source_files_per_commit: int = 10
+exclude_authors: list[str] = []    # e.g. ["dependabot[bot]@users.noreply.github.com"]
+require_new_test_funcs: bool = True
+skip_ci_only: bool = True
+
+# Validation
+require_fail_to_pass: bool = True
+min_fail_to_pass: int = 1
+validation_timeout_sec: int = 600
 ```
 
-## What we'd reuse from `references/R2E-Gym/`
+## Known limitations (Arc 3 audit)
 
-- Their commit-selection heuristics (which commits qualify as task candidates)
-- The "synthesize an issue from a code change" prompt templates
-- Their hybrid verifier design (execution + LLM judge)
+- **Thin instructions when no issue link.** ~30% of emitted tasks lacked a `Closes #N`, so the instruction is sourced from the commit subject + body — which can be a one-liner. `pr_runtime` is naturally better when there's an issue to fall back on.
+- **Lower yield on PR-driven repos.** Pallets/Django/Flask-style repos merge-commit their PRs; `commit_runtime` correctly rejects all those merge commits and so yields ~0 there. Use `pr_runtime` for those.
+- **Go-subtest parser over-counts untracked failures.** A handful of `stretchr/testify` tasks land tracked-resolved but **not** command_resolved because the verifier marks Go subtests as "untracked failed" when the parent test exited 0. Affects `command_resolved`/`eval_grade` only; gold-patch reward is still 1.0.
+- **No `commit_stream` / continuous variant.** `pr_stream` was removed in v0.8.3 as scope-creep; no plans to add a commit equivalent. If needed in future, it would be flags (`since=auto` + `state-file=…`) on `commit_runtime`, not a separate pipeline.
+
+See [`findings-commit_runtime`](../release_notes/v0.8.3/findings-commit_runtime.md) for the full Arc 3 changelog + audit.

--- a/docs/release_notes/v0.8.3/findings-commit_runtime.md
+++ b/docs/release_notes/v0.8.3/findings-commit_runtime.md
@@ -1,0 +1,99 @@
+# `commit_runtime` — filter / leak / artifact fixes + 52-env reference dataset (Arc 3)
+
+This release sharpens `commit_runtime` end-to-end and ships **52 oracle-verified environments** as the reference dataset. Kept **experimental** for now — the underlying mining problem (commits without linked issues yield thinner instructions than PRs do) hasn't fully gone away, but every other lever has been pulled.
+
+## Published dataset
+
+**<https://huggingface.co/datasets/AdithyaSK/repo2rlenv-commit-runtime>** — added to the [Verifiable RL Environments](https://huggingface.co/collections/AdithyaSK/repo2rlenv-verifiable-rl-environments-6a15e7eee7c112fe841b2990) collection.
+
+- **52 environments**, all oracle-verified (`reward == 1.0` with the gold patch).
+- Resolution split: **52 `resolved`** (tracked SWE-bench-style) · **47 `command_resolved`** (clean test command) · **47 `eval_grade`** (`command_resolved` + non-empty P2P regression guard).
+- 12 source repos: `urfave/cli` 15 · `gin-gonic/gin` 8 · `pallets/click` 7 · `gorilla/mux` 6 · `python-attrs/attrs` 4 · `stretchr/testify` 3 · `spf13/cobra` 3 · `pocketbase/pocketbase` 2 · `pallets/werkzeug` · `encode/httpx` · `sirupsen/logrus` · `psf/requests` (1 each).
+- **Go-heavy by design** — see Audit § Repo skew below.
+- Same shape as the `pr_runtime` reference dataset (manifest with per-task build/oracle status + checksums + dataset commit; plain `tests/verifier.py` + `tests/f2p.json` + `tests/p2p.json` artifacts; inline `environment/Dockerfile` from public bases).
+
+## What changed
+
+`commit_runtime` already reuses `pr_runtime`'s validation harness, so most of Arc 2's wins came along for free. Arc 3 was about everything **upstream** of validation (the mining filters and the instruction text) plus one critical Arc-2 inheritance bug.
+
+### 1. Non-bugfix conventional-commit-type rejection
+
+Before Arc 3, `_CC_PREFIX_RE` only *stripped* the conventional-commit type from a subject. So `chore: bump version`, `docs: typo`, `feat: add X`, `refactor: rename Y`, `style: black format`, `test: cover Z`, `ci: pin actions`, `build: drop py3.10`, `perf: hot loop`, and `revert: …` all sailed past the filter, got bootstrapped, and burned validation cycles before finally getting rejected at the F2P stage. The new `_NON_BUG_TYPE_RE` returns `non_bugfix_type` from `_metadata_filter` for those, mirroring `pr_runtime._NON_BUG_TITLE_RE`.
+
+### 2. Bugfix positive-signal filter
+
+A commit with no type prefix had no positive bugfix signal either — so plain-subject feature commits ("Update README", "Improve performance") slipped through. Now `_metadata_filter` requires at least one of:
+
+- `fix:` prefix
+- A `Closes #N` / `Fixes #N` issue trailer
+- A bugfix keyword in the subject (`fix` / `bug(fix|s)?` / `regression` / `crash(ed|ing)?` / `broken` / `incorrect(ly)?` / `wrong(ly)?` / `fail(s|ed|ing|ure)?` / `defect` / `hotfix` / `patch(ed)?`)
+
+### 3. Issue-fetch fallback for the instruction
+
+The biggest single quality lever, ported from Arc 2's PR-body leak fix. Commit messages routinely name the function being fixed ("Fix off-by-one in `Pager.advance`"), describe the fix approach, and link to companion fix-PRs or commit SHAs. The bug **report** doesn't usually do any of that.
+
+When a commit has `Closes #N`, `build_instruction_from_commit` now fetches the issue body (`github.fetch_issue`, same path `pr_runtime` uses) and renders that as the problem statement. Commits without a linked issue fall back to the commit subject + body, run through `_strip_info_leak` and `_reflow_pr_body`. The smoke test on `pallets/click` showed the first emitted task's instruction came verbatim from the GitHub issue, not the commit message — exactly the design.
+
+### 4. Solution-leak strip + extended patterns
+
+Imported `_strip_info_leak` from `pr_runtime` and applied it to commit subject + body. Plus two new patterns covering the audit's residual soft leaks:
+
+- **Trailing `(#NNNN)` squash trailers** — Pallets/Werkzeug/Flask/httpx all squash-merge PRs with `(#1234)` appended to the subject; that's a direct lookup back to the merged fix.
+- **Cross-repo issue refs without a closes keyword** (`gorilla#739` style) — the existing `_LEAK_PATTERNS` only caught the `owner/repo#N` form when paired with a closes keyword.
+
+Both shared with `pr_runtime` since the patterns are universally applicable.
+
+### 5. Body reflow
+
+Ported `_reflow_pr_body` (drop HTML template comments, stop at checklist headers, collapse blank runs, length cap) — commit bodies can be just as verbose as PR bodies, especially when authors paste in CI output or sign-off lines.
+
+### 6. `reward_calibration` stamping (parity with `pr_runtime`)
+
+Emitted tasks now carry `[metadata.repo2env.reward_calibration]` with `f2p_count`, `p2p_count`, `source_files`, `loc_changed`, and a bucketed `difficulty` — and the `HarborTask.difficulty` is set from the bucket rather than the hard-coded `"medium"`. The launch-side manifest enricher (`plans/build_enriched_manifest.py`) reads these to compute the `eval_grade` flag without re-parsing the diff.
+
+### 7. The critical bug: emit graded `test.sh` + plain artifacts (Arc 2 inheritance miss)
+
+Arc 2 refactored `pr_runtime` to ship `tests/{verifier.py,f2p.json,p2p.json}` as plain task artifacts and to call them from `test.sh`. `commit_runtime` never inherited that — it called `pr_runtime.build_eval_script` *without* `fail_to_pass` / `pass_to_pass`, which falls back to the binary exit-code path. Result: emitted `test.sh` only wrote `reward.txt` (binary 1.0/0.0), `reward.json` was **never** written, and `tracked` / `command_resolved` / the full F2P/P2P breakdown were silently lost across the whole dataset.
+
+Two fixes:
+
+- Pass `fail_to_pass=…, pass_to_pass=…` to `build_eval_script` so the graded path triggers.
+- Pass `aux_files=_runtime_aux_files(fail_to_pass, pass_to_pass)` to the emitted `HarborTask` so the three artifacts ship with the task dir.
+
+The oracle gate caught this immediately — `0/56 reward.json` files on the first run vs `52/52 reward.json` after the fix.
+
+## Validation evidence
+
+Full 100-task-style oracle gate run on the 52-env dataset:
+
+- **52/52 tracked-resolved** (gold patch always satisfies the F2P+P2P sets — the oracle invariant).
+- **47/52 command_resolved.** The 5 that aren't: 3× `spf13/cobra` (one untracked failure each — sibling test in the same file that the gold patch doesn't touch) + 2× `stretchr/testify` (22 untracked failures each — Go-subtest parser over-counts; see Limitations below).
+- **47/52 eval_grade.** All 47 `command_resolved` tasks also have `p2p_count > 0`, so `eval_grade` matches `command_resolved` exactly on this dataset.
+
+A separate qualitative audit on 9 stratified tasks (one per repo, eval_grade + edge cases): **5/9 gold-standard** (clean issue body sourced from GitHub, well-scoped F2P/P2P, real source fix), **3/9 mediocre** (thin commit-message-fallback instructions when no linked issue), **1/9 weak** (270-char title-only prompt — also one of the 4 broken-oracle tasks that was dropped pre-publish). The mediocre tail is the structural commit-runtime limitation, not a fixable bug.
+
+**4 broken-oracle tasks dropped** from the 56 generated: `psf__requests-6404f3`, `stretchr__testify-15f682`, `urfave__cli-195aaf`, `urfave__cli-b4f42d`. All scored 0.97-0.999 on the gold patch — single flaky P2P each, same shape as Arc 2's `urfave__cli-2290`/`TestCompletionShell`. Could be salvaged with the same flaky-P2P prune Arc 2 used; left for a future polish pass.
+
+## Limitations
+
+- **Thin instructions when no linked issue.** ~30% of tasks have no `Closes #N` and fall back to the commit subject + body. When the commit subject is a one-liner ("Fix RFC 2069 mode digest authentication"), the agent has very little to work with. This is the structural difference vs `pr_runtime` and the reason `commit_runtime` stays experimental.
+- **Go-subtest parser over-counts untracked failures.** The verifier's Go-test log parser treats each subtest line as a tracked test, so when a subtest fails inside a non-F2P parent the count of "untracked failed" balloons (22 for `stretchr/testify` even though the test command exited 0). Affects `command_resolved` / `eval_grade` flagging only; `resolved` and the graded `reward` are correct. Subtest-aware grouping is a follow-up.
+- **Lower yield on PR-driven repos.** Pallets/Werkzeug/Flask/httpx all merge-commit their PRs; `commit_runtime` correctly rejects those merge commits and yields ~0 directly mineable bugfix commits. Use `pr_runtime` for those repos — that's its turf.
+- **Go-heavy reference dataset.** 39/52 envs are Go (urfave/gin/mux/cobra/testify/logrus) because Go projects in the bootstrap-cached set commit directly + squash-merge more than the Python projects do. This isn't a `commit_runtime` defect — it's the pipeline's natural fit shining through. Documented up-front for any eval that wants language balance.
+- **No `commit_stream` continuous variant.** Same call as Arc 2: if continuous mining ever becomes a hard requirement, it's flags on `commit_runtime` (`since=auto` + `state-file=…`), not a separate pipeline.
+
+## How it was generated
+
+```bash
+# Per repo: bootstrap (cached from Arc 2) + mine/validate commits
+repo2rlenv generate --repo <owner>/<repo> --pipeline commit_runtime \
+  --pipeline-opt limit=120 --pipeline-opt clone_depth=400 \
+  --llm anthropic/claude-sonnet-4-6 \
+  --out ./stage/<repo>
+
+# Oracle-gate (keep reward 1.0), drop broken oracles, push
+harbor run -p ./pool -a oracle --env docker -n 5
+repo2rlenv push ./dataset AdithyaSK/repo2rlenv-commit-runtime --inline-dockerfile
+```
+
+Scale driver: `plans/arc3_scale.py` (gitignored, launch-side).

--- a/src/repo2rlenv/pipelines/commit_runtime.py
+++ b/src/repo2rlenv/pipelines/commit_runtime.py
@@ -50,6 +50,8 @@ from repo2rlenv.pipelines.base import PipelineResult
 from repo2rlenv.pipelines.pr_runtime import (
     _count_new_test_funcs,
     _files_in_patch,
+    _linked_issue_number,
+    _strip_info_leak,
     build_environment_dockerfile,
     build_eval_script,
     normalize_test_cmds_for_runtime,
@@ -62,12 +64,34 @@ from repo2rlenv.spec.options import CommitRuntimeOptions
 logger = logging.getLogger(__name__)
 
 
-# Strips "Closes #N", "Fixes #N", "Resolves #N" trailers from commit bodies
-_CLOSES_RE = re.compile(r"\b(?:closes|fixes|resolves)\s+#\d+\b", re.IGNORECASE)
+# Strips "Closes #N" / "Fixes [#N](...)" trailers from commit bodies.
+# Includes the markdown form Arc 2 added (`fixes [#1234](url)`) and the
+# bare `[#N](url)` link form too.
+_CLOSES_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+\[?#\d+\]?(?:\([^)]*\))?",
+    re.IGNORECASE,
+)
 
 # Strips conventional-commit prefixes ("fix: ", "feat(scope): ", etc.) from subjects
 _CC_PREFIX_RE = re.compile(
     r"^(?:fix|feat|chore|docs|refactor|test|perf|build|ci|style|revert)(?:\([^)]+\))?:\s*",
+    re.IGNORECASE,
+)
+
+# Conventional-commit types that are NOT bugfixes. These slip into the
+# candidate pool today because `_CC_PREFIX_RE` only *strips* the prefix; it
+# doesn't reject. Mirrors `pr_runtime._NON_BUG_TITLE_RE` for the commit world.
+_NON_BUG_TYPE_RE = re.compile(
+    r"^(?:chore|docs|feat|refactor|style|test|ci|build|perf|revert)(?:\([^)]+\))?:\s*",
+    re.IGNORECASE,
+)
+
+# A bugfix-positive signal we look for when no `fix:` prefix is present and
+# no `Closes #N` trailer links an issue. Avoids letting feature commits with
+# no type prefix sail through.
+_BUGFIX_KEYWORD_RE = re.compile(
+    r"\b(?:fix(?:e[sd])?|fixing|bug(?:fix|s)?|regression|crash(?:e[sd]|ing)?|broken|"
+    r"incorrect(?:ly)?|wrong(?:ly)?|fail(?:s|ed|ing|ure)?|defect|hotfix|patch(?:e[sd])?)\b",
     re.IGNORECASE,
 )
 
@@ -88,9 +112,16 @@ def _strip_commit_prefix(subject: str) -> str:
 
 
 def build_instruction_from_commit(commit: CommitInfo) -> str:
-    """Render a commit's subject + body into a task-prompt-shaped string."""
-    subject = _strip_commit_prefix(commit.subject)
-    body = _CLOSES_RE.sub("", commit.body or "").strip()
+    """Render a commit's subject + body into a task-prompt-shaped string.
+
+    Commit messages are leak-prone (the subject often names the function /
+    bug being fixed). We run subject + body through `_strip_info_leak`
+    (ported from `pr_runtime`) so cross-references to fix commits, SHAs,
+    markdown PR/issue links, and `#N` trailers don't pre-solve the task.
+    """
+    subject = _strip_info_leak(_strip_commit_prefix(commit.subject)).strip()
+    body = _CLOSES_RE.sub("", commit.body or "")
+    body = _strip_info_leak(body).strip()
     parts = [f"# Issue\n\n**Title:** {subject}"]
     if body:
         parts.append("## Description\n\n" + body)
@@ -305,7 +336,16 @@ class CommitRuntimePipeline:
     # ----- filters ------------------------------------------------------------
 
     def _metadata_filter(self, commit: CommitInfo) -> str | None:
-        """Cheap filters that don't need the diff content."""
+        """Cheap filters that don't need the diff content.
+
+        Bugfix detection runs in two stages: (a) reject conventional-commit
+        types that are explicitly not bugfixes (chore/docs/feat/refactor/
+        style/test/ci/build/perf/revert), (b) require a positive bugfix
+        signal — `fix:` prefix, a `Closes #N` / `Fixes #N` issue trailer,
+        or a bugfix keyword in the subject. Together these mirror Arc 2's
+        non-bug-PR rejection and stop feature/refactor commits from
+        burning bootstrap cycles in validation.
+        """
         if self.options.skip_merge_commits and commit.is_merge:
             return "merge_commit"
         if commit.author_email in self.options.exclude_authors:
@@ -317,6 +357,16 @@ class CommitRuntimePipeline:
             and _word_count(commit.message) < self.options.min_problem_statement_words
         ):
             return "problem_statement_too_short"
+        subject = commit.subject or ""
+        # (a) explicit non-bugfix type prefix → reject.
+        if _NON_BUG_TYPE_RE.match(subject):
+            return "non_bugfix_type"
+        # (b) at least one bugfix signal must be present.
+        has_fix_prefix = bool(re.match(r"^fix(?:\([^)]+\))?:\s*", subject, re.IGNORECASE))
+        has_linked_issue = _linked_issue_number(commit.message or "") is not None
+        has_keyword = bool(_BUGFIX_KEYWORD_RE.search(subject))
+        if not (has_fix_prefix or has_linked_issue or has_keyword):
+            return "no_bugfix_signal"
         return None
 
     def _structural_filter(self, source_patch: str, test_patch: str) -> str | None:

--- a/src/repo2rlenv/pipelines/commit_runtime.py
+++ b/src/repo2rlenv/pipelines/commit_runtime.py
@@ -46,11 +46,15 @@ from repo2rlenv.bootstrap.runner import _shallow_clone_at_ref
 from repo2rlenv.bootstrap.spec import BootstrapResult
 from repo2rlenv.emitter.harbor import HarborTask, write_harbor_task
 from repo2rlenv.git_local import CommitInfo, GitError, list_commits, show_diff
+from repo2rlenv.github import fetch_issue
 from repo2rlenv.pipelines.base import PipelineResult
 from repo2rlenv.pipelines.pr_runtime import (
     _count_new_test_funcs,
+    _diff_loc_changed,
+    _difficulty_bucket,
     _files_in_patch,
     _linked_issue_number,
+    _reflow_pr_body,
     _strip_info_leak,
     build_environment_dockerfile,
     build_eval_script,
@@ -111,18 +115,32 @@ def _strip_commit_prefix(subject: str) -> str:
     return cleaned.strip()
 
 
-def build_instruction_from_commit(commit: CommitInfo) -> str:
-    """Render a commit's subject + body into a task-prompt-shaped string.
+def build_instruction_from_commit(
+    commit: CommitInfo,
+    *,
+    issue: tuple[str, str] | None = None,
+) -> str:
+    """Render a commit's subject + body (or a linked issue) into the task prompt.
 
-    Commit messages are leak-prone (the subject often names the function /
-    bug being fixed). We run subject + body through `_strip_info_leak`
-    (ported from `pr_runtime`) so cross-references to fix commits, SHAs,
-    markdown PR/issue links, and `#N` trailers don't pre-solve the task.
+    Sourcing order — same lesson as Arc 2's `pr_runtime` fix:
+      1. If the commit links an issue (``Closes #N``) and the caller has
+         fetched it, use the **issue title + body** as the problem statement.
+         The bug report is far less leak-prone than the commit message, which
+         frequently names the function being fixed and points at fix-PRs.
+      2. Otherwise fall back to the commit subject + body, run through
+         `_strip_info_leak` + `_reflow_pr_body` to scrub cross-refs and trim
+         template noise / line-wrap chatter.
     """
-    subject = _strip_info_leak(_strip_commit_prefix(commit.subject)).strip()
-    body = _CLOSES_RE.sub("", commit.body or "")
-    body = _strip_info_leak(body).strip()
-    parts = [f"# Issue\n\n**Title:** {subject}"]
+    if issue is not None:
+        i_title, i_body = issue
+        title = _strip_info_leak(i_title).strip()
+        body = _reflow_pr_body(_strip_info_leak(_CLOSES_RE.sub("", i_body or ""))).strip()
+    else:
+        title = _strip_info_leak(_strip_commit_prefix(commit.subject)).strip()
+        body = _reflow_pr_body(_strip_info_leak(_CLOSES_RE.sub("", commit.body or ""))).strip()
+    if not title:
+        title = _strip_commit_prefix(commit.subject) or "(no title)"
+    parts = [f"# Issue\n\n**Title:** {title}"]
     if body:
         parts.append("## Description\n\n" + body)
     parts.append(
@@ -301,6 +319,14 @@ class CommitRuntimePipeline:
                             self._emit_progress(label, "skip", outcome.reason or "no_fail_to_pass")
                             continue
 
+                    # Issue-fetch fallback: when the commit links an issue
+                    # (`Closes #N`), source the problem statement from the
+                    # issue body — the bug report is far less leak-prone than
+                    # the commit message. Same lesson as Arc 2 for pr_runtime.
+                    issue_num = _linked_issue_number(commit.message or "")
+                    issue = None
+                    if issue_num is not None:
+                        issue = fetch_issue(owner, name, issue_num, token=token)
                     task = self._build_task(
                         commit,
                         patch,
@@ -308,6 +334,7 @@ class CommitRuntimePipeline:
                         fail_to_pass=fail_to_pass,
                         pass_to_pass=pass_to_pass,
                         validation_status=validation_status,
+                        issue=issue,
                     )
                     write_harbor_task(task, out_dir)
                     emitted += 1
@@ -410,6 +437,7 @@ class CommitRuntimePipeline:
         fail_to_pass: list[str],
         pass_to_pass: list[str],
         validation_status: str,
+        issue: tuple[str, str] | None = None,
     ) -> HarborTask:
         owner, name = self.input.repo.owner_name
         # commit_runtime task ID convention: <owner>__<repo>-<sha12>
@@ -435,9 +463,11 @@ class CommitRuntimePipeline:
             base_commit=commit.parent_sha,
         )
 
+        loc_changed = _diff_loc_changed(patch)
+        difficulty = _difficulty_bucket(len(fail_to_pass), loc_changed)
         repo2env = {
             "pipeline": "commit_runtime",
-            "pipeline_version": "0.5.0",
+            "pipeline_version": "0.8.3",
             "repo": f"{owner}/{name}",
             "ref": commit.parent_sha,
             "reference": f"https://github.com/{owner}/{name}/commit/{commit.sha}",
@@ -456,16 +486,26 @@ class CommitRuntimePipeline:
                 "validation_status": validation_status,
                 "bootstrap_image": self.bootstrap.image_digest,
             },
+            # Calibration parity with pr_runtime: lets the manifest enricher
+            # compute difficulty / p2p_count == 0 / loc_changed sliceability
+            # without re-parsing the diff.
+            "reward_calibration": {
+                "f2p_count": len(fail_to_pass),
+                "p2p_count": len(pass_to_pass),
+                "source_files": len(_files_in_patch(patch)),
+                "loc_changed": loc_changed,
+                "difficulty": difficulty,
+            },
         }
 
         return HarborTask(
             name=task_id,
             org=self.input.output.org,
             description=_strip_commit_prefix(commit.subject) or task_id,
-            instruction=build_instruction_from_commit(commit),
+            instruction=build_instruction_from_commit(commit, issue=issue),
             oracle_diff=patch,
             repo2env=repo2env,
-            difficulty="medium",
+            difficulty=difficulty,
             category="bugfix",
             keywords=[name, "commit_runtime"],
             environment_dockerfile=dockerfile,

--- a/src/repo2rlenv/pipelines/commit_runtime.py
+++ b/src/repo2rlenv/pipelines/commit_runtime.py
@@ -55,6 +55,7 @@ from repo2rlenv.pipelines.pr_runtime import (
     _files_in_patch,
     _linked_issue_number,
     _reflow_pr_body,
+    _runtime_aux_files,
     _strip_info_leak,
     build_environment_dockerfile,
     build_eval_script,
@@ -452,6 +453,11 @@ class CommitRuntimePipeline:
                 _files_in_patch(test_patch),
             ),
             language=self.bootstrap.language.value,
+            # Without F2P/P2P, build_eval_script returns the binary exit-code
+            # script and reward.json is never written. Pass them in so we get
+            # the graded path + tracked/command_resolved breakdown.
+            fail_to_pass=fail_to_pass,
+            pass_to_pass=pass_to_pass,
         )
         image_ref = (
             self.bootstrap.image_digest
@@ -510,4 +516,10 @@ class CommitRuntimePipeline:
             keywords=[name, "commit_runtime"],
             environment_dockerfile=dockerfile,
             test_script=eval_script,
+            # Ship the graded verifier + F2P/P2P JSON as plain task artifacts
+            # (Harbor mounts tests/ at /tests). Same shape pr_runtime ships
+            # after Arc 2's plain-artifacts refactor — without this, test.sh
+            # falls back to the exit-code reward and reward.json is never
+            # written, so tracked/command_resolved + the breakdown are lost.
+            aux_files=_runtime_aux_files(fail_to_pass, pass_to_pass) if fail_to_pass else {},
         )

--- a/src/repo2rlenv/pipelines/pr_runtime.py
+++ b/src/repo2rlenv/pipelines/pr_runtime.py
@@ -116,6 +116,14 @@ _LEAK_PATTERNS: tuple[re.Pattern[str], ...] = (
     ),
     # Markdown issue/PR refs `[#1234](url)` and bare `[#1234]`
     re.compile(r"\[#\d+\]\([^)]*\)"),
+    # Parenthesized PR/issue ref at the end of a commit subject — common
+    # "merged via squash" trailer: `Fix X (#1234)`. Strip incl. preceding
+    # whitespace so the title cleans up to "Fix X".
+    re.compile(r"\s*\(#\d+\)"),
+    # Cross-repo issue refs without a closes keyword (`gorilla#739`).
+    # Distinct from owner/repo#N (which has a slash) — that's already
+    # covered by the closes pattern above when paired with a keyword.
+    re.compile(r"\b[a-zA-Z][\w.-]*#\d+\b"),
 )
 
 

--- a/tests/test_pipeline_commit_runtime.py
+++ b/tests/test_pipeline_commit_runtime.py
@@ -203,6 +203,113 @@ def test_instruction_strips_leak_from_subject():
     assert "#42" not in out
 
 
+def test_instruction_uses_issue_when_provided():
+    """When `issue=(title, body)` is supplied (issue-fetch fallback), the
+    problem statement comes from the issue — not the leak-prone commit msg."""
+    commit = _make_commit(
+        subject="fix: off-by-one in `Pager.advance`",  # leaks the function name
+        body="See [#42](https://github.com/o/r/issues/42)",
+    )
+    issue = (
+        "Pagination skips the last entry",
+        "When you click 'next' on the final page, the trailing entry vanishes.",
+    )
+    out = build_instruction_from_commit(commit, issue=issue)
+    # Issue text drives the prompt
+    assert "Pagination skips the last entry" in out
+    assert "trailing entry vanishes" in out
+    # And the commit-message leak ("Pager.advance", "off-by-one") does NOT appear
+    assert "Pager.advance" not in out
+    assert "off-by-one" not in out
+
+
+def test_instruction_reflows_long_body_with_template_noise():
+    """Verbose commit bodies get the same `_reflow_pr_body` cleanup as PRs:
+    drop HTML template comments, stop at checklist headers, collapse blanks."""
+    commit = _make_commit(
+        body=(
+            "<!-- thanks for the contribution -->\n"
+            "Real problem statement: parser crashes on empty input.\n\n\n\n"
+            "## Checklist\n"
+            "- [ ] tests added\n"
+            "- [ ] docs updated\n"
+        )
+    )
+    out = build_instruction_from_commit(commit)
+    assert "Real problem statement" in out
+    assert "thanks for the contribution" not in out
+    # Checklist noise stripped from the description
+    assert "tests added" not in out
+
+
+# -------------------------- _build_task metadata ------------------------------
+
+
+def _stub_pipeline_for_build_task(test_cmds=None, language="python"):
+    """A pipeline instance with just enough scaffolding to call `_build_task`."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    pipe = CommitRuntimePipeline.__new__(CommitRuntimePipeline)
+    pipe.options = CommitRuntimeOptions()
+    pipe.bootstrap = SimpleNamespace(
+        image_tag="local/r2e-bootstrap/o__r:abc",
+        image_digest="local/r2e-bootstrap/o__r:abc",
+        pushed_to_registry=False,
+        test_cmds=test_cmds or ["pytest -v"],
+        language=SimpleNamespace(value=language),
+    )
+    pipe.input = MagicMock()
+    pipe.input.repo.owner_name = ("o", "r")
+    pipe.input.repo.access = "auto"
+    pipe.input.repo.url = "https://github.com/o/r"
+    pipe.input.output.org = "default"
+    pipe.input.llm = None
+    pipe.input.bootstrap.platform = "linux/amd64"
+    pipe._progress_cb = None
+    return pipe
+
+
+def test_build_task_stamps_reward_calibration_and_difficulty():
+    """Tasks now carry reward_calibration parity with pr_runtime — needed by
+    the manifest enricher and the eval_grade flag."""
+    pipe = _stub_pipeline_for_build_task()
+    commit = _make_commit(subject="fix: parser crashes on empty input")
+    # one-line patch + one new F2P test ⇒ trivial bucket
+    patch = (
+        "diff --git a/parser.py b/parser.py\n"
+        "--- a/parser.py\n"
+        "+++ b/parser.py\n"
+        "@@ -1,2 +1,2 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+    test_patch = (
+        "diff --git a/tests/test_parser.py b/tests/test_parser.py\n"
+        "--- a/tests/test_parser.py\n"
+        "+++ b/tests/test_parser.py\n"
+        "@@ -0,0 +1,3 @@\n"
+        "+def test_empty_input():\n"
+        "+    assert True\n"
+    )
+    task = pipe._build_task(
+        commit,
+        patch,
+        test_patch,
+        fail_to_pass=["tests/test_parser.py::test_empty_input"],
+        pass_to_pass=["tests/test_parser.py::test_other"],
+        validation_status="ok",
+    )
+    cal = task.repo2env["reward_calibration"]
+    assert cal["f2p_count"] == 1
+    assert cal["p2p_count"] == 1
+    assert cal["source_files"] == 1
+    assert cal["loc_changed"] >= 1
+    assert cal["difficulty"] in {"trivial", "small", "medium", "large"}
+    # The HarborTask's difficulty is set from the bucket, not hard-coded "medium"
+    assert task.difficulty == cal["difficulty"]
+
+
 # -------------------------- structural filter ---------------------------------
 
 

--- a/tests/test_pipeline_commit_runtime.py
+++ b/tests/test_pipeline_commit_runtime.py
@@ -133,6 +133,76 @@ def test_metadata_filter_passes_a_good_commit():
     assert pipe._metadata_filter(_make_commit()) is None
 
 
+def test_metadata_filter_rejects_non_bugfix_types():
+    """chore/docs/feat/refactor/style/test/ci/build/perf/revert are NOT bugfixes."""
+    pipe = _pipeline_for_filter_tests()
+    for prefix in (
+        "chore: bump",
+        "docs: typo fix",
+        "feat(api): new endpoint",
+        "refactor: rename helper",
+        "style: black format",
+        "test: add coverage",
+        "ci: pin actions",
+        "build: drop py3.10",
+        "perf: hot loop tweak",
+        "revert: revert previous change",
+    ):
+        c = _make_commit(subject=prefix, body="long enough body text here")
+        assert pipe._metadata_filter(c) == "non_bugfix_type", prefix
+
+
+def test_metadata_filter_no_bugfix_signal_is_rejected():
+    """No `fix:` prefix, no `Closes #N`, no bugfix keyword ⇒ rejected."""
+    pipe = _pipeline_for_filter_tests()
+    c = _make_commit(subject="Update README with new logo", body="")
+    assert pipe._metadata_filter(c) == "no_bugfix_signal"
+
+
+def test_metadata_filter_keeps_fix_prefix():
+    pipe = _pipeline_for_filter_tests()
+    c = _make_commit(subject="fix: off-by-one in pager", body="")
+    assert pipe._metadata_filter(c) is None
+
+
+def test_metadata_filter_keeps_linked_issue_even_without_keyword():
+    """A commit that links an issue (e.g. `Closes #42`) is a bugfix signal."""
+    pipe = _pipeline_for_filter_tests()
+    c = _make_commit(subject="Update token handling", body="Closes #42, see context.")
+    assert pipe._metadata_filter(c) is None
+
+
+def test_metadata_filter_keeps_bugfix_keyword_in_subject():
+    pipe = _pipeline_for_filter_tests()
+    c = _make_commit(subject="Repair broken parser regression on Windows", body="")
+    assert pipe._metadata_filter(c) is None
+
+
+# -------------------------- instruction leak strip ----------------------------
+
+
+def test_instruction_strips_fix_pr_link_leak():
+    """Markdown PR/commit links in the body must not leak into the instruction."""
+    commit = _make_commit(
+        body=(
+            "This bug was first noticed in [#1234](https://github.com/o/r/pull/1234) "
+            "and the fix is in commit 0123456789abcdef0123456789abcdef01234567. "
+            "Replaces the broken thing."
+        ),
+    )
+    out = build_instruction_from_commit(commit)
+    assert "1234" not in out
+    assert "0123456789abcdef" not in out
+    assert "Replaces the broken thing" in out  # context preserved
+
+
+def test_instruction_strips_leak_from_subject():
+    """Cross-references in the subject itself must also be stripped."""
+    commit = _make_commit(subject="fix: regression introduced in [#42](url)", body="")
+    out = build_instruction_from_commit(commit)
+    assert "#42" not in out
+
+
 # -------------------------- structural filter ---------------------------------
 
 


### PR DESCRIPTION
Arc 3 of the v0.8.3 pipeline-by-pipeline optimization. Closes #46. Predecessors: Arc 1 `pr_diff` (#40), Arc 2 `pr_runtime` (#45) — both merged.

## What shipped

**Dataset**: [`AdithyaSK/repo2rlenv-commit-runtime`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-commit-runtime) — **52 oracle-verified envs** across 12 repos (Python + Go). Added to the [Verifiable RL Environments collection](https://huggingface.co/collections/AdithyaSK/repo2rlenv-verifiable-rl-environments-6a15e7eee7c112fe841b2990).

| | Count | % |
|---|---|---|
| `resolved` (tracked SWE-bench-style) | 52 | 100% |
| `command_resolved` (clean test command) | 47 | 90% |
| `eval_grade` (cmd_resolved + has P2P guard) | 47 | 90% |

**Kept experimental** — not promoting to stable yet. The structural limitation (commits without `Closes #N` give thinner instructions than `pr_runtime` does) hasn't fully gone away. README/at-a-glance table updated accordingly.

## Code changes

1. **Mining filters** (`2549b0f`) — non-bugfix conventional-commit-type rejection (`chore:` / `docs:` / `feat:` / `refactor:` / …) + bugfix positive-signal requirement (`fix:` prefix OR `Closes #N` OR keyword in subject).
2. **Instruction quality** (`5db9d2d`) — issue-fetch fallback when `Closes #N` is present (sources problem statement from the issue body, not the leak-prone commit message), body reflow, `reward_calibration` metadata stamping for manifest parity with `pr_runtime`.
3. **Critical Arc 2 inheritance fix** (`758b56d`) — commit_runtime was calling `build_eval_script` without `fail_to_pass` / `pass_to_pass`, hitting the binary-reward fallback path; `reward.json` was **never** written across the whole pipeline. Plus emitted tasks shipped only `test.sh`, missing the plain `tests/{verifier.py,f2p.json,p2p.json}` artifacts. Both fixed. Extended `_strip_info_leak` to catch trailing `(#NNNN)` squash trailers + cross-repo `repo#N` refs (shared with `pr_runtime`).
4. **README + manifest enricher** (`e7e5613`) — dataset link in the experimental list; hardened the trial-ID matcher in `plans/build_enriched_manifest.py` so harbor's SHA truncation doesn't drop tasks from the count.
5. **Docs** (`07b0b2a`) — rewrote `docs/pipelines/commit_runtime.md` to match the current pipeline (the old doc still claimed an LLM authors instruction text). Added `docs/release_notes/v0.8.3/findings-commit_runtime.md`.

## Audit / validation

- Full 100-task-style oracle gate: 52/52 resolved, 47/52 command_resolved (5 untracked-failure tail: 3 cobra single-test, 2 testify Go-subtest parser over-count), 47/52 eval_grade.
- Stratified qualitative audit of 9 tasks: 5 gold-standard, 3 mediocre (thin no-linked-issue instructions), 1 weak (also one of the dropped broken-oracle tasks).
- 4 broken-oracle tasks dropped pre-publish (`psf/requests-6404f3`, `testify-15f682`, `cli-195aaf`, `cli-b4f42d` — all single flaky P2P, 0.97-0.999 on gold).
- 723 tests pass · ruff lint + format clean · CI green.

## Out of scope (deliberately)

- **100-env target.** Arc 2 hit 100 because pallets repos let `pr_runtime` mine 30+ per repo. For `commit_runtime` those same repos merge-commit their PRs and yield ~0 directly mineable bugfix commits (correctly filtered out). 52 is what the pipeline's natural fit produces on the bootstrap-cached repo set; the remaining ~50 would require new bootstraps which is out of Arc 3's scope.
- **Promote to stable.** Not yet — the no-linked-issue instruction tail and the Go-subtest parser issue should land first.
- **Flaky-P2P prune** on the 4 dropped tasks. Could be salvaged Arc-2-style; left for a polish round.
- **`commit_stream` / continuous variant.** `pr_stream` was already removed as scope-creep; if needed it's flags on `commit_runtime`, not a separate pipeline.
