### PR TITLE
fix(commit_runtime): warn when candidate count reaches clone_depth

### DIFF
--- a/src/repo2rlenv/pipelines/commit_runtime.py
+++ b/src/repo2rlenv/pipelines/commit_runtime.py
@@ -239,6 +239,15 @@ class CommitRuntimePipeline:
                 self.options.since,
                 self.options.until,
             )
+            if len(candidates) >= self.options.clone_depth:
+                logger.warning(
+                    "commit_runtime: candidate count (%d) reached clone_depth=%d — "
+                    "the shallow clone may be truncating history. "
+                    "Pass --pipeline-opt clone_depth=%d or higher to capture more commits.",
+                    len(candidates),
+                    self.options.clone_depth,
+                    self.options.clone_depth * 2,
+                )
 
             try:
                 for commit in candidates:


### PR DESCRIPTION
~~commit_runtime was only stripping "Closes #N" trailers, leaving
cherry-pick refs, backport URLs, and bare SHAs in the instruction
text. Apply the same _strip_info_leak() already used by pr_runtime. (not sure this was intentional)~~

Also warn when candidate count reaches clone_depth, which indicates
the shallow clone may be truncating history.