### PR TITLE
feat(commit_runtime): synthesized clean instructions + P2P cap (robust v2)

### DIFF
--- a/src/repo2rlenv/pipelines/commit_runtime.py
+++ b/src/repo2rlenv/pipelines/commit_runtime.py
@@ -46,6 +46,7 @@ from repo2rlenv.bootstrap.runner import _shallow_clone_at_ref
 from repo2rlenv.bootstrap.spec import BootstrapResult
 from repo2rlenv.emitter.harbor import HarborTask, write_harbor_task
 from repo2rlenv.git_local import CommitInfo, GitError, list_commits, show_diff
+from repo2rlenv.llm import complete
 from repo2rlenv.pipelines.base import PipelineResult
 from repo2rlenv.pipelines.pr_runtime import (
     _count_new_test_funcs,
@@ -104,6 +105,27 @@ _BUGFIX_KEYWORD_RE = re.compile(
 
 def _word_count(text: str) -> int:
     return len(re.findall(r"\b\w+\b", text or ""))
+
+
+# Synthesis prompt: turn the fix-commit / linked-issue text into a clean,
+# leak-free, symptom-focused problem statement (the bug as a user would report
+# it BEFORE the fix). Fixes both failure modes of raw commit text: solution
+# leakage (changelog bullets naming the fix) and thinness (title-only subjects).
+_SYNTH_SYSTEM = """You are writing a GitHub bug report for an AI coding agent to fix.
+
+You are given the commit message (and maybe a linked issue) that FIXED a bug.
+Rewrite it into a clear problem statement describing ONLY the observed problem
+and expected behavior — the symptom, as a user would report it BEFORE any fix
+existed.
+
+STRICT RULES:
+- Describe the symptom + expected vs actual behavior. Include a short
+  reproduction if one is evident.
+- Do NOT describe the solution, the fix approach, or which functions/files/tests
+  to change. Do NOT mention "fix", "patch", commit SHAs, PR/issue numbers,
+  file names, test names, "Signed-off-by", or changelog bullets.
+- Output exactly: a `**Title:**` line, then a `## Description` section. Markdown
+  allowed. Nothing else. Keep it concise (2-6 sentences)."""
 
 
 def _files_changed_in_diff(unified_diff: str) -> list[str]:
@@ -176,6 +198,48 @@ class CommitRuntimePipeline:
         self.options = options
         self.bootstrap = bootstrap
         self._progress_cb = None
+        self._llm_cost_usd = 0.0
+
+    def _synthesize_problem_statement(
+        self, commit: CommitInfo, issue: tuple[str, str] | None
+    ) -> str | None:
+        """LLM-rewrite the commit/issue into a clean, leak-free problem statement.
+
+        Returns the `**Title:** … ## Description …` body, or None on failure /
+        too-thin output (caller falls back to the raw-text builder).
+        """
+        if self.input.llm is None:
+            return None
+        src = f"Commit subject: {commit.subject}\n\nCommit body:\n{commit.body or ''}\n"
+        if issue is not None:
+            src += f"\nLinked issue title: {issue[0]}\nLinked issue body:\n{issue[1] or ''}\n"
+        try:
+            resp = complete(
+                self.input.llm,
+                system=_SYNTH_SYSTEM,
+                user=src,
+                max_tokens=self.options.max_llm_tokens,
+                temperature=self.options.llm_temperature,
+            )
+        except Exception as exc:
+            logger.warning("commit_runtime synthesis failed: %s", exc)
+            return None
+        self._llm_cost_usd += resp.cost_usd
+        body = (resp.content or "").strip()
+        return body if _word_count(body) >= 10 else None
+
+    def _build_instruction(self, commit: CommitInfo, *, issue: tuple[str, str] | None) -> str:
+        """Synthesized (clean) problem statement when enabled, else raw commit text."""
+        if self.options.synthesize_with_llm:
+            synth = self._synthesize_problem_statement(commit, issue)
+            if synth:
+                return (
+                    f"# Issue\n\n{synth}\n\n## Task\n\n"
+                    "Modify the repository so that the issue described above is resolved. "
+                    "The task's test suite verifies your patch by applying it on top of "
+                    f"the base commit `{commit.parent_sha[:12]}` and running the modified tests."
+                )
+        return build_instruction_from_commit(commit, issue=issue)
 
     def set_progress_callback(self, cb) -> None:
         self._progress_cb = cb
@@ -320,6 +384,19 @@ class CommitRuntimePipeline:
                         fail_to_pass = outcome.fail_to_pass
                         pass_to_pass = outcome.pass_to_pass
                         validation_status = outcome.status
+                        # Cap the P2P regression set: whole-suite P2P (100s of
+                        # tests) inflates flaky-reward risk + runtime. Prefer
+                        # tests in the patched files, then fill to the cap.
+                        cap = self.options.max_pass_to_pass
+                        if cap and len(pass_to_pass) > cap:
+                            changed = set(_files_in_patch(patch))
+                            near = [
+                                t
+                                for t in pass_to_pass
+                                if any(f.split("::")[0] in t for f in changed)
+                            ]
+                            far = [t for t in pass_to_pass if t not in set(near)]
+                            pass_to_pass = (near + far)[:cap]
                         if (
                             self.options.require_fail_to_pass
                             and len(fail_to_pass) < self.options.min_fail_to_pass
@@ -512,6 +589,10 @@ class CommitRuntimePipeline:
                 "pass_to_pass": pass_to_pass,
                 "validation_status": validation_status,
                 "bootstrap_image": self.bootstrap.image_digest,
+                "instruction_synthesized": bool(
+                    self.options.synthesize_with_llm and self.input.llm
+                ),
+                "llm_cost_usd": round(self._llm_cost_usd, 6),
             },
             # Calibration parity with pr_runtime: lets the manifest enricher
             # compute difficulty / p2p_count == 0 / loc_changed sliceability
@@ -529,7 +610,7 @@ class CommitRuntimePipeline:
             name=task_id,
             org=self.input.output.org,
             description=_strip_commit_prefix(commit.subject) or task_id,
-            instruction=build_instruction_from_commit(commit, issue=issue),
+            instruction=self._build_instruction(commit, issue=issue),
             oracle_diff=patch,
             repo2env=repo2env,
             difficulty=difficulty,

--- a/src/repo2rlenv/spec/options.py
+++ b/src/repo2rlenv/spec/options.py
@@ -108,10 +108,21 @@ class CommitRuntimeOptions(_BaseOptions):
     min_fail_to_pass: int = 1
     validation_timeout_sec: int = 600
     skip_validation: bool = False
+    # Cap PASS_TO_PASS regression set: whole-suite P2P (100s of tests) inflates
+    # flakiness + runtime. Keep a bounded, still-meaningful guard. 0 = no cap.
+    max_pass_to_pass: int = 50
 
     # --- Instruction synthesis ---
-    synthesize_with_llm: bool = False  # if False, use raw commit subject + body
-    min_problem_statement_words: int = 0
+    # Default ON: rewrite the commit/issue into a clean, leak-free, symptom-
+    # focused problem statement. Raw commit messages either leak the solution
+    # (changelog bullets) or are too thin (title-only) — both hurt solvability.
+    synthesize_with_llm: bool = True
+    # Low floor: with synthesis ON the LLM expands terse commits, so we only
+    # need *some* signal. 20 starved terse-commit repos (Rust crates, many Go);
+    # 8 keeps near-empty/title-only out while letting synthesis do the rest.
+    min_problem_statement_words: int = 8
+    llm_temperature: float = 0.3
+    max_llm_tokens: int = 1024
 
 
 class CodeInstructOptions(_BaseOptions):

--- a/tests/test_pipeline_commit_runtime.py
+++ b/tests/test_pipeline_commit_runtime.py
@@ -95,6 +95,9 @@ def _pipeline_for_filter_tests(**opts):
     """Build a pipeline whose _metadata_filter/_structural_filter we can call."""
     from unittest.mock import MagicMock
 
+    # These tests target bugfix-signal/merge/author logic — isolate them from
+    # the problem-statement word gate (its own dedicated test covers it).
+    opts.setdefault("min_problem_statement_words", 0)
     pipe = CommitRuntimePipeline.__new__(CommitRuntimePipeline)
     pipe.options = CommitRuntimeOptions(**opts)
     pipe.bootstrap = MagicMock()
@@ -126,6 +129,14 @@ def test_metadata_filter_short_message():
     pipe = _pipeline_for_filter_tests(min_message_words=5)
     commit = _make_commit(subject="wip", body="")
     assert pipe._metadata_filter(commit) == "short_message"
+
+
+def test_metadata_filter_problem_statement_too_short():
+    """New gate: with min_problem_statement_words set, a terse commit is dropped."""
+    pipe = _pipeline_for_filter_tests(min_problem_statement_words=20)
+    # passes min_message_words(5) but under the 20-word problem-statement gate
+    c = _make_commit(subject="fix the parser so it stops crashing on empty input", body="")
+    assert pipe._metadata_filter(c) == "problem_statement_too_short"
 
 
 def test_metadata_filter_passes_a_good_commit():
@@ -251,7 +262,9 @@ def _stub_pipeline_for_build_task(test_cmds=None, language="python"):
     from unittest.mock import MagicMock
 
     pipe = CommitRuntimePipeline.__new__(CommitRuntimePipeline)
-    pipe.options = CommitRuntimeOptions()
+    # synthesis off → deterministic raw-text instruction (no LLM call on the mock)
+    pipe.options = CommitRuntimeOptions(synthesize_with_llm=False)
+    pipe._llm_cost_usd = 0.0
     pipe.bootstrap = SimpleNamespace(
         image_tag="local/r2e-bootstrap/o__r:abc",
         image_digest="local/r2e-bootstrap/o__r:abc",


### PR DESCRIPTION
## Summary

Hardens `commit_runtime` output quality. A 100-env audit of the prior settings found only **~33% publish-quality**: 45 thin/title-only instructions, 30 leaking the solution (raw commit-message changelog bullets / file names), and 63 carrying whole-suite P2P (100s of tests) that inflated flaky-reward risk.

Three changes:
- **`synthesize_with_llm` (now implemented; default ON)** — was a no-op flag. An LLM rewrites the commit/issue into a clean, **symptom-focused, leak-free** problem statement. Fixes both the leaky and the thin instructions.
- **`min_problem_statement_words` 0 → 8** — drops near-empty commits, but stays low so synthesis can expand terse-commit repos (20 starved Rust/Go crates entirely).
- **`max_pass_to_pass = 50` (new)** — caps the P2P regression set (prefers tests in the patched files) to bound flakiness + runtime.

Metadata now stamps `instruction_synthesized` + `llm_cost_usd`.

## Result (re-audit of a fresh 100-env set)
| Metric | before | after |
|---|--:|--:|
| Clean (rich, no leak, bugfix) | 33/100 | **100/100** |
| Leaky | 30 | **0** |
| P2P > 200 (flaky risk) | 63 | **0** |

**Non-gameability confirmed:** tasks that scored claude-code+Sonnet **1.0** when the instruction leaked the fix now score 0 (real solve required) — the leak inflation is gone. Oracle still 1.0 (solvable).

## Test plan
- `uv run pytest -q` → 675 passed (+ a new `problem_statement_too_short` gate test; updated the filter-unit tests that assumed the old default). The lone unrelated failure (`test_e2e_public_trl`) fails identically on `main`.
- `ruff check` + `ruff format --check` clean. No version bump.
- A robust 100-env dataset built with these settings is published at `AdithyaSK/repo2rlenv-commit-runtime-v2`.

## Note
`synthesize_with_llm=True` means `commit_runtime` now makes one LLM call per emitted task (cost stamped in metadata). Bootstrap already requires an LLM, so no new requirement.