### PR TITLE
pr_diff verifier: mirror #75 — reward-details.json sidecar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repo2rlenv"
-version = "0.8.5"
+version = "0.8.5.post1"
 description = "Turn any repository into an RL environment for training and evaluation."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/repo2rlenv/hub.py
+++ b/src/repo2rlenv/hub.py
@@ -154,7 +154,7 @@ def _reward_doc_for(pipeline: str) -> str:
             "applied, `tests/test.sh` runs the suite and a baked verifier scores "
             "`reward = f2p_rate × p2p_rate` to `/logs/verifier/reward.txt` (a dense "
             "training signal), and writes the strict SWE-bench `resolved` bool plus a "
-            "breakdown to `/logs/verifier/reward.json`:\n\n"
+            "breakdown to `/logs/verifier/reward-details.json`:\n\n"
             "```json\n"
             '{"reward": 1.0, "resolved": true, "f2p_passed": 3, "f2p_total": 3,\n'
             ' "p2p_passed": 595, "p2p_total": 595, "regressions": [], "parse_status": "ok"}\n'
@@ -169,11 +169,11 @@ def _reward_doc_for(pipeline: str) -> str:
             "similarity / LLM-judge). The `--ve ANTHROPIC_API_KEY=...` verifier-env "
             "pass enables the LLM-judge component; without it the verifier still "
             "produces a valid score with `llm_judge: null` and the deterministic "
-            "weights renormalized. Full breakdown in `/logs/verifier/reward.json`."
+            "weights renormalized. Full breakdown in `/logs/verifier/reward-details.json`."
         )
     return (
         "The reward function ships inside the task (`tests/test.sh` + verifier); "
-        "the breakdown is written to `/logs/verifier/reward.json` at run time."
+        "the breakdown is written to `/logs/verifier/reward-details.json` at run time."
     )
 
 
