### PR TITLE
feat: input-source abstraction — local + GitLab repos (capability-gated)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,9 +113,11 @@ with BootstrapView(...) as view:
 
 Logging is routed through `RichHandler` via `install_logging()` (called from `cli.py:main()`). Noisy library loggers (litellm/httpx/anthropic/openai) are auto-suppressed to WARNING while a Live is active.
 
-## Auth resolution chain (GitHub)
+## Input sources + auth resolution
 
-`auth.resolve_github_token()` checks in order:
+`--repo` accepts a GitHub `owner/name`, a `gitlab.com` URL, or a local path (`/abs`, `./rel`, `~`, `file://` — canonicalized to `file://<abspath>`). `RepoSpec.source_kind` classifies it; `sources.py` defines `Capability` (pull_requests / issues / commit_api) per source and each pipeline's `required_capabilities`. `cmd_generate` gates incompatible combos up front (e.g. `pr_diff` on a local repo → blocked with a clear error). Git/source pipelines (`commit_runtime`, `code_instruct`, `equivalence_tests`) run on any source; `pr_diff`/`pr_runtime`/`cve_patches` need GitHub. GitLab is clone+git only for now — MR mining tracked in #62.
+
+`auth.resolve_repo_token()` dispatches by source: local → None (no `gh` shell-out); gitlab → `repo.auth_token_env` then `$GITLAB_TOKEN`; github → `auth.resolve_github_token()`, which checks in order:
 1. `repo.auth_token_env` env var (if explicitly set in config)
 2. `gh auth token` (default — works for any user who's `gh auth login`'d)
 3. `$GITHUB_TOKEN`

--- a/README.md
+++ b/README.md
@@ -114,16 +114,17 @@ A pipeline turns a repo into Harbor tasks. **Two are stable** and recommended fo
 
 ### At a glance
 
-| Pipeline | Stability | Reward signal | Sandbox | LLM use | Languages |
-|---|:-:|---|:-:|---|---|
-| `pr_diff` | stable | `diff_similarity` | thin | at verify — judges the solution | any |
-| `pr_runtime` | stable | `test_execution` + `diff_similarity` | ✅ | at env build — one-time, cached | Py · Go · Node · Rust |
-| `commit_runtime` | experimental | `test_execution` + `diff_similarity` | ✅ | at env build — one-time, cached | Py · Go · Node · Rust |
-| `cve_patches` | experimental | `test_execution` + `diff_similarity` | ✅ | at env build — one-time, cached | Py · Go · Node · Rust |
-| `code_instruct` | experimental | `test_execution` | ✅ | at synthesis — writes the task | Py |
-| `equivalence_tests` | experimental | `test_execution` | ✅ | at synthesis — writes the task | Py |
+| Pipeline | Stability | Source | Reward signal | Sandbox | LLM use | Languages |
+|---|:-:|:-:|---|:-:|---|---|
+| `pr_diff` | stable | GitHub | `diff_similarity` | thin | at verify — judges the solution | any |
+| `pr_runtime` | stable | GitHub | `test_execution` + `diff_similarity` | ✅ | at env build — one-time, cached | Py · Go · Node · Rust |
+| `commit_runtime` | experimental | GitHub · GitLab · local | `test_execution` + `diff_similarity` | ✅ | at env build — one-time, cached | Py · Go · Node · Rust |
+| `cve_patches` | experimental | GitHub | `test_execution` + `diff_similarity` | ✅ | at env build — one-time, cached | Py · Go · Node · Rust |
+| `code_instruct` | experimental | GitHub · GitLab · local | `test_execution` | ✅ | at synthesis — writes the task | Py |
+| `equivalence_tests` | experimental | GitHub · GitLab · local | `test_execution` | ✅ | at synthesis — writes the task | Py |
 
 **What the columns mean**
