### PR TITLE
Fix Harbor reward details output

### DIFF
--- a/src/repo2rlenv/pipelines/_pr_runtime_verifier.py
+++ b/src/repo2rlenv/pipelines/_pr_runtime_verifier.py
@@ -17,7 +17,7 @@ RL training — an agent that fixes 4 of 5 failing tests scores the same
 So this verifier emits BOTH:
   * /logs/verifier/reward.txt  — the GRADED scalar (training signal,
         which Harbor reads):  reward = f2p_rate * p2p_factor
-  * /logs/verifier/reward.json — carries the strict SWE-bench
+  * /logs/verifier/reward-details.json — carries the strict SWE-bench
         ``resolved`` bool (eval signal) PLUS the full breakdown.
 
 Refs: SWE-bench (F2P/P2P semantics), SWE-RL / SWE-Gym (dense reward for
@@ -372,7 +372,7 @@ def main(argv: list[str] | None = None) -> int:
     os.makedirs(args.out_dir, exist_ok=True)
     with open(os.path.join(args.out_dir, "reward.txt"), "w", encoding="utf-8") as f:
         f.write(f"{reward:.6f}\n")
-    with open(os.path.join(args.out_dir, "reward.json"), "w", encoding="utf-8") as f:
+    with open(os.path.join(args.out_dir, "reward-details.json"), "w", encoding="utf-8") as f:
         json.dump(breakdown, f, indent=2)
 
     print(json.dumps(breakdown, indent=2))

--- a/src/repo2rlenv/pipelines/pr_runtime.py
+++ b/src/repo2rlenv/pipelines/pr_runtime.py
@@ -454,7 +454,7 @@ def build_eval_script(
          - GRADED (default, when fail_to_pass is provided): bake the standalone
            graded verifier + the F2P/P2P test-name lists, parse the captured
            log, and write reward = f2p_rate * p2p_rate to reward.txt (+ full
-           breakdown incl. the strict SWE-bench ``resolved`` bool to reward.json)
+           breakdown incl. the strict SWE-bench ``resolved`` bool to reward-details.json)
          - BINARY (fallback, e.g. ``skip_validation`` with no F2P known): write
            1.0 if the suite exited 0 else 0.0
       7. Reset test files again on the way out
@@ -486,7 +486,7 @@ def build_eval_script(
             '  echo "0.000000" > /logs/verifier/reward.txt\n'
             "  printf '%s' "
             '\'{"reward": 0.0, "resolved": false, "parse_status": '
-            '"test_patch_apply_failed"}\' > /logs/verifier/reward.json\n'
+            '"test_patch_apply_failed"}\' > /logs/verifier/reward-details.json\n'
             '  echo "R2E: test_patch failed to apply (rc=$R2E_APPLY_RC) — failing closed" >&2\n'
             "  exit 0\n"
             "fi\n"

--- a/tests/test_pipeline_pr_runtime.py
+++ b/tests/test_pipeline_pr_runtime.py
@@ -381,6 +381,8 @@ def test_build_eval_script_fails_closed_on_patch_apply():
     )
     assert "R2E_APPLY_RC" in script
     assert "test_patch_apply_failed" in script
+    assert "/logs/verifier/reward-details.json" in script
+    assert "/logs/verifier/reward.json" not in script
     assert script.find("R2E_APPLY_RC") < script.find("test_output.log")
 
 

--- a/tests/test_pr_runtime_verifier.py
+++ b/tests/test_pr_runtime_verifier.py
@@ -170,7 +170,8 @@ def test_main_writes_graded_reward(tmp_path: Path):
     )
     assert rc == 0
     assert (out_dir / "reward.txt").read_text().strip() == "1.000000"
-    breakdown = json.loads((out_dir / "reward.json").read_text())
+    assert not (out_dir / "reward.json").exists()
+    breakdown = json.loads((out_dir / "reward-details.json").read_text())
     assert breakdown["resolved"] is True
     assert breakdown["command_resolved"] is True  # clean command, exit 0
     assert breakdown["parse_status"] == "ok"
@@ -203,7 +204,7 @@ def test_main_command_resolved_false_on_untracked_failure(tmp_path: Path):
             str(out_dir),
         ]
     )
-    b = json.loads((out_dir / "reward.json").read_text())
+    b = json.loads((out_dir / "reward-details.json").read_text())
     assert b["reward"] == 1.0  # tracked subset clean -> training reward 1.0
     assert b["resolved"] is True  # tracked resolution preserved
     assert b["command_resolved"] is False  # untracked failure + nonzero exit
@@ -231,7 +232,7 @@ def test_main_falls_back_to_exit_code_on_unparseable_log(tmp_path: Path):
             str(out_dir),
         ]
     )
-    breakdown = json.loads((out_dir / "reward.json").read_text())
+    breakdown = json.loads((out_dir / "reward-details.json").read_text())
     assert breakdown["parse_status"] == "fallback_exitcode"
     assert (out_dir / "reward.txt").read_text().strip() == "1.000000"
 
@@ -244,7 +245,7 @@ def test_main_fallback_not_resolved_when_oracle_declared(tmp_path: Path):
     p2p = _write(tmp_path / "p2p.json", json.dumps([]))
     out_dir = tmp_path / "verifier"
     main(["--log", log, "--f2p", f2p, "--p2p", p2p, "--exit-code", "0", "--out-dir", str(out_dir)])
-    b = json.loads((out_dir / "reward.json").read_text())
+    b = json.loads((out_dir / "reward-details.json").read_text())
     assert b["parse_status"] == "fallback_exitcode"
     assert b["resolved"] is False  # cannot confirm F2P passed
     assert b["eval_trustworthy"] is False


### PR DESCRIPTION
## Summary

- Keep `reward.txt` as the Harbor-readable scalar result.
- Write `pr_runtime` diagnostics to Harbor's `reward-details.json` sidecar.

## Test plan

- [x] `uv run pytest -q tests/test_pr_runtime_verifier.py tests/test_pipeline_pr_runtime.py`
- [x] `uv run ruff check src/repo2rlenv/pipelines/_pr_runtime_verifier.py src/repo2rlenv/pipelines/pr_runtime.py tests/test_pr_runtime_verifier.py tests/test_pipeline_pr_runtime.py`
- [x] `uv run ruff format --check src/repo2rlenv/pipelines/_pr_runtime_verifier.py src/repo2rlenv/pipelines/pr_runtime.py tests/test_pr_runtime_verifier.py tests/test_pipeline_pr_runtime.py`

## Out of scope

- Regenerating published Hub dataset revisions.

Closes #74

## Live evidence

Run on 2026-07-13 UTC with the real standalone production `_pr_runtime_verifier.py` CLI in each checkout. Both runs used the identical parsed pytest log and F2P/P2P oracle files:

```bash
python src/repo2rlenv/pipelines/_pr_runtime_verifier.py \
  --log pytest.log \
  --f2p f2p.json \
  --p2p p2p.json \
  --runner pytest \
  --exit-code 0 \
  --out-dir "$OUT_DIR"
```

The input contained one passing FAIL_TO_PASS test and one passing PASS_TO_PASS test, so the production verifier computed a scalar reward of 1.0 and `resolved=true`.

### Current `main`: Harbor-preferred file has an invalid schema

Commit: `a8cf74d71a0f6de6bbc9adfb43a00249108610c1`

The CLI wrote both `reward.txt` and `reward.json`. Although `reward.txt` contained the valid scalar `1.000000`, Harbor gives `reward.json` precedence. The emitted JSON was neither a number nor a flat numeric map: it contained booleans (`resolved`, `command_resolved`), arrays (`regressions`, `untracked_failed`), and strings (`parse_status`, `runner`). Applying Harbor's numeric-or-flat-numeric-map contract produced:

```json
{
  "harbor_schema_valid": false,
  "resolved": true,
  "command_resolved": true,
  "parse_status": "ok"
}
```

This demonstrates the issue directly: a correctly resolved verifier run still presents Harbor with a higher-precedence structured reward file that violates its reward schema.

### PR head: Harbor consumes the scalar and details remain available

Commit: `056632c92d4d4d01a33ab2c337b21f8024297b94`

The identical CLI invocation wrote `reward.txt` and `reward-details.json`, with no `reward.json` present:

```text
files=reward.txt reward-details.json
reward.txt=1.000000
reward.json present=false
harbor_scalar_valid=true
```

The sidecar retained the structured evaluation data without competing for Harbor reward precedence:

```json
{
  "reward": 1.0,
  "resolved": true,
  "command_resolved": true,
  "parse_status": "ok",
  "runner": "pytest"
}
```

This validates the changed scalar-plus-sidecar output contract through the actual standalone verifier process. Regenerating published Hub dataset revisions remains explicitly out of scope for this code-only PR.