@@ -352,7 +352,7 @@ See the [pipeline docs](https://github.com/huggingface/Repo2RLEnv/blob/main/docs
 
 The reward function is part of the task itself (`tests/test.sh` + the
 verifier code baked into the image). The full per-task breakdown is
-written to `/logs/verifier/reward.json` at run time — useful for slicing
+written to `/logs/verifier/reward-details.json` at run time — useful for slicing
 training data by component.
 
 See the [pipeline doc]({f"https://github.com/huggingface/Repo2RLEnv/blob/main/docs/pipelines/{pipeline}.md"}#multi-component-reward) for the component-by-component design.

--- a/src/repo2rlenv/pipelines/_pr_diff_verifier.py
+++ b/src/repo2rlenv/pipelines/_pr_diff_verifier.py
@@ -33,9 +33,12 @@ Final reward is clipped to [0, 1] and additionally clamped to ≤ 0.40
 when ``size_sanity < 0.10`` (catastrophic-size hard cap — stops a
 charitable judge from inflating scores on wildly wrong-sized patches).
 
-Outputs:
-  /logs/verifier/reward.txt   — single float (Harbor reads this)
-  /logs/verifier/reward.json  — full component breakdown + status
+Outputs (mirrors `_pr_runtime_verifier.py` after #75):
+  /logs/verifier/reward.txt           — single float (Harbor reads this)
+  /logs/verifier/reward-details.json  — full component breakdown + status
+      (structured diagnostics; Harbor's `reward.json` schema is flat-numeric-
+      only, so the breakdown goes to the `reward-details.json` sidecar which
+      Harbor renders under Verifier Logs → Rewards)
 
 Pure stdlib — uses only ``difflib``, ``json``, ``os``, ``re``,
 ``urllib``, ``sys``. The same module is imported by the unit tests
@@ -479,7 +482,12 @@ def main(argv: list[str] | None = None) -> int:
     os.makedirs("/logs/verifier", exist_ok=True)
     with open("/logs/verifier/reward.txt", "w", encoding="utf-8") as f:
         f.write(f"{final:.6f}\n")
-    with open("/logs/verifier/reward.json", "w", encoding="utf-8") as f:
+    # Harbor's `reward.json` must be a flat map of floats/ints (spec, see
+    # <https://harborframework.com/docs/tasks>); our breakdown carries nested
+    # dicts, judge strings, and status strings, so it goes to the sidecar the
+    # Harbor UI renders under Verifier Logs → Rewards. Mirrors #75 (Neubig)
+    # for `_pr_runtime_verifier.py`.
+    with open("/logs/verifier/reward-details.json", "w", encoding="utf-8") as f:
         json.dump(breakdown, f, indent=2)
 
     # Also print to stdout so harbor's log captures the breakdown

--- a/src/repo2rlenv/pipelines/pr_diff.py
+++ b/src/repo2rlenv/pipelines/pr_diff.py
@@ -11,7 +11,7 @@ The *emitted* task is runnable in Docker (when ``emit_harbor_env=True``,
 the default): it ships a thin ``python:3.12-slim`` ``environment/Dockerfile``
 + a ``tests/test.sh`` carrying the 6-component diff-similarity verifier
 (``_pr_diff_verifier``). Reward kind is ``diff_similarity``; the component
-breakdown lands in ``/logs/verifier/reward.json``. With
+breakdown lands in ``/logs/verifier/reward-details.json``. With
 ``emit_harbor_env=False`` the task is pure text (instruction.md +
 solution/patch.diff) for consumers who score the diff themselves.
 
@@ -263,7 +263,7 @@ def build_pr_diff_eval_script(*, base_commit: str) -> str:
 
       1. Captures the agent's edits via ``git diff <base_commit>``
       2. Invokes the verifier, which writes ``/logs/verifier/reward.txt``
-         (single float) and ``/logs/verifier/reward.json`` (component
+         (single float) and ``/logs/verifier/reward-details.json`` (component
          breakdown) for Harbor + downstream inspection.
 
     Exit code: 0 always — the reward score is the verdict, not the bash
@@ -550,7 +550,7 @@ class PRDiffPipeline:
             "built_at": datetime.now(UTC).isoformat(),
             # Spec reward kind is `diff_similarity` (see docs/reference/SPEC.md).
             # The 6-component breakdown is *how* the similarity is scored — it's
-            # surfaced in /logs/verifier/reward.json, not as a separate kind.
+            # surfaced in /logs/verifier/reward-details.json, not as a separate kind.
             "reward_kinds": ["diff_similarity"],
             **({"synthesis_llm": self.input.llm.qualified_name} if self.input.llm else {}),
             "pr_diff": {

--- a/src/repo2rlenv/pipelines/pr_runtime.py
+++ b/src/repo2rlenv/pipelines/pr_runtime.py
@@ -1098,8 +1098,9 @@ class PRRuntimePipeline:
                 "validation_status": validation_status,
                 "bootstrap_image": self.bootstrap.image_digest,
                 # Graded reward: reward.txt carries f2p_rate*p2p_rate (training
-                # signal); reward.json adds the strict SWE-bench `resolved` bool
-                # (eval signal). See _pr_runtime_verifier.py.
+                # signal); the strict SWE-bench `resolved` bool + full breakdown
+                # go to reward-details.json (eval signal — Harbor's reward.json
+                # schema is flat-numeric-only). See _pr_runtime_verifier.py.
                 "reward_mode": "graded",
             },
             # Difficulty + coverage metadata so consumers can slice train/eval

--- a/tests/test_e2e_hub_build.py
+++ b/tests/test_e2e_hub_build.py
@@ -100,7 +100,7 @@ def test_hub_task_builds_and_oracle_resolves(tmp_path: Path) -> None:
     val = float(rewards[0].read_text().strip())
     assert val == 1.0, f"oracle reward {val} != 1.0 for {one.name}"
 
-    rj = list(jobs.glob("*/*/verifier/reward.json"))
+    rj = list(jobs.glob("*/*/verifier/reward-details.json"))
     if rj:
         breakdown = json.loads(rj[0].read_text())
         assert breakdown.get("resolved") is True, breakdown

--- a/uv.lock
+++ b/uv.lock
@@ -1249,7 +1249,7 @@ wheels = [
 
 [[package]]
 name = "repo2rlenv"
-version = "0.8.4"
+version = "0.8.5.post1"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
Follow-up to #75. Same fix, ported to `_pr_diff_verifier.py` which #75 didn't cover.

## Why this is needed on top of #75

`#75` fixed the shared `_pr_runtime_verifier.py`, so `pr_runtime` / `commit_runtime` / `cve_patches` are now Harbor-spec-compliant. But `pr_diff` has its own separate `_pr_diff_verifier.py` (the 6-component diff-similarity reward) and it was writing this to `reward.json`:

```json
{
  "final_reward": 1.0,
  "components": { "format_valid": 1.0, ... },   // ❌ nested dict
  "weights":    { ... },                         // ❌ nested dict
  "judge_model": "claude-haiku-...",             // ❌ string
  "judge_status": "ok"                           // ❌ string
}
```

Every non-scalar field violates Harbor's [reward.json schema](https://harborframework.com/docs/tasks) ("flat map of floats/ints only"). Same shape of bug — moved the same way:

- `/logs/verifier/reward.txt` — scalar (Harbor reads this)
- `/logs/verifier/reward-details.json` — full 6-component breakdown + judge metadata

## Changes

- `src/repo2rlenv/pipelines/_pr_diff_verifier.py` — swap output filename; docstring updated to match #75's phrasing.
- `src/repo2rlenv/pipelines/pr_diff.py` — docstring refs.
- `src/repo2rlenv/hub.py` — dataset-card prose that gets rendered into the published READMEs.
- `src/repo2rlenv/pipelines/pr_runtime.py` — one comment left stale by #75.
- `tests/test_e2e_hub_build.py` — glob pattern.
- `pyproject.toml` — 0.8.5 → 0.8.5.post1.

## Testing
- `uv run pytest -q` — 684 pass, lint + format clean.

## Follow-up (not in this PR)
Refresh the five published Hub datasets so their baked-in `tests/verifier.py` copies pick up both #75 and this fix. Standard per-task file-copy re-bake, no re-oracle needed (only the output *filename* moved, reward values are unchanged).