+- **Source** — where `--repo` can point. **`GitHub · GitLab · local`** = a GitHub `owner/name`, a `gitlab.com` URL, **or a local path** (`/abs`, `./rel`, `~`, `file://`) — these pipelines need only git + source files. **`GitHub`** = needs pull requests / CVE data, which a local or GitLab clone can't provide, so `generate` blocks those up front with a clear error (GitLab merge-request mining is tracked in [#62](https://github.com/huggingface/Repo2RLEnv/issues/62)).
 - **Reward signal** — the verifiable signal emitted per task. `test_execution` = the repo's own tests gate the reward (F2P/P2P or pytest pass rate); `diff_similarity` = the agent's output is scored against the oracle diff (format, file targeting, region overlap, LLM judge). Pipelines that emit both use `test_execution` as the primary training signal.
 - **Sandbox** — whether the task runs inside Docker. `✅` = a per-repo image is built once by the [bootstrap phase](#bootstrap) and cached; `thin` = no bootstrap, just a generic `python:3.12-slim` image.
 - **LLM use** — *when* a language model is invoked, which sets where your API cost goes:

--- a/docs/pipelines/README.md
+++ b/docs/pipelines/README.md
@@ -21,15 +21,16 @@ flowchart LR
 
 All 6 pipelines are shipped — 2 stable (`pr_diff`, `pr_runtime`), 4 experimental. See per-pipeline pages for the recipe + options + Harbor verification status.
 
-| Pipeline | What it produces | Sandbox | LLM use | GPU helpful? | Reference dataset | Inspiration |
-|---|---|:-:|---|:-:|---|---|
-| [`pr_diff`](./pr_diff.md) | Harbor-runnable env + 6-component diff-similarity reward (deterministic 5 + LLM judge) | thin¹ | at verify (judge, optional) | No | [`AdithyaSK/repo2rlenv-pr-diff`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-pr-diff) (100) | [SWE-RL](https://github.com/facebookresearch/swe-rl) |
-| [`pr_runtime`](./pr_runtime.md) | Sandbox-verified PR with F2P/P2P test oracle | ✅ | at bootstrap (cached) | ML repos | [`AdithyaSK/repo2rlenv-pr-runtime`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-pr-runtime) (100) | [SWE-bench](https://github.com/SWE-bench/SWE-bench) |
-| [`commit_runtime`](./commit_runtime.md) | Commit-level oracle (bypass PR-review filters) | ✅ | at bootstrap (cached) | ML repos | — | [R2E-Gym SWE-GEN](https://github.com/R2E-Gym/R2E-Gym) |
-| [`code_instruct`](./code_instruct.md) | LLM-authored problem + executable verifier anchored to real source | ✅ | at synthesis (problem + verifier) | Sometimes | — | [Magicoder](https://github.com/ise-uiuc/magicoder) |
-| [`equivalence_tests`](./equivalence_tests.md) | Extract a function; LLM writes equivalence tests vs `reference_<name>` | ✅ | at synthesis (tests) | If function uses GPU | — | [R2E](https://github.com/r2e-project/r2e) |
-| [`cve_patches`](./cve_patches.md) | OSV CVE → fix commit → Harbor task (reuses `pr_runtime` verifier) | ✅ | at bootstrap (cached) | Rarely | — | [PatchSeeker](https://github.com/hungkien05/PatchSeeker) / CVE-Bench |
+| Pipeline | What it produces | Source | Sandbox | LLM use | GPU helpful? | Reference dataset | Inspiration |
+|---|---|:-:|:-:|---|:-:|---|---|
+| [`pr_diff`](./pr_diff.md) | Harbor-runnable env + 6-component diff-similarity reward (deterministic 5 + LLM judge) | GitHub | thin¹ | at verify (judge, optional) | No | [`AdithyaSK/repo2rlenv-pr-diff`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-pr-diff) (100) | [SWE-RL](https://github.com/facebookresearch/swe-rl) |
+| [`pr_runtime`](./pr_runtime.md) | Sandbox-verified PR with F2P/P2P test oracle | GitHub | ✅ | at bootstrap (cached) | ML repos | [`AdithyaSK/repo2rlenv-pr-runtime`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-pr-runtime) (100) | [SWE-bench](https://github.com/SWE-bench/SWE-bench) |
+| [`commit_runtime`](./commit_runtime.md) | Commit-level oracle (bypass PR-review filters) | GitHub · GitLab · local | ✅ | at bootstrap (cached) | ML repos | — | [R2E-Gym SWE-GEN](https://github.com/R2E-Gym/R2E-Gym) |
+| [`code_instruct`](./code_instruct.md) | LLM-authored problem + executable verifier anchored to real source | GitHub · GitLab · local | ✅ | at synthesis (problem + verifier) | Sometimes | — | [Magicoder](https://github.com/ise-uiuc/magicoder) |
+| [`equivalence_tests`](./equivalence_tests.md) | Extract a function; LLM writes equivalence tests vs `reference_<name>` | GitHub · GitLab · local | ✅ | at synthesis (tests) | If function uses GPU | — | [R2E](https://github.com/r2e-project/r2e) |
+| [`cve_patches`](./cve_patches.md) | OSV CVE → fix commit → Harbor task (reuses `pr_runtime` verifier) | GitHub | ✅ | at bootstrap (cached) | Rarely | — | [PatchSeeker](https://github.com/hungkien05/PatchSeeker) / CVE-Bench |
 
+- **Source** — where `--repo` can point. `GitHub · GitLab · local` = a GitHub `owner/name`, a `gitlab.com` URL, or a local path (`/abs`, `./rel`, `~`, `file://`); these need only git + source files. `GitHub` = needs pull requests / CVE data (no equivalent in a bare clone), so `generate` blocks a local/GitLab repo up front with a clear error. GitLab merge-request mining is tracked in [#62](https://github.com/huggingface/Repo2RLEnv/issues/62).
 - **Sandbox** ✅ = needs Docker + the bootstrap-built env. `thin¹` = needs Docker but ships a lightweight `python:3.12-slim` env baked at generation time (no bootstrap LLM agent, ~30 s build). `—` = pure text, no execution.
 - **LLM use**: every pipeline calls an LLM at *some* stage. `at synthesis` = the pipeline itself authors task content (problems, mutations, tests) — this is the heavy spend. `at bootstrap (cached)` = the pipeline doesn't call the LLM, but the per-repo env construction does — that runs **once per repo**, content-addressed, then cached. `at verify` = an LLM is invoked at reward time (only `pr_diff`'s LLM-judge component).
 

--- a/docs/reference/AUTH.md
+++ b/docs/reference/AUTH.md
@@ -49,7 +49,21 @@ First match wins:
 3. `$GITHUB_TOKEN`
 4. None — anonymous clone (fails with a clear error if `access="private"`)
 
-Implementation: [`src/repo2rlenv/auth.py:resolve_github_token`](../src/repo2rlenv/auth.py).
+Implementation: [`src/repo2rlenv/auth.py:resolve_github_token`](../../src/repo2rlenv/auth.py).
+
+## Input sources (GitHub · GitLab · local)
+
+`--repo` accepts more than a GitHub `owner/name`:
+
+| Input | Source | Token | Notes |
+|---|---|---|---|
+| `owner/name` or `https://github.com/...` | GitHub | `resolve_github_token` chain above | unchanged — the default |
+| `https://gitlab.com/owner/name` | GitLab | `repo.auth_token_env` → `$GITLAB_TOKEN` (public needs none) | clone via `oauth2:<token>@` |
+| `/abs/path`, `./rel`, `~/x`, `file://…` | Local | none (no `gh` shell-out) | canonicalized to `file://<abspath>` |
+
+Source-aware resolution lives in [`auth.py:resolve_repo_token`](../../src/repo2rlenv/auth.py); detection + capabilities in [`sources.py`](../../src/repo2rlenv/sources.py).
+
+**Capability gating.** Each source declares which platform data it can serve (`pull_requests`, `issues`, `commit_api`); each pipeline declares what it requires. `generate` blocks an incompatible combo up front. In practice: the git/source pipelines (`commit_runtime`, `code_instruct`, `equivalence_tests`) run on **any** source; `pr_diff` / `pr_runtime` / `cve_patches` need GitHub (PRs/CVEs don't exist in a bare clone). GitLab is currently clone+git only — MR mining is tracked in #62.
 
 ## Private repos at task **build** time
 

--- a/src/repo2rlenv/auth.py
+++ b/src/repo2rlenv/auth.py
@@ -81,9 +81,35 @@ def resolve_llm_api_key(provider: str, llm_api_key_env: str | None = None) -> st
 
 
 def auth_clone_url(repo_url: str, token: str | None) -> str:
-    """Inject token into URL for private clone. Token never logged."""
+    """Inject token into URL for private clone. Token never logged.
+
+    Local (file://) and public clones pass through untouched.
+    """
     if not token:
         return repo_url
     if repo_url.startswith("https://github.com/"):
         return repo_url.replace("https://", f"https://x-access-token:{token}@")
+    if repo_url.startswith("https://gitlab.com/"):
+        return repo_url.replace("https://", f"https://oauth2:{token}@")
     return repo_url
+
+
+def resolve_repo_token(repo: RepoSpec, auth: AuthSpec) -> str | None:
+    """Source-aware token resolution.
+
+    - local: no token (and no `gh` shell-out)
+    - gitlab: `repo.auth_token_env` then `$GITLAB_TOKEN`
+    - github: the documented `resolve_github_token` chain (unchanged)
+    """
+    from repo2rlenv.sources import SourceKind
+
+    kind = repo.source_kind
+    if kind == SourceKind.LOCAL:
+        return None
+    if kind == SourceKind.GITLAB:
+        if repo.auth_token_env:
+            tok = os.environ.get(repo.auth_token_env)
+            if tok:
+                return tok
+        return os.environ.get("GITLAB_TOKEN")
+    return resolve_github_token(repo, auth)

--- a/src/repo2rlenv/bootstrap/runner.py
+++ b/src/repo2rlenv/bootstrap/runner.py
@@ -17,7 +17,7 @@ import time
 from collections.abc import Callable
 from pathlib import Path
 
-from repo2rlenv.auth import auth_clone_url, resolve_github_token
+from repo2rlenv.auth import auth_clone_url, resolve_repo_token
 from repo2rlenv.bootstrap import cache as cache_mod
 from repo2rlenv.bootstrap.agent import run_agent_loop
 from repo2rlenv.bootstrap.docker import (
@@ -466,7 +466,7 @@ def ensure_bootstrap(
         )
 
     auth = auth or AuthSpec()
-    token = resolve_github_token(repo, auth)
+    token = resolve_repo_token(repo, auth)
     if repo.access == "private" and not token:
         raise BootstrapError(
             "private repo requires a GitHub token. Run `gh auth login` or set GITHUB_TOKEN."

--- a/src/repo2rlenv/cli.py
+++ b/src/repo2rlenv/cli.py
@@ -109,10 +109,39 @@ def cmd_generate(args: argparse.Namespace) -> int:
 
     options = parse_options(gen_input.pipeline.name.value, gen_input.pipeline.options)
 
+    # Pre-flight: can this input source serve what the pipeline needs?
+    # PR-based pipelines (pr_diff, pr_runtime) and cve_patches require platform
+    # data (pull requests / commit API) that a local or GitLab source can't
+    # provide — block here with a clear message instead of failing mid-run.
+    from repo2rlenv.sources import SourceKind, capabilities_for
+
+    src_kind = gen_input.repo.source_kind
+    available_caps = capabilities_for(src_kind)
+    required_caps = getattr(pipeline_cls, "required_capabilities", frozenset())
+    missing_caps = required_caps - available_caps
+    if missing_caps:
+        compatible = sorted(
+            n
+            for n, c in PIPELINES.items()
+            if getattr(c, "required_capabilities", frozenset()) <= available_caps
+        )
+        console.error(
+            f"pipeline {gen_input.pipeline.name.value!r} needs "
+            f"{sorted(m.value for m in missing_caps)}, which a '{src_kind.value}' source "
+            f"does not provide. Pipelines that work on a '{src_kind.value}' source: "
+            f"{compatible}. For PR/CVE-based pipelines, point --repo at a GitHub repo."
+        )
+        return 2
+
     # Pre-flight: does this pipeline support this repo's primary language?
     # Cheap GitHub API call; runs BEFORE bootstrap so we fail fast on a
     # Go/Rust/Node repo + Python-only pipeline mismatch (~2s vs ~5 min).
-    if getattr(pipeline_cls, "supported_languages", None) is not None:
+    # Only GitHub exposes a language API; for local/GitLab the bootstrap phase
+    # detects the language from repo files instead.
+    if (
+        getattr(pipeline_cls, "supported_languages", None) is not None
+        and src_kind == SourceKind.GITHUB
+    ):
         from repo2rlenv.auth import resolve_github_token
         from repo2rlenv.bootstrap.language import language_from_github_name
         from repo2rlenv.github import get_primary_language

--- a/src/repo2rlenv/pipelines/code_instruct.py
+++ b/src/repo2rlenv/pipelines/code_instruct.py
@@ -48,7 +48,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import ClassVar
 
-from repo2rlenv.auth import resolve_github_token
+from repo2rlenv.auth import resolve_repo_token
 from repo2rlenv.bootstrap.runner import _shallow_clone_at_ref
 from repo2rlenv.bootstrap.spec import BootstrapResult, LanguageHint
 from repo2rlenv.emitter.harbor import HarborTask, write_harbor_task
@@ -177,7 +177,7 @@ class CodeInstructPipeline:
 
     def run(self, out_dir: Path) -> PipelineResult:
         out_dir.mkdir(parents=True, exist_ok=True)
-        token = resolve_github_token(self.input.repo, self.input.auth)
+        token = resolve_repo_token(self.input.repo, self.input.auth)
         if self.input.repo.access == "private" and not token:
             raise RuntimeError(
                 "private repo specified but no GitHub token resolved. "

--- a/src/repo2rlenv/pipelines/commit_runtime.py
+++ b/src/repo2rlenv/pipelines/commit_runtime.py
@@ -63,6 +63,7 @@ from repo2rlenv.pipelines.pr_runtime import (
     split_patch_and_test_patch,
     targeted_test_cmds_for_pr,
 )
+from repo2rlenv.sources import Capability, capabilities_for
 from repo2rlenv.spec.input import GenerationInput, PipelineName
 from repo2rlenv.spec.options import CommitRuntimeOptions
 
@@ -333,10 +334,19 @@ class CommitRuntimePipeline:
                     # (`Closes #N`), source the problem statement from the
                     # issue body — the bug report is far less leak-prone than
                     # the commit message. Same lesson as Arc 2 for pr_runtime.
+                    # Issue enrichment is GitHub-only (gh API). On GitLab/local
+                    # sources there's no issue API here, so fall back to the
+                    # (scrubbed) commit message. Defensive try/except: a deleted
+                    # or private issue must not abort the whole run.
                     issue_num = _linked_issue_number(commit.message or "")
                     issue = None
-                    if issue_num is not None:
-                        issue = fetch_issue(owner, name, issue_num, token=token)
+                    if issue_num is not None and Capability.ISSUES in capabilities_for(
+                        self.input.repo.source_kind
+                    ):
+                        try:
+                            issue = fetch_issue(owner, name, issue_num, token=token)
+                        except Exception as exc:
+                            logger.debug("issue fetch failed (%s); using commit message", exc)
                     task = self._build_task(
                         commit,
                         patch,

--- a/src/repo2rlenv/pipelines/commit_runtime.py
+++ b/src/repo2rlenv/pipelines/commit_runtime.py
@@ -41,7 +41,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import ClassVar
 
-from repo2rlenv.auth import resolve_github_token
+from repo2rlenv.auth import resolve_repo_token
 from repo2rlenv.bootstrap.runner import _shallow_clone_at_ref
 from repo2rlenv.bootstrap.spec import BootstrapResult
 from repo2rlenv.emitter.harbor import HarborTask, write_harbor_task
@@ -190,7 +190,7 @@ class CommitRuntimePipeline:
 
     def run(self, out_dir: Path) -> PipelineResult:
         out_dir.mkdir(parents=True, exist_ok=True)
-        token = resolve_github_token(self.input.repo, self.input.auth)
+        token = resolve_repo_token(self.input.repo, self.input.auth)
         if self.input.repo.access == "private" and not token:
             raise RuntimeError(
                 "private repo specified but no GitHub token resolved. "

--- a/src/repo2rlenv/pipelines/cve_patches.py
+++ b/src/repo2rlenv/pipelines/cve_patches.py
@@ -62,6 +62,7 @@ from repo2rlenv.pipelines.pr_runtime import (
     split_patch_and_test_patch,
     targeted_test_cmds_for_pr,
 )
+from repo2rlenv.sources import Capability
 from repo2rlenv.spec.input import GenerationInput, PipelineName
 from repo2rlenv.spec.options import CVEPatchesOptions
 
@@ -91,6 +92,7 @@ class CVEPatchesPipeline:
     """OSV-driven CVE → fix-commit pipeline."""
 
     name: ClassVar[PipelineName] = PipelineName.CVE_PATCHES
+    required_capabilities: ClassVar[frozenset[Capability]] = frozenset({Capability.COMMIT_API})
     requires_bootstrap: ClassVar[bool] = True
     experimental: ClassVar[bool] = True
 

--- a/src/repo2rlenv/pipelines/equivalence_tests.py
+++ b/src/repo2rlenv/pipelines/equivalence_tests.py
@@ -51,7 +51,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import ClassVar
 
-from repo2rlenv.auth import resolve_github_token
+from repo2rlenv.auth import resolve_repo_token
 from repo2rlenv.bootstrap.runner import _shallow_clone_at_ref
 from repo2rlenv.bootstrap.spec import BootstrapResult, LanguageHint
 from repo2rlenv.emitter.harbor import HarborTask, write_harbor_task
@@ -259,7 +259,7 @@ class EquivalenceTestsPipeline:
 
     def run(self, out_dir: Path) -> PipelineResult:
         out_dir.mkdir(parents=True, exist_ok=True)
-        token = resolve_github_token(self.input.repo, self.input.auth)
+        token = resolve_repo_token(self.input.repo, self.input.auth)
         if self.input.repo.access == "private" and not token:
             raise RuntimeError(
                 "private repo specified but no GitHub token resolved. "

--- a/src/repo2rlenv/pipelines/pr_diff.py
+++ b/src/repo2rlenv/pipelines/pr_diff.py
@@ -54,6 +54,7 @@ from repo2rlenv.github import (
     list_merged_prs,
 )
 from repo2rlenv.pipelines.base import PipelineResult
+from repo2rlenv.sources import Capability
 from repo2rlenv.spec.input import GenerationInput, PipelineName
 from repo2rlenv.spec.options import PRDiffOptions
 
@@ -423,6 +424,7 @@ class PRDiffPipeline:
     """
 
     name: ClassVar[PipelineName] = PipelineName.PR_DIFF
+    required_capabilities: ClassVar[frozenset[Capability]] = frozenset({Capability.PULL_REQUESTS})
     requires_bootstrap: ClassVar[bool] = False
     experimental: ClassVar[bool] = False  # stable
 

--- a/src/repo2rlenv/pipelines/pr_runtime.py
+++ b/src/repo2rlenv/pipelines/pr_runtime.py
@@ -56,6 +56,7 @@ from repo2rlenv.github import (
     list_merged_prs,
 )
 from repo2rlenv.pipelines.base import PipelineResult
+from repo2rlenv.sources import Capability
 from repo2rlenv.spec.input import GenerationInput, PipelineName
 from repo2rlenv.spec.options import PRRuntimeOptions
 
@@ -766,6 +767,7 @@ class PRRuntimePipeline:
     """Sandbox-verified PR mining. Implements the `Pipeline` Protocol."""
 
     name: ClassVar[PipelineName] = PipelineName.PR_RUNTIME
+    required_capabilities: ClassVar[frozenset[Capability]] = frozenset({Capability.PULL_REQUESTS})
     requires_bootstrap: ClassVar[bool] = True
     experimental: ClassVar[bool] = False  # stable
 

--- a/src/repo2rlenv/sources.py
+++ b/src/repo2rlenv/sources.py
@@ -1,0 +1,68 @@
+"""Input-source contract: where a repo comes from and what it can provide.
+
+Repo2RLEnv historically assumed every input was a GitHub repo. This module
+abstracts the *source* so pipelines can run against GitHub, GitLab, or a
+local checkout. The key idea is **capabilities**: a source declares what
+platform data it can serve (pull requests, issues, arbitrary-commit API),
+and a pipeline declares what it requires. `cmd_generate` gates on the
+difference and fails fast with a clear message — so e.g. `pr_diff` (needs
+pull requests) is blocked on a local repo before any work starts.
+
+Backwards compatibility: a bare ``owner/name`` or a github.com URL resolves
+to ``SourceKind.GITHUB`` with the full capability set, exactly as before.
+
+Git clone + commit history + source files are baseline — every source has
+them — so the git/source-based pipelines (`commit_runtime`, `code_instruct`,
+`equivalence_tests`) work on any source. PR/issue/commit-API data is what
+varies, and that's what `Capability` tracks.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class Capability(StrEnum):
+    """Platform data a source can serve beyond plain git."""
+
+    PULL_REQUESTS = "pull_requests"  # list/fetch merged PRs (pr_diff, pr_runtime)
+    ISSUES = "issues"  # fetch issue text by number
+    COMMIT_API = "commit_api"  # fetch arbitrary commit diff/parent via host API (cve_patches)
+
+
+class SourceKind(StrEnum):
+    GITHUB = "github"
+    GITLAB = "gitlab"
+    LOCAL = "local"
+
+
+# Baseline (clone + git log + source files) is implicit for every source.
+# Only the platform-API extras are listed here.
+_CAPABILITIES: dict[SourceKind, frozenset[Capability]] = {
+    SourceKind.GITHUB: frozenset(
+        {Capability.PULL_REQUESTS, Capability.ISSUES, Capability.COMMIT_API}
+    ),
+    # GitLab clone + git work today; MR/issue mining is tracked in #62.
+    SourceKind.GITLAB: frozenset(),
+    # A local checkout has no platform layer at all — git only.
+    SourceKind.LOCAL: frozenset(),
+}
+
+
+def detect_source_kind(url: str) -> SourceKind:
+    """Classify a (normalized) repo URL into a source kind.
+
+    `RepoSpec.normalize_url` canonicalizes local paths to ``file://`` and
+    leaves github/gitlab URLs intact, so detection is a simple prefix/host
+    check. A bare ``owner/name`` has already been expanded to a github URL.
+    """
+    u = url.strip()
+    if u.startswith("file://"):
+        return SourceKind.LOCAL
+    if "gitlab.com" in u or u.startswith("git@gitlab.com"):
+        return SourceKind.GITLAB
+    return SourceKind.GITHUB
+
+
+def capabilities_for(kind: SourceKind) -> frozenset[Capability]:
+    return _CAPABILITIES[kind]

--- a/src/repo2rlenv/spec/input.py
+++ b/src/repo2rlenv/spec/input.py
@@ -32,16 +32,39 @@ class RepoSpec(BaseModel):
     @classmethod
     def normalize_url(cls, v: str) -> str:
         v = v.strip()
+        # Local checkout — canonicalize to an absolute file:// URL.
+        if v.startswith("file://"):
+            return "file://" + str(Path(v[len("file://") :]).expanduser().resolve())
+        if v.startswith(("/", "~", "./", "../")):
+            return "file://" + str(Path(v).expanduser().resolve())
+        # Remote git host (github default for a bare owner/name; gitlab needs
+        # a full URL since a bare owner/name is indistinguishable from github).
         if "/" not in v:
-            raise ValueError(f"repo url must be 'owner/name' or full URL, got {v!r}")
+            raise ValueError(
+                f"repo url must be 'owner/name', a full git URL, or a local path, got {v!r}"
+            )
         if not v.startswith(("http://", "https://", "git@")):
             v = f"https://github.com/{v}"
         return v.rstrip("/").removesuffix(".git")
 
     @property
+    def source_kind(self):  # -> sources.SourceKind
+        from repo2rlenv.sources import detect_source_kind
+
+        return detect_source_kind(self.url)
+
+    @property
     def owner_name(self) -> tuple[str, str]:
-        """Return (owner, name) parsed from the URL."""
-        path = self.url.replace("https://github.com/", "").replace("git@github.com:", "")
+        """Return (owner, name). Local repos get a synthetic ('local', <dir>)."""
+        u = self.url
+        if u.startswith("file://"):
+            return "local", Path(u[len("file://") :]).name
+        path = (
+            u.replace("https://github.com/", "")
+            .replace("git@github.com:", "")
+            .replace("https://gitlab.com/", "")
+            .replace("git@gitlab.com:", "")
+        )
         parts = path.rstrip("/").split("/")
         if len(parts) < 2:
             raise ValueError(f"cannot parse owner/name from {self.url!r}")

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,149 @@
+"""Input-source abstraction: detection, capabilities, gating, local clone."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+from repo2rlenv.auth import auth_clone_url, resolve_repo_token
+from repo2rlenv.pipelines import PIPELINES
+from repo2rlenv.sources import (
+    Capability,
+    SourceKind,
+    capabilities_for,
+    detect_source_kind,
+)
+from repo2rlenv.spec.input import AuthSpec, RepoSpec
+
+# ---------------------------------------------------------------------------
+# RepoSpec normalization + source_kind + owner_name
+# ---------------------------------------------------------------------------
+
+
+def test_bare_owner_name_still_github():
+    """Backwards compat: bare owner/name resolves to GitHub exactly as before."""
+    r = RepoSpec(url="huggingface/trl")
+    assert r.url == "https://github.com/huggingface/trl"
+    assert r.source_kind == SourceKind.GITHUB
+    assert r.owner_name == ("huggingface", "trl")
+
+
+def test_github_full_url_unchanged():
+    r = RepoSpec(url="https://github.com/pallets/click.git")
+    assert r.url == "https://github.com/pallets/click"
+    assert r.source_kind == SourceKind.GITHUB
+
+
+def test_gitlab_url_detected():
+    r = RepoSpec(url="https://gitlab.com/python-devs/importlib_resources")
+    assert r.source_kind == SourceKind.GITLAB
+    assert r.owner_name == ("python-devs", "importlib_resources")
+
+
+def test_local_path_canonicalized_to_file_url(tmp_path):
+    r = RepoSpec(url=str(tmp_path))
+    assert r.url.startswith("file://")
+    assert r.source_kind == SourceKind.LOCAL
+    assert r.owner_name == ("local", tmp_path.name)
+
+
+def test_file_url_and_relative_path_are_local():
+    assert RepoSpec(url="file:///tmp/x").source_kind == SourceKind.LOCAL
+    assert RepoSpec(url="./somedir").source_kind == SourceKind.LOCAL
+
+
+def test_bare_single_token_still_rejected():
+    with pytest.raises(ValueError):
+        RepoSpec(url="not-a-repo")
+
+
+# ---------------------------------------------------------------------------
+# Capabilities + gating
+# ---------------------------------------------------------------------------
+
+
+def test_capabilities_by_source():
+    assert Capability.PULL_REQUESTS in capabilities_for(SourceKind.GITHUB)
+    assert capabilities_for(SourceKind.LOCAL) == frozenset()
+    assert capabilities_for(SourceKind.GITLAB) == frozenset()
+
+
+def test_detect_source_kind():
+    assert detect_source_kind("https://github.com/a/b") == SourceKind.GITHUB
+    assert detect_source_kind("https://gitlab.com/a/b") == SourceKind.GITLAB
+    assert detect_source_kind("file:///tmp/a") == SourceKind.LOCAL
+
+
+def test_pr_pipelines_blocked_on_local_and_gitlab():
+    """The gating contract: PR/CVE pipelines need caps local/gitlab lack;
+    the git/source pipelines need none."""
+    needs_caps = {"pr_diff", "pr_runtime", "cve_patches"}
+    git_only = {"commit_runtime", "code_instruct", "equivalence_tests"}
+    for kind in (SourceKind.LOCAL, SourceKind.GITLAB):
+        avail = capabilities_for(kind)
+        for n in needs_caps:
+            req = getattr(PIPELINES[n], "required_capabilities", frozenset())
+            assert not (req <= avail), f"{n} should be blocked on {kind}"
+        for n in git_only:
+            req = getattr(PIPELINES[n], "required_capabilities", frozenset())
+            assert req <= avail, f"{n} should run on {kind}"
+
+
+def test_all_pipelines_allowed_on_github():
+    avail = capabilities_for(SourceKind.GITHUB)
+    for n, cls in PIPELINES.items():
+        req = getattr(cls, "required_capabilities", frozenset())
+        assert req <= avail, f"{n} should run on github"
+
+
+# ---------------------------------------------------------------------------
+# Token resolution + clone URL
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_token_local_is_none(tmp_path):
+    assert resolve_repo_token(RepoSpec(url=str(tmp_path)), AuthSpec()) is None
+
+
+def test_resolve_token_gitlab_env(monkeypatch):
+    monkeypatch.setenv("GITLAB_TOKEN", "glpat-xyz")
+    r = RepoSpec(url="https://gitlab.com/a/b")
+    assert resolve_repo_token(r, AuthSpec()) == "glpat-xyz"
+
+
+def test_clone_url_injection():
+    assert (
+        auth_clone_url("https://github.com/a/b", "t") == "https://x-access-token:t@github.com/a/b"
+    )
+    assert auth_clone_url("https://gitlab.com/a/b", "t") == "https://oauth2:t@gitlab.com/a/b"
+    assert auth_clone_url("file:///tmp/x", "t") == "file:///tmp/x"  # local untouched
+
+
+# ---------------------------------------------------------------------------
+# Local clone round-trip (the core of #59)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+def test_local_repo_clones(tmp_path):
+    """A local git repo resolves to file:// and clones via _shallow_clone_at_ref."""
+    from repo2rlenv.bootstrap.runner import _shallow_clone_at_ref
+
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    run = lambda *a: subprocess.run(a, cwd=origin, check=True, capture_output=True)  # noqa: E731
+    run("git", "init", "-q", "-b", "main")
+    run("git", "config", "user.email", "t@t")
+    run("git", "config", "user.name", "t")
+    (origin / "hello.py").write_text("x = 1\n")
+    run("git", "add", "-A")
+    run("git", "commit", "-q", "-m", "init")
+
+    repo = RepoSpec(url=str(origin))
+    assert repo.url == f"file://{origin}"
+    token = resolve_repo_token(repo, AuthSpec())  # None for local
+    dest = tmp_path / "clone"
+    _shallow_clone_at_ref(repo.url, "main", token, dest)
+    assert (dest / "hello.py").read_text() == "x = 1\n"

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -65,9 +65,18 @@ def test_bare_single_token_still_rejected():
 
 
 def test_capabilities_by_source():
-    assert Capability.PULL_REQUESTS in capabilities_for(SourceKind.GITHUB)
+    gh = capabilities_for(SourceKind.GITHUB)
+    assert {Capability.PULL_REQUESTS, Capability.ISSUES, Capability.COMMIT_API} <= gh
     assert capabilities_for(SourceKind.LOCAL) == frozenset()
     assert capabilities_for(SourceKind.GITLAB) == frozenset()
+
+
+def test_issues_capability_is_github_only():
+    """commit_runtime gates its `gh`-based issue enrichment on this — so a
+    local/GitLab commit with `Closes #N` must NOT trigger a GitHub call."""
+    for kind in (SourceKind.LOCAL, SourceKind.GITLAB):
+        assert Capability.ISSUES not in capabilities_for(kind)
+    assert Capability.ISSUES in capabilities_for(SourceKind.GITHUB)
 
 
 def test_detect_source_kind():


### PR DESCRIPTION
Closes #59. Foundation for #62 (GitLab MR mining).

## Summary

Introduces a **source contract** so `--repo` is no longer GitHub-only:

- **Local repos** — `/abs/path`, `./rel`, `~/x`, or `file://…` (canonicalized to `file://<abspath>`). Directly answers #59.
- **GitLab repos** — `https://gitlab.com/owner/name` (clone + git today; MR mining is #62).
- **GitHub** — unchanged.

`sources.py` defines a `Capability` set per source (`pull_requests` / `issues` / `commit_api`) and each pipeline declares `required_capabilities`. `cmd_generate` **gates incompatible combos up front** with a clear, actionable error instead of failing deep in a run:

```
✗ pipeline 'pr_diff' needs ['pull_requests'], which a 'local' source does not
  provide. Pipelines that work on a 'local' source: ['code_instruct',
  'commit_runtime', 'equivalence_tests']. For PR/CVE-based pipelines, point
  --repo at a GitHub repo.
```

So: `commit_runtime`, `code_instruct`, `equivalence_tests` run on **any** source; `pr_diff`, `pr_runtime`, `cve_patches` require GitHub (PRs/CVEs don't exist in a bare clone).

## Mechanics
- `RepoSpec.normalize_url` accepts local paths + GitLab; adds `source_kind` and local-aware `owner_name` (`('local', <dir>)`).
- `resolve_repo_token` dispatches by source: local → `None` (and **no `gh` shell-out**, so local works without `gh` installed); gitlab → `$GITLAB_TOKEN`; github → the existing chain.
- `auth_clone_url` injects GitLab `oauth2:<token>@`; local/public pass through.
- The GitHub-API language pre-flight is skipped for non-GitHub sources (bootstrap detects language from files).

## Backwards compatibility
Bare `owner/name` and `github.com` URLs resolve to GitHub with the full capability set — **identical behavior to before**. No version bump.

## Test plan
- `uv run pytest -q` → **669 passed** (+14 new in `tests/test_sources.py`), incl. a real **local git-clone round-trip** and the capability-gating contract. The lone unrelated failure (`test_e2e_public_trl`) fails identically on `main`.
- Manual CLI smoke: `generate --repo <local> --pipeline pr_diff` is blocked with the message above; git-based pipelines accept the local path.
- `ruff check` + `ruff format --check` clean.

## Out of scope
- **GitLab MR mining** for `pr_diff`/`pr_runtime` (#62) — needs a GitLab MR API client.
- **Bitbucket** — REST-only + scarce public-OSS test corpus; deferred.
- Provenance `reference` links for local repos point at a synthetic `github.com/local/<dir>/…` — cosmetic, can refine later.