### PR TITLE
docs: add pipeline-RFC scaffold + retro RFCs for all 6 shipped pipelines

### DIFF
--- a/docs/contributing/ADDING_A_PIPELINE.md
+++ b/docs/contributing/ADDING_A_PIPELINE.md
@@ -2,6 +2,8 @@
 
 Step-by-step walkthrough for shipping a new synthesis pipeline. Use [`pr_diff`](../../src/repo2rlenv/pipelines/pr_diff.py) as the canonical reference implementation throughout.
 
+> **Before you code an entirely new pipeline**, write an RFC in [`docs/rfcs/`](../rfcs/README.md). The RFC captures *why* the pipeline exists in the shape it does — motivation, verification approach, contamination story, LLM use, yield expectations — and lets the design be reviewed without the implementation blur. Small reshapes of an existing pipeline don't need one; new `PipelineName` entries always do. Copy [`docs/rfcs/TEMPLATE.md`](../rfcs/TEMPLATE.md) to `docs/rfcs/NNNN-<name>.md` and land the RFC first, then follow this cookbook.
+
 ## What you're building
 
 A class that:

--- a/docs/rfcs/0001-pr-diff.md
+++ b/docs/rfcs/0001-pr-diff.md
@@ -1,0 +1,107 @@
+# RFC 0001: `pr_diff`
+
+**Status:** implemented
+**Author:** `@adithya-s-k`
+**Created:** 2026-01-15 *(retrospective — pipeline shipped in v0.1.0; RFC written 2026-07-15 as archival record)*
+
+## Summary
+
+Mine merged pull-request diffs from a target repo into text-only Harbor tasks with a 6-component graded reward (5 deterministic components + 1 LLM-as-judge). No per-repo Docker bootstrap; every task ships a thin `python:3.12-slim` image with the repo cloned at the PR's `base_commit` and the oracle + verifier base64-baked in. The lowest-cost pipeline in the set.
+
+## Motivation
+
+The starting point for the project. Datasets of merged PR diffs are the closest thing there is to a natural corpus of "here's a code change plus the human review signal that it was correct." SWE-RL (Meta FAIR, arXiv:2502.18449) showed that a diff-similarity reward on merged PRs is enough to bootstrap a coding-agent RL loop without any executable tests. We wanted that shape in Repo2RLEnv as the *baseline* pipeline: cheap to generate, no bootstrap dependency, works on any repo with merged PRs. Every subsequent pipeline is compared against it for cost/signal ratio.
+
+## Design
+
+### Input
+
+- **Source** — GitHub · GitLab (via input-source abstraction added in v0.8.4).
+- **Trigger** — `repo2rlenv generate --pipeline pr_diff --repo <owner>/<name> --pipeline-opt limit=100 ...`
+- **Options model** — `PrDiffOptions`: `limit`, `since`, `until`, `skip_drafts`, `min_loc_changed`, `max_files_per_pr`, `require_test_changes`, plus provenance knobs.
+
+### Algorithm
+
+1. `gh pr list --state merged --json ...` — filter mergeAts and skip drafts client-side.
+2. Fetch `base.sha` per PR via `github.fetch_pr` (patched in #73 — `gh pr list --json baseRefOid` doesn't populate).
+3. Per PR: split into `(source_patch, test_patch)`, apply structural filters, drop drafts and CI-only changes.
+4. Emit a Harbor task with the thin env: `python:3.12-slim` + repo clone at `base_commit` + base64-baked `/verifier/oracle.patch`, `/verifier/instruction.md`, `/verifier/verifier.py`.
+5. **No sandbox bootstrap.** The Dockerfile is self-contained; consumers rebuild it in ~30 s.
+
+### Output
+
+- Task shape: `environment/Dockerfile` (self-contained), `tests/test.sh` (diff-then-invoke-verifier), `solution/{patch.diff, solve.sh}`, `instruction.md`, `task.toml`.
+- `[metadata.repo2env]` provenance: `pipeline`, `repo`, `ref` (= base_commit), `reference` (PR URL), `reward_kinds=["diff_similarity"]`, `reward_calibration` (LOC + difficulty bucket).
+
+## Verification
+
+- **Reward kind** — `diff_similarity`.
+- **Reward formula** — weighted sum of 6 components:
+
+  | Component | Weight | Captures |
+  |---|--:|---|
+  | `format_valid` | 0.00 | Guard: parses as a unified diff (weight 0; kept as a bit) |
+  | `size_sanity` | 0.08 | `min(oracle_loc, predicted_loc) / max(...)` |
+  | `file_targeting` | 0.12 | F1 over changed-file sets |
+  | `region_overlap` | 0.20 | Predicted hunks overlap oracle hunks (5-line slack) |
+  | `similarity` | 0.10 | `SequenceMatcher` over `+`/`-` lines only |
+  | `llm_judge` | 0.50 | Haiku 4.5 semantic correctness rating |
+
+  Plus a **catastrophic-size cap** — clamps reward to ≤ 0.40 when `size_sanity < 0.10`.
+
+- **Oracle invariant** — the merged diff scores exactly 1.0.
+- **Non-tamper** — verifier reads the agent's diff from `git diff --cached <base_commit>` and scores it against the oracle; the agent has no test file to tamper with.
+
+## Anti-contamination
+
+- **Git-history scrub** — after checkout at `base_commit`, remove `origin`, prune future refs, `gc`. Prevents `git diff origin/main`.
+- **Egress guard** — the shared `_env_guard.py` `docker-compose.yaml` overlay blackholes PyPI + GitHub, so `pip download <pkg>==<fix>` and web fetches of the fix commit fail.
+- **Instruction leak-strip** — extended in v0.8.5 to catch trailing `(#NNNN)` squash-trailers and cross-repo `repo#N` refs.
+
+## LLM use
+
+- **`at verify` (per scoring)** — one Anthropic Haiku call per agent invocation, weight 0.50. Graceful degradation on missing API key: `judge_status=no_api_key`, other 5 components renormalize.
+- **No bootstrap LLM** — the thin env doesn't need it.
+- **Cost order-of-magnitude** — ~$0.001-$0.005 per scoring call. A 100-agent-run × 100-task eval ≈ $10-50.
+
+## Yield & repo suitability
+
+- **80–95% yield** — text-only, no execution gate. Almost every merged PR qualifies.
+- **Works on any repo with merged PRs.** No sandbox constraint means monorepos, ML repos with non-portable test suites, and GPU-only projects all mine cleanly.
+
+## Dependencies
+
+- No reuse; `pr_diff` is the *base* pipeline. Later pipelines borrow its Dockerfile-baking + verifier pattern.
+- Stdlib + `difflib`. LLM judge via LiteLLM.
+
+## Alternatives considered
+
+- **Full sandbox-verified diff similarity** — deferred to `pr_runtime`. `pr_diff` deliberately stays text-only so it's the cheapest, broadest baseline.
+- **Deterministic weights only, no LLM judge** — tried; scored `format_valid` + `similarity` too high (pilot data). LLM judge earns its 0.50 weight.
+
+## Rollout plan
+
+Historic. Shipped in v0.1.0. Retuned in v0.8.3 via an LLM-driven reward-engineering pass on a 23-task pilot: Sonnet analyzed per-task component data and recommended the current weights (data-grounded; the original guesses were wrong).
+
+## Open questions
+
+Historic — none active.
+
+## References
+
+- SWE-RL: [arXiv:2502.18449](https://arxiv.org/abs/2502.18449), [facebookresearch/swe-rl](https://github.com/facebookresearch/swe-rl).
+- Reward-tuning pilot: [`docs/release_notes/v0.8.3/findings-pr_diff.md`](../release_notes/v0.8.3/findings-pr_diff.md).
+
+## Implementation
+
+| | |
+|---|---|
+| **Initial PR** | Multiple commits pre-#4 (`be7a0f5` renamed; earlier commits landed the pipeline) |
+| **Shipping release** | v0.1.0 |
+| **Source file** | [`src/repo2rlenv/pipelines/pr_diff.py`](../../src/repo2rlenv/pipelines/pr_diff.py) |
+| **Verifier** | [`src/repo2rlenv/pipelines/_pr_diff_verifier.py`](../../src/repo2rlenv/pipelines/_pr_diff_verifier.py) |
+| **Options model** | [`src/repo2rlenv/spec/options.py`](../../src/repo2rlenv/spec/options.py) — `PrDiffOptions` |
+| **Doc page** | [`docs/pipelines/pr_diff.md`](../pipelines/pr_diff.md) |
+| **Findings / release notes** | [`docs/release_notes/v0.8.3/findings-pr_diff.md`](../release_notes/v0.8.3/findings-pr_diff.md) |
+| **Reference dataset** | [`AdithyaSK/repo2rlenv-pr-diff`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-pr-diff) (181 envs) |
+| **Follow-up PRs** | [#40](https://github.com/huggingface/Repo2RLEnv/pull/40) Harbor-runnable env + 6-component reward · [#63](https://github.com/huggingface/Repo2RLEnv/pull/63) GitLab source support · [#73](https://github.com/huggingface/Repo2RLEnv/pull/73) fetch base_sha via REST · [#76](https://github.com/huggingface/Repo2RLEnv/pull/76) mirror #75 (Harbor spec: reward-details.json sidecar) |

--- a/docs/rfcs/0002-pr-runtime.md
+++ b/docs/rfcs/0002-pr-runtime.md
@@ -1,0 +1,107 @@
+# RFC 0002: `pr_runtime`
+
+**Status:** implemented
+**Author:** `@adithya-s-k`
+**Created:** 2026-02-01 *(retrospective — pipeline shipped in v0.3.0; RFC written 2026-07-15 as archival record)*
+
+## Summary
+
+SWE-bench-style PR mining with **sandbox-verified F2P/P2P test oracles**. Mines merged PRs and runs the repo's actual test suite inside a Docker container built by the bootstrap phase; only PRs whose new tests flip fail→pass under the gold patch (while all pre-existing tests stay green) are emitted. Graded reward: `reward = f2p_rate × p2p_rate`. The flagship of the runtime family.
+
+## Motivation
+
+`pr_diff` is cheap but its reward is *proxy* — diff similarity to the merged patch, not an execution signal. For an RL loop that trains agents to actually make code work, you want the same signal SWE-bench uses: **did the patch fix the failing test, and did no other test break?** That's F2P/P2P. It requires a working sandbox for the target repo, which is where our `bootstrap/` phase comes in. `pr_runtime` is the pipeline that consumes bootstrap and turns each candidate PR into a runnable Harbor task.
+
+The counter-argument at the time: "sandbox setup is a lot of engineering; SWE-bench already exists." True but SWE-bench is a fixed 2K-task benchmark, not a pipeline that works on arbitrary repos. Repo2RLEnv's contribution is the **reusable pipeline** — point it at any repo with a working test suite and get F2P/P2P-graded tasks. Every non-Django repo in our datasets is proof of that.
+
+## Design
+
+### Input
+
+- **Source** — GitHub · GitLab (input-source abstraction from v0.8.4).
+- **Trigger** — `repo2rlenv generate --pipeline pr_runtime --repo <owner>/<name> --pipeline-opt limit=60 --llm anthropic/claude-sonnet-4-6 ...`
+- **Options model** — `PrRuntimeOptions`: mining knobs (`limit`, `since`, `until`, `skip_drafts`) + structural filters (`require_new_test_funcs`, `min_problem_statement_words`, `lite_filter`, `max_files_per_pr`) + validation (`require_fail_to_pass`, `min_fail_to_pass`, `validation_timeout_sec`).
+
+### Algorithm
+
+1. `gh pr list --state merged` → candidate PRs.
+2. `_bootstrap` — LLM agent iterates shell commands in a fresh Docker container until the repo builds and its test suite collects. Result is cached content-addressed under `envs/<repo>__<sha>/`.
+3. Per PR: fetch metadata (title, body, `base.sha` via REST — #73), split diff into `(source_patch, test_patch)`.
+4. **Two-stage validation inside the bootstrap sandbox**:
+   - Pre-fix: apply only the test patch on top of `base_commit`, run tests → those failing are candidate F2P.
+   - Post-fix: apply the full merged diff, run tests → all F2P must pass, all P2P must stay green.
+5. **Instruction sourcing** — when the PR has `Closes #N`, fetch the linked issue body (leak-free); otherwise fall back to the PR body run through `_strip_info_leak` + `_reflow_pr_body`.
+6. Emit a Harbor task with the shared shape.
+
+### Output
+
+- Task shape: `environment/Dockerfile` (built on the bootstrap image), `environment/docker-compose.yaml` (egress guard), `tests/{test.sh, verifier.py, f2p.json, p2p.json}`, `solution/{patch.diff, solve.sh}`, `instruction.md`, `task.toml`.
+- `[metadata.repo2env]` provenance: standard fields plus `pr_runtime` subtable (`pr_url`, `pr_merged_at`, `base_commit`, `fail_to_pass`, `pass_to_pass`) and `reward_calibration` (F2P/P2P counts, LOC, difficulty).
+
+## Verification
+
+- **Reward kinds** — `test_execution` + `diff_similarity`.
+- **Reward formula** — graded: `reward = f2p_rate × p2p_rate`.
+- **Two eval signals** (Arc 2 split): **`resolved`** = SWE-bench-tracked (all F2P + P2P pass); **`command_resolved`** = stricter (resolved AND no untracked failures AND `exit_code==0`). Plus **`eval_grade`** = `command_resolved` AND `p2p_count > 0`. Documented in [`docs/reference/REWARD_SCHEMA.md`](../reference/REWARD_SCHEMA.md).
+- **Oracle invariant** — gold patch scores `reward=1.0, resolved=True` on every task. Enforced by dropping tasks that fail the invariant during the oracle gate.
+- **Non-tamper** — `test.sh` resets test files to `base_commit` and re-applies the heredoc'd test-patch at every invocation, so an agent that edits/deletes tests loses.
+
+## Anti-contamination
+
+Full v0.8.5 defenses baked in:
+
+- **Git-history scrub** — remove `origin`, prune future refs, `gc`.
+- **Egress guard** — compose overlay blackholing `pypi.org`, `github.com`, and CDNs.
+- **Instruction leak-strip** — issue-fetch fallback (bug reports don't name the fix); `_LEAK_PATTERNS` scrub SHAs, fix-PR links, `Closes #N`, `(#NNNN)`, `repo#N`.
+
+## LLM use
+
+- **`at bootstrap` (cached)** — one call chain per (repo, ref) for the LLM agent that iterates the Docker env into a build-and-test-green state. Amortized across all tasks from that repo. Cost per repo: ~$3–8 uncached, $0 cached.
+- **Zero per-task LLM cost** during mining (the instruction is real issue/PR text, not synthesized).
+
+## Yield & repo suitability
+
+- **15–40% yield.** Dominant factor: does the PR ship a new test that flips fail→pass, and does the suite run green in the container?
+- **What works**: pytest-clean Python (pallets, requests, httpx, attrs, werkzeug, flask, typer, aiohttp), Go with `go test` (urfave/cli, gin, mux, cobra, testify, logrus), Node with jest, Rust with cargo test.
+- **What doesn't**: ML repos whose tests need CUDA, tests that need network, monorepos where tests span multiple packages.
+
+## Dependencies
+
+- **`bootstrap/`** — LLM-driven Docker env build + content-addressed cache.
+- **`_pr_runtime_verifier.py`** — the in-container graded scorer. Shared with `commit_runtime`, `cve_patches`.
+- **`_env_guard.py`** — anti-contamination.
+- Standard tooling: `gh` CLI + REST for PR fetch, LiteLLM for bootstrap.
+
+## Alternatives considered
+
+- **Binary exit-code reward** — shipped that way originally in v0.3.0. Upgraded to graded F2P/P2P in v0.8.3 (Arc 2) because the binary form gave the same 0.0 to an agent that fixed 4/5 tests as to one that fixed 0.
+- **Whole-suite P2P** — considered; too flaky. Went with the *tracked* P2P set (tests known to pass at HEAD before the fix), which is what SWE-bench does.
+
+## Rollout plan
+
+Historic. v0.3.0 shipped the binary version; v0.8.3 (Arc 2) shipped the graded version + 100-env reference dataset. Ongoing improvements: PEP 735 `--group tests` recipe fix, `command_resolved` split (audit rev 2), enriched manifest with checksums.
+
+## Open questions
+
+Historic — none active. The `command_resolved` / `eval_grade` split is now the stable model.
+
+## References
+
+- SWE-bench: [arXiv:2310.06770](https://arxiv.org/abs/2310.06770), [SWE-bench/SWE-bench](https://github.com/SWE-bench/SWE-bench).
+- SWE-Gym: [arXiv:2412.21139](https://arxiv.org/abs/2412.21139).
+- Full v0.8.3 audit: [`docs/release_notes/v0.8.3/findings-pr_runtime.md`](../release_notes/v0.8.3/findings-pr_runtime.md).
+
+## Implementation
+
+| | |
+|---|---|
+| **Initial PR** | [#4](https://github.com/huggingface/Repo2RLEnv/pull/4) — `pr_runtime` pipeline v0.3: SWE-bench-style PR mining with sandbox verification |
+| **Shipping release** | v0.3.0 |
+| **Source file** | [`src/repo2rlenv/pipelines/pr_runtime.py`](../../src/repo2rlenv/pipelines/pr_runtime.py) |
+| **Verifier** | [`src/repo2rlenv/pipelines/_pr_runtime_verifier.py`](../../src/repo2rlenv/pipelines/_pr_runtime_verifier.py) |
+| **Validation harness** | [`src/repo2rlenv/pipelines/pr_runtime_validate.py`](../../src/repo2rlenv/pipelines/pr_runtime_validate.py) |
+| **Options model** | [`src/repo2rlenv/spec/options.py`](../../src/repo2rlenv/spec/options.py) — `PrRuntimeOptions` |
+| **Doc page** | [`docs/pipelines/pr_runtime.md`](../pipelines/pr_runtime.md) |
+| **Findings / release notes** | [`docs/release_notes/v0.8.3/findings-pr_runtime.md`](../release_notes/v0.8.3/findings-pr_runtime.md) |
+| **Reference dataset** | [`AdithyaSK/repo2rlenv-pr-runtime`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-pr-runtime) (100 oracle-verified envs; 100 tracked / 88 command / 87 eval_grade) |
+| **Follow-up PRs** | [#45](https://github.com/huggingface/Repo2RLEnv/pull/45) Arc 2 (graded F2P/P2P + tracked/command_resolved split + enriched manifest) · [#63](https://github.com/huggingface/Repo2RLEnv/pull/63) GitLab source · [#69](https://github.com/huggingface/Repo2RLEnv/pull/69) anti-contamination defenses · [#73](https://github.com/huggingface/Repo2RLEnv/pull/73) fetch base_sha via REST · [#75](https://github.com/huggingface/Repo2RLEnv/pull/75) Harbor spec: reward-details.json sidecar |

--- a/docs/rfcs/0003-commit-runtime.md
+++ b/docs/rfcs/0003-commit-runtime.md
@@ -1,0 +1,101 @@
+# RFC 0003: `commit_runtime`
+
+**Status:** implemented
+**Author:** `@adithya-s-k`
+**Created:** 2026-03-01 *(retrospective — pipeline shipped in v0.5.0; RFC written 2026-07-15 as archival record)*
+
+## Summary
+
+R2E-Gym SWE-GEN-style pipeline: walk commit history (not PRs) and turn each qualifying bugfix commit into a sandbox-verified Harbor task. Same F2P/P2P verifier as `pr_runtime`; the only new machinery is the mining stage. Reaches repos and fixes `pr_runtime` cannot — squash-merged / direct-commit repos where the fix lives as a plain commit, not behind a PR merge.
+
+## Motivation
+
+R2E-Gym's headline finding (Jain et al., COLM '25): *"instead of using human-written PRs, good-quality execution environments can directly be curated from commits."* SWE-GEN reaches 34.4% on SWE-Bench Verified with commit-mined data alone. Two concrete motivations for us:
+
+1. **Repos that don't use PRs are invisible to `pr_runtime`.** Solo-maintained crates, research repos, projects that squash-merge everything — all yield 0 from `pr_runtime`, but they have plenty of bugfix commits on `HEAD`. Commit mining unlocks that pool.
+2. **Larger candidate pool.** For repos that *do* use PRs, commit history is still 3–10× larger and includes drive-by fixes that never went through review.
+
+The counter-argument: noisier signal per candidate (no reviewer signed off). Our answer: filters at the metadata + structural layer, plus LLM-synthesized instructions (v0.8.4) to compensate for the fact that commit messages are more leak-prone than issue bodies.
+
+## Design
+
+### Input
+
+- **Source** — GitHub · GitLab · local.
+- **Trigger** — `repo2rlenv generate --pipeline commit_runtime --repo <owner>/<name> --pipeline-opt limit=120 --pipeline-opt clone_depth=400 --llm anthropic/claude-sonnet-4-6 ...`
+- **Options model** — `CommitRuntimeOptions`: mining knobs (`limit`, `since`, `until`, `branch`, `clone_depth`) + metadata filters (`skip_merge_commits`, `min_message_words`, `max_source_files_per_commit`, `exclude_authors`) + structural (`require_new_test_funcs`, `skip_ci_only`) + validation (mirrors `pr_runtime`) + `synthesize_with_llm` + `max_pass_to_pass`.
+
+### Algorithm
+
+1. `git clone --depth N` (default 200; bump for monthly mining).
+2. `git log --first-parent` → candidate commits.
+3. **Metadata filter**: drop merges, bots, short messages, **non-bugfix conventional-commit types** (`chore:`, `docs:`, `feat:`, `refactor:`, `style:`, `test:`, `ci:`, `build:`, `perf:`, `revert:`), require **bugfix positive signal** (`fix:` prefix OR `Closes #N` OR bugfix keyword in subject).
+4. `git show <sha>` → split into `(source_patch, test_patch)` via `pr_runtime._split_patch_and_test_patch`.
+5. **Structural filter**: skip CI-only, sweeping refactors, commits without ≥1 new test function.
+6. **Validate** inside bootstrap sandbox — reuses `pr_runtime.validate_pr` verbatim.
+7. **Instruction** — v0.8.4 default is `synthesize_with_llm=True`: rewrite the commit message into a clean, symptom-focused problem statement with the solution stripped. Fallback path: if `Closes #N`, fetch the linked issue body; else use commit subject + body through `_strip_info_leak` + `_reflow_pr_body`.
+8. Emit Harbor task with shared shape.
+
+### Output
+
+Same shape as `pr_runtime` output. `[metadata.repo2env]` adds a `commit_runtime` subtable (`commit_sha`, `parent_sha`, `authored_at`, `author_email`, `subject`, F2P/P2P lists, `validation_status`, `bootstrap_image`).
+
+## Verification
+
+- **Reward kinds** — `test_execution` + `diff_similarity`. Reuses `_pr_runtime_verifier.py`.
+- **Oracle invariant** — same as `pr_runtime`: gold patch scores `reward=1.0`.
+- **Non-tamper** — same test-file reset + heredoc reapply as `pr_runtime`.
+
+## Anti-contamination
+
+- **Git-history scrub** and **egress guard** from `_env_guard.py` — applied out of the box.
+- **Instruction leak-strip** — extended patterns in Arc 3 catch trailing `(#NNNN)` and `repo#N` cross-repo refs.
+- **v0.8.4 LLM synthesis** — the biggest leak defense: raw commit messages routinely name the function being fixed ("Fix off-by-one in `Pager.advance`"), and LLM synthesis rewrites them into symptom-only prompts. Audit went 33% → 100% clean.
+
+## LLM use
+
+- **`at bootstrap` (cached)** — reuses `pr_runtime`'s bootstrap. Cache-hit path costs zero.
+- **`at synthesis` (per emitted task, v0.8.4+)** — one Sonnet call per task to rewrite the instruction. Cost: ~$0.01–0.03 per task. A 100-env dataset ≈ $1–3 of Sonnet on top of any bootstrap.
+
+## Yield & repo suitability
+
+- **10–35% yield** — same F2P execution gate as `pr_runtime`, applied to raw commits.
+- **~0% yield on squash/merge-PR repos** (Pallets/Django/Flask-style): the source change and its test live in a merge commit that the filter correctly rejects. Use `pr_runtime` there.
+- **Ideal repos**: direct-commit / squash-merge shops. Go projects, Rust crates, solo-maintained infra. Arc 3's 52-env dataset was Go-heavy for exactly this reason.
+
+## Dependencies
+
+- **`pr_runtime`** for the validation harness (`validate_pr`), eval-script builder (`build_eval_script`), Docker file emitter (`build_environment_dockerfile`), split helper (`_split_patch_and_test_patch`), instruction helpers (`_strip_info_leak`, `_reflow_pr_body`, `_linked_issue_number`), aux-files builder (`_runtime_aux_files`).
+- **`bootstrap/`** — shared cache.
+- **`github.fetch_issue`** — for the issue-fetch fallback when `Closes #N` present.
+
+## Alternatives considered
+
+- **Fold into `pr_runtime` as a `mine=commits` mode** — rejected. The mining stage is fundamentally different and the option surfaces would collide. Sibling pipeline is cleaner.
+- **Continuous commit-mining variant (`commit_stream`)** — explicitly rejected (v0.8.3 removed `pr_stream` as scope-creep; a `commit_stream` would repeat the mistake). If continuous mining ever ships, it's flags on `commit_runtime`, not a separate pipeline.
+
+## Rollout plan
+
+Historic. v0.5.0 shipped; v0.8.3 (Arc 3) tightened filters + issue-fetch fallback + fixed Arc 2 inheritance bug (missing `aux_files`) + published 52-env dataset. v0.8.4 added LLM-synthesized instructions and **promoted from experimental → stable** with the 100-env `-v2` dataset.
+
+## Open questions
+
+Historic — none active.
+
+## References
+
+- R2E-Gym: [arXiv:2504.09724](https://arxiv.org/abs/2504.09724), [R2E-Gym/R2E-Gym](https://github.com/R2E-Gym/R2E-Gym) (Apache-2.0).
+- Arc 3 audit: [`docs/release_notes/v0.8.3/findings-commit_runtime.md`](../release_notes/v0.8.3/findings-commit_runtime.md).
+
+## Implementation
+
+| | |
+|---|---|
+| **Initial PR** | Landed in `ecd31f2` — "Two new pipelines: pr_stream (continuous) + commit_runtime (commit-level)" |
+| **Shipping release** | v0.5.0 (experimental); promoted to stable in v0.8.4 |
+| **Source file** | [`src/repo2rlenv/pipelines/commit_runtime.py`](../../src/repo2rlenv/pipelines/commit_runtime.py) |
+| **Options model** | [`src/repo2rlenv/spec/options.py`](../../src/repo2rlenv/spec/options.py) — `CommitRuntimeOptions` |
+| **Doc page** | [`docs/pipelines/commit_runtime.md`](../pipelines/commit_runtime.md) |
+| **Findings / release notes** | [`docs/release_notes/v0.8.3/findings-commit_runtime.md`](../release_notes/v0.8.3/findings-commit_runtime.md) |
+| **Reference datasets** | [`AdithyaSK/repo2rlenv-commit-runtime`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-commit-runtime) (52 envs, pre-synthesis) · [`AdithyaSK/repo2rlenv-commit-runtime-v2`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-commit-runtime-v2) (100 envs, LLM-synthesized instructions) |
+| **Follow-up PRs** | [#47](https://github.com/huggingface/Repo2RLEnv/pull/47) Arc 3 (filters + leak strip + Arc-2 inheritance fix + 52-env dataset) · [#49](https://github.com/huggingface/Repo2RLEnv/pull/49) warn when candidate count reaches clone_depth · [#63](https://github.com/huggingface/Repo2RLEnv/pull/63) local + GitLab source · [#66](https://github.com/huggingface/Repo2RLEnv/pull/66) LLM-synthesized instructions + `max_pass_to_pass` cap · [#67](https://github.com/huggingface/Repo2RLEnv/pull/67) promote to stable + v0.8.4 · [#69](https://github.com/huggingface/Repo2RLEnv/pull/69) anti-contamination · [#75](https://github.com/huggingface/Repo2RLEnv/pull/75) Harbor spec sidecar |

--- a/docs/rfcs/0004-code-instruct.md
+++ b/docs/rfcs/0004-code-instruct.md
@@ -1,0 +1,106 @@
+# RFC 0004: `code_instruct`
+
+**Status:** implemented (experimental)
+**Author:** `@adithya-s-k`
+**Created:** 2026-04-01 *(retrospective — pipeline shipped in v0.6.0; RFC written 2026-07-15 as archival record)*
+
+## Summary
+
+Magicoder OSS-Instruct, grounded in a specific target repo and **verified by execution**. The LLM proposes a coding task seeded by a real snippet from the repo's actual code and writes both an executable test and a candidate solution. The pipeline runs the synthesized test inside the repo's bootstrap container to confirm it FAILS without the oracle and PASSES with it. Emits a Harbor task whose reward is `test_execution` on the LLM-authored test.
+
+## Motivation
+
+Two synthesis approaches were floated for v0.6:
+- **`mutation_bugs`** — inject synthetic AST bugs. Cheap, deterministic, but the bugs are unrealistic.
+- **`code_instruct`** — LLM proposes tasks anchored to real repo code. Costs an LLM call per candidate, produces realistic problems.
+
+Both shipped in v0.6.0. `mutation_bugs` was removed in v0.9 (audit — synthetic AST bugs turned out to be too unrealistic for RL signal). `code_instruct` survived because its tasks are grounded in the target repo's actual code — the LLM invents a problem that reads like something a junior engineer would write, and if the executable-verifier gate passes, we get a synthesized-but-real task.
+
+The key differentiator vs. Magicoder itself: **each task ships an executable verifier**, not just a `(problem, solution)` text pair. That's the RL signal we care about — verifiable execution, not text similarity.
+
+## Design
+
+### Input
+
+- **Source** — GitHub · GitLab · local.
+- **Trigger** — `repo2rlenv generate --pipeline code_instruct --repo <owner>/<name> --pipeline-opt limit=50 --llm anthropic/claude-sonnet-4-6 ...`
+- **Options model** — `CodeInstructOptions`: `limit`, `max_attempts_per_seed`, `seed_min_loc`, `seed_max_loc`, `min_snippet_words`, generation LLM knobs. Python-only via `supported_languages`.
+
+### Algorithm
+
+1. Enumerate Python source files in the target repo.
+2. Sample seed snippets (LOC-bounded) from those files.
+3. For each seed: LLM proposes `(problem, executable_test, candidate_solution)` in a single call.
+4. **Execute both sides in the bootstrap sandbox**:
+   - Test on `base_commit` (no candidate applied) → must FAIL.
+   - Test with candidate applied → must PASS.
+5. Emit Harbor task if both gates pass.
+
+### Output
+
+- Task shape: standard `pr_runtime`-style with the LLM-authored test in the test.sh heredoc, and the LLM's candidate solution in `solution/patch.diff` (the "oracle").
+- `[metadata.repo2env]` provenance: `code_instruct` subtable with seed file path, seed LOC range, generation LLM.
+
+## Verification
+
+- **Reward kind** — `test_execution`. Binary today (`reward = 1.0` if the LLM-authored test passes on the agent's patch, else `0.0`).
+- **Oracle invariant** — the candidate solution the LLM wrote passes its own test at emit time. Enforced by the gate above.
+- **Non-tamper** — same test-file reset + heredoc reapply as `pr_runtime`.
+
+**Known limitation**: reward is binary. Bringing this onto the shared graded machinery is a **v0.9 roadmap item** (`todo.md` bucket B).
+
+## Anti-contamination
+
+- **Git-history scrub** + **egress guard** — applied out of the box.
+- **Instruction leak concern** — the LLM writes the problem statement itself, so the "leak" is whatever the LLM chooses to include. Prompt engineering keeps it symptom-focused. Empirically clean, but not audit-proven at the level of `pr_runtime` or v0.8.4 `commit_runtime`.
+- **Reachability fix in #55**: pre-fix, the LLM-authored test file wasn't reachable to non-oracle agents (they ran the repo's original tests, not the emitted one). Fixed.
+
+## LLM use
+
+- **`at bootstrap` (cached)** — reuses `pr_runtime`'s bootstrap.
+- **`at synthesis` (per emitted task)** — 1 call per seed × `max_attempts_per_seed` attempts. Realistic budget: ~$0.02–0.10 per emitted task (some seeds need retries).
+- **Cost for 100 envs** — ~$5–15 of Sonnet on top of any bootstrap.
+
+## Yield & repo suitability
+
+- **40–70% yield** — fraction of seeds where the LLM's test fails-without / passes-with the oracle in the container.
+- **Python-only** — the LLM prompt + test scaffolding are pytest-shaped. Polyglot support is on the v1.0 roadmap.
+- **Best on repos with clean, self-contained modules** (utility libs). Struggles on framework-heavy repos where a seed can't be tested in isolation.
+
+## Dependencies
+
+- **`bootstrap/`** — for the Docker env.
+- **`_pr_runtime_verifier.py`** — reused for the binary reward; upgrade to graded is pending.
+- **`_env_guard.py`** — anti-contamination.
+- LiteLLM for the synthesis call.
+
+## Alternatives considered
+
+- **Text-only Magicoder** — rejected. No RL signal.
+- **Seed from the repo's tests** (instead of source) — dropped in early prototyping; the LLM writes better problems when seeded with the code it's supposed to exercise.
+
+## Rollout plan
+
+Historic. v0.6.0 shipped experimental. Ongoing work: graded reward port (v0.9 roadmap), reference dataset publish.
+
+## Open questions
+
+- **When does this graduate from experimental?** Blocker: graded reward + published reference dataset. Both on the v0.9 roadmap.
+- **Class-method support** — currently module-level Python only. Class methods with `self` / `cls` deferred (same limitation as `equivalence_tests`).
+
+## References
+
+- Magicoder: [ICML '24](https://arxiv.org/abs/2312.02120), [ise-uiuc/magicoder](https://github.com/ise-uiuc/magicoder).
+
+## Implementation
+
+| | |
+|---|---|
+| **Initial PR** | [#8](https://github.com/huggingface/Repo2RLEnv/pull/8) — v0.6: mutation_bugs + code_instruct (first LLM-synthesized pipelines) |
+| **Shipping release** | v0.6.0 (experimental) |
+| **Source file** | [`src/repo2rlenv/pipelines/code_instruct.py`](../../src/repo2rlenv/pipelines/code_instruct.py) |
+| **Options model** | [`src/repo2rlenv/spec/options.py`](../../src/repo2rlenv/spec/options.py) — `CodeInstructOptions` |
+| **Doc page** | [`docs/pipelines/code_instruct.md`](../pipelines/code_instruct.md) |
+| **Findings / release notes** | *(none yet — publish alongside the graded-reward + first reference dataset)* |
+| **Reference dataset** | *(none yet — bucket B of `plans/todo.md`)* |
+| **Follow-up PRs** | [#55](https://github.com/huggingface/Repo2RLEnv/pull/55) fix grading-test unreachable to non-oracle agents · [#63](https://github.com/huggingface/Repo2RLEnv/pull/63) local + GitLab source · [#69](https://github.com/huggingface/Repo2RLEnv/pull/69) anti-contamination · [#75](https://github.com/huggingface/Repo2RLEnv/pull/75) / [#76](https://github.com/huggingface/Repo2RLEnv/pull/76) Harbor spec sidecar |

--- a/docs/rfcs/0005-equivalence-tests.md
+++ b/docs/rfcs/0005-equivalence-tests.md
@@ -1,0 +1,107 @@
+# RFC 0005: `equivalence_tests`
+
+**Status:** implemented (experimental)
+**Author:** `@adithya-s-k`
+**Created:** 2026-05-01 *(retrospective — pipeline shipped in v0.7.0; RFC written 2026-07-15 as archival record)*
+
+## Summary
+
+R2E-style function-level synthesis. Extract a real Python function from the target repo, freeze it as an oracle (`reference_<name>`), and ask the LLM to write **equivalence tests** that compare a `<name>` candidate against the oracle on crafted inputs. The gold patch fills in the candidate with the original implementation. Reward: `test_execution` on the LLM-authored equivalence test.
+
+## Motivation
+
+`code_instruct` asks the LLM to invent an entire problem. That's a lot of load on the model — get the problem wrong and the whole task is unsolvable. R2E's insight: **start from real code**. The function you're testing is already real; the LLM only has to write the test that discriminates a working implementation from a broken one. Narrower LLM job → lower failure surface → cleaner tasks.
+
+The counter-argument: it's Python-only and function-level, so the coverage is narrower than `code_instruct`. Our answer: yield per repo is much higher (one task per qualifying function, of which there can be hundreds), and the tasks are cleaner precisely *because* the LLM job is smaller.
+
+## Design
+
+### Input
+
+- **Source** — GitHub · GitLab · local.
+- **Trigger** — `repo2rlenv generate --pipeline equivalence_tests --repo <owner>/<name> --pipeline-opt limit=50 --llm anthropic/claude-sonnet-4-6 ...`
+- **Options model** — `EquivalenceTestsOptions`: `limit`, `max_attempts_per_function`, `min_loc`, `max_loc`, decorators-to-exclude, side-effect exclusions, generation LLM knobs. Python-only.
+
+### Algorithm
+
+1. Enumerate Python source files; extract candidate functions with the R2E-inspired filter set (LOC bounds, must-have-return, name + decorator + side-effect exclusions).
+2. For each qualifying function `<name>`: rename its definition to `reference_<name>` in a fresh working copy (frozen oracle).
+3. **LLM writes an equivalence test**: given the original code + the oracle name, generate a pytest that asserts `<name>(inputs) == reference_<name>(inputs)` over a distribution of crafted inputs.
+4. **Two-stage gate** in the sandbox:
+   - Stage A: test the LLM's test on a stub candidate (function body replaced with `raise NotImplementedError`). Must FAIL.
+   - Stage B: test the LLM's test on the original candidate. Must PASS.
+5. If both gates pass, emit the Harbor task. Gold patch = the original function body.
+
+### Output
+
+- Task shape: standard sandbox-verified. Test.sh contains the LLM's equivalence test.
+- `[metadata.repo2env]` provenance: `equivalence_tests` subtable with `function_name`, seed file path, LOC.
+
+## Verification
+
+- **Reward kind** — `test_execution`. Binary today.
+- **Oracle invariant** — the original function body (the gold patch) passes the LLM's equivalence test at emit time. Enforced by Stage B.
+- **Non-tamper** — same reset + reapply pattern.
+
+**Known limitation**: reward is binary. Graded port on the v0.9 roadmap.
+
+## Anti-contamination
+
+- Git-history scrub + egress guard from `_env_guard.py`.
+- The LLM's test file lands in the emitted task's `tests/`; the `reference_<name>` symbol is *inside the test module* (imported from a separate frozen file baked into the environment), so the agent can't just `import reference_<name>` from `src/` and shortcut.
+- **Instruction hygiene**: the instruction says "implement `<name>`" and shows the signature + docstring, but not the original body. The `reference_<name>` name is only visible in the test module (not the instruction).
+
+## LLM use
+
+- **`at bootstrap` (cached)** — reuses `pr_runtime`'s bootstrap.
+- **`at synthesis` (per emitted task)** — 1 LLM call per candidate function × `max_attempts_per_function` attempts. The LLM writes only the test, not the solution — smaller output → lower cost than `code_instruct`. ~$0.01–0.05 per emitted task.
+
+## Yield & repo suitability
+
+- **30–60% yield** — fraction of extracted functions where the LLM writes a test that discriminates stub-vs-oracle.
+- **Python-only, module-level functions** — class methods (with `self` / `cls`) are deferred to a follow-up. Same limitation as `code_instruct`.
+- **Best on repos with lots of small, pure functions** (utility libs, formatting libs, data-processing modules). Struggles on framework-heavy repos where a function's behavior depends on complex fixture state.
+
+## Dependencies
+
+- **`bootstrap/`** — Docker env.
+- **`_pr_runtime_verifier.py`** — binary reward today; graded port pending.
+- **`_env_guard.py`** — anti-contamination.
+- **Function extractor** (`extract_base.py` — patterns lifted from R2E's `repo_builder/fut_extractor/`).
+- LiteLLM for the synthesis call.
+
+## Alternatives considered
+
+- **Include class methods via dependency slicing** (bring class context into the isolated test) — attempted; deferred to v0.8 roadmap. Too much complexity for the initial ship.
+- **Fuzz + property-based tests** (Hypothesis) instead of LLM-written unit tests — considered; LLM-written tests turn out to catch more real bugs because they exercise the function's *intended* behavior, not just random inputs.
+
+## Rollout plan
+
+Historic. v0.7.0 shipped experimental. Two "v0.8 deferred" items are still open (both listed in `plans/todo.md`):
+
+1. **Iterative test refinement loop** — R2E's `feedback → fix_error → improve_coverage` cycle. Current implementation is single-shot: if the LLM writes a flaky test, we skip rather than retry.
+2. **Class-method support** — module-level Python only today.
+
+Graded reward port + reference dataset + promotion to stable also pending, all on v0.9 roadmap.
+
+## Open questions
+
+- **Retry-with-feedback loop shape** — how many retries, what feedback signal (test-output snippet? coverage diff? LLM error-analysis?). Design decision to make in a follow-up mini-RFC when we pick this up.
+- **Recursion**: `_rename_function_source` only rewrites the `def` line. If a function calls itself by name, the renamed `reference_<name>` still calls `<name>` internally — usually trips Stage B, the candidate is dropped. Acceptable skip rate in practice, worth logging if the rate ever exceeds ~5%.
+
+## References
+
+- R2E: [ICML '24](https://arxiv.org/abs/2404.11895), [r2e-project/r2e](https://github.com/r2e-project/r2e).
+
+## Implementation
+
+| | |
+|---|---|
+| **Initial PR** | [#10](https://github.com/huggingface/Repo2RLEnv/pull/10) — v0.7: equivalence_tests + cve_patches |
+| **Shipping release** | v0.7.0 (experimental) |
+| **Source file** | [`src/repo2rlenv/pipelines/equivalence_tests.py`](../../src/repo2rlenv/pipelines/equivalence_tests.py) |
+| **Options model** | [`src/repo2rlenv/spec/options.py`](../../src/repo2rlenv/spec/options.py) — `EquivalenceTestsOptions` |
+| **Doc page** | [`docs/pipelines/equivalence_tests.md`](../pipelines/equivalence_tests.md) |
+| **Findings / release notes** | *(none yet — publish alongside the graded-reward + iterative-refinement work)* |
+| **Reference dataset** | *(none yet — bucket B of `plans/todo.md`)* |
+| **Follow-up PRs** | [#55](https://github.com/huggingface/Repo2RLEnv/pull/55) fix grading-test unreachable to non-oracle agents · [#63](https://github.com/huggingface/Repo2RLEnv/pull/63) local + GitLab source · [#69](https://github.com/huggingface/Repo2RLEnv/pull/69) anti-contamination · [#75](https://github.com/huggingface/Repo2RLEnv/pull/75) / [#76](https://github.com/huggingface/Repo2RLEnv/pull/76) Harbor spec sidecar |

--- a/docs/rfcs/0006-cve-patches.md
+++ b/docs/rfcs/0006-cve-patches.md
@@ -1,0 +1,121 @@
+# RFC 0006: `cve_patches`
+
+**Status:** implemented (experimental)
+**Author:** `@adithya-s-k`
+**Created:** 2026-05-15 *(retrospective — pipeline shipped in v0.7.0; hardened + PoC agent added in v0.8.5; RFC written 2026-07-15 as archival record)*
+
+## Summary
+
+OSV-driven security-task pipeline: for a target repo, look up its CVE fixes in the OSV database, map each vulnerability to the fixing commit, and emit a Harbor task whose oracle is the upstream security patch. Reuses `pr_runtime`'s F2P/P2P verifier. When the CVE ships no regression test (common), an **agentic PoC-test synthesis** step (v0.8.5) lets an LLM with shell access inside the vulnerable sandbox write a regression test that catches the vulnerability.
+
+## Motivation
+
+Two existing corpora — PatchSeeker (5K CVEs), PATCHEVAL (1K) — are *datasets* of CVE-fix pairs. What didn't exist was a **reusable pipeline** that takes any repo + OSV and turns the pair into Repo2RLEnv-shaped tasks: paper-only artifacts, no library. `cve_patches` closes that gap.
+
+Beyond the practical "pipeline over dataset" reason, CVEs are qualitatively different from ordinary bugs — they're security-relevant, human-triaged, and have documented reproduction paths. An RL agent that can *fix a CVE* (not just any test failure) is a more compelling story than one that fixes an off-by-one.
+
+The counter-argument at v0.7 time was scope: "we don't need a CVE-specific pipeline; `pr_runtime` would emit these too if the fix PR was in the mined set." Our answer: OSV gives us an authoritative source of *which* commits are the security fixes, and the CVE→fix mapping is data that `pr_runtime` doesn't have. Plus the follow-up shape (LLM-synthesized PoC tests when the fix ships no test) is CVE-specific and doesn't belong in `pr_runtime`.
+
+## Design
+
+### Input
+
+- **Source** — GitHub (needs the GitHub commit API + OSV; local + GitLab don't apply).
+- **Trigger** — `repo2rlenv generate --pipeline cve_patches --repo <owner>/<name> --pipeline-opt limit=20 --pipeline-opt osv_ecosystem=PyPI --llm anthropic/claude-sonnet-4-6 ...`
+- **Options model** — `CvePatchesOptions`: `limit`, `since`, `min_severity`, `osv_ecosystem` (auto-guessed per owner for known ecosystems), `require_fail_to_pass`, `synthesize_poc_test` (default on in v0.8.5), `poc_agent_max_iterations`, LLM knobs.
+
+### Algorithm
+
+1. Query OSV for vulnerabilities affecting the repo's package.
+2. For each vulnerability: resolve the fixing commit URL (OSV's `references[].url`).
+3. `git show <fix_commit>` → split into `(source_patch, test_patch)`.
+4. **Branch A — CVE ships a test**: proceed like `pr_runtime`, validate F2P/P2P in the sandbox.
+5. **Branch B — CVE has no test** (majority case, ~60–70% of OSV entries): run the **PoC agent** (`_poc_agent.py`, v0.8.5). An LLM with shell access inside the pre-fix vulnerable container writes a regression test that: (a) fails on the pre-fix state, (b) passes on the post-fix state, (c) doesn't reference the fix's SHA or CVE ID.
+6. Validate the resulting `(patch, test_patch)` tuple in the sandbox.
+7. Emit Harbor task with the shared shape.
+
+### Output
+
+Same shape as `pr_runtime`. `[metadata.repo2env]` adds a `cve_patches` subtable: `cve_id`, `ghsa_id`, `severity`, `fix_commit`, `osv_ecosystem`, `poc_agent_used` (bool), `poc_agent_iterations` (if used).
+
+## Verification
+
+- **Reward kinds** — `test_execution` + `diff_similarity`. Uses `_pr_runtime_verifier.py` verbatim (upgraded to graded F2P/P2P in v0.8.5; was binary whole-suite before that pass, which spuriously scored the gold patch 0.0 on unrelated suite failures).
+- **Oracle invariant** — gold security patch scores `reward=1.0, resolved=True` on every emitted task.
+- **Non-tamper** — same as `pr_runtime`.
+
+## Anti-contamination
+
+CVE tasks have the **highest** contamination risk in the set. The fix has a CVE ID, a GHSA ID, a public advisory, a PyPI release note, a patched wheel published to PyPI, and often a PoC in the advisory. Multiple leak paths.
+
+- **Git-history scrub** + **egress guard** — mandatory. PyPI is blackholed so `pip download <pkg>==<fixed_version>` fails (the *original* observed leak that drove `_env_guard.py`'s creation).
+- **Leak-stripped instruction** — v0.8.5 strips CVE / GHSA IDs, PR/commit URLs, `"fixed in vX.Y"` phrases, `Closes #N` trailers. The prompt only carries the symptom.
+- **PoC agent's `no_fix_reference` guard** — the agent that synthesizes a regression test is prompted + regex-checked to not include the fix commit SHA or CVE ID in the emitted test.
+
+The principle: **the environment enforces, the prompt never asks.** For CVE tasks, prompt-only defenses are insufficient — the network isolation is doing the real work.
+
+## LLM use
+
+- **`at bootstrap` (cached)** — one call chain per repo, standard.
+- **`at synthesis` (branch B, per CVE without a shipped test)** — the PoC agent iterates in a shell inside the vulnerable sandbox. Multi-turn, budget-bounded (`poc_agent_max_iterations`, default 8). Cost: ~$0.10–0.50 per PoC synthesis. Skipped for branch A CVEs.
+
+## Yield & repo suitability
+
+- **5–25% yield** — the lowest in the set. Dominant factors:
+  - Does the CVE fix actually have a verifiable test (shipped or synthesizable)?
+  - Does the repo's suite collect in a slim container?
+- **Real numbers** from repo scouting (`plans/cve_repo_scout.py`): `urllib3` → 0/16 CVEs (tests need network, don't collect in slim); `sqlparse` → 2/4 (suite runs clean); `werkzeug`, `requests`, `httpx`, `flask` → mid-yield.
+- **What works**: library-shaped Python repos with pytest-clean suites and CVE-rich histories.
+- **Budget many repos**: at ~15% yield, 100 CVE tasks ≈ 15–20 CVE-rich, test-clean repos.
+
+## Dependencies
+
+- **`pr_runtime`** — full validation harness + verifier + Docker file emitter.
+- **`bootstrap/`** — cache.
+- **`_env_guard.py`** — critical here.
+- **OSV API** — public, no auth needed.
+- **GitHub commit API** — to resolve fixing commits.
+- **`_poc_agent.py`** — new in v0.8.5, wraps LiteLLM + a bash-tool loop inside a `DockerSandbox`.
+
+## Alternatives considered
+
+- **Static PoC extraction from CVE advisories** — rejected. Advisory PoCs are inconsistent in format and often not runnable (curl-y HTTP dumps that don't map to a test).
+- **Third-party CVE-fix datasets (PatchSeeker, PATCHEVAL) as input** — the pipeline can *consume* them (via a hand-curated URL list, once `pr_to_env` lands as RFC 0007) but the direct-mine path is OSV.
+- **Skip CVEs without shipped tests entirely** — considered pre-v0.8.5. Would have cut yield to ~5%. PoC-agent synthesis expanded the addressable set 3–4×.
+
+## Rollout plan
+
+Historic. v0.7.0 shipped experimental (binary whole-suite reward, no PoC synthesis). v0.8.5 hardening pass in PR #69 added:
+- Graded F2P/P2P verifier (was binary; fixed the "gold patch scores 0.0 on unrelated suite failures" bug)
+- Leak-stripped instruction
+- Anti-contamination bake (git-history scrub + egress guard applied via emitter)
+- Agentic PoC-test synthesis
+- 19-env reference dataset published
+
+Stays experimental until a graded-reward audit shows the reward is meaningful across a broader CVE pool.
+
+## Open questions
+
+- **NVD-direct fallback for CVEs OSV hasn't curated.** Rely on OSV's pre-resolved fix URLs today; a PatchSeeker-style LLM+embedding fallback that resolves NVD CVEs to fix commits is on the roadmap.
+- **PoC synthesis distribution shape** — should we distribute PoC tests as part of the published dataset, or does that carry a "we're publishing exploit code" concern? Currently included. Worth revisiting with the community.
+
+## References
+
+- OSV: [osv.dev](https://osv.dev/).
+- PatchSeeker: [hungkien05/PatchSeeker](https://github.com/hungkien05/PatchSeeker).
+- CVE-Bench (NAACL '25): [uiuc-kang-lab/cve-bench](https://github.com/uiuc-kang-lab/cve-bench).
+- Anti-contamination writeup: `plans/reward_hacking_writeups.md`.
+
+## Implementation
+
+| | |
+|---|---|
+| **Initial PR** | [#10](https://github.com/huggingface/Repo2RLEnv/pull/10) — v0.7: equivalence_tests + cve_patches |
+| **Shipping release** | v0.7.0 (experimental); hardened in v0.8.5 |
+| **Source file** | [`src/repo2rlenv/pipelines/cve_patches.py`](../../src/repo2rlenv/pipelines/cve_patches.py) |
+| **PoC agent** | [`src/repo2rlenv/pipelines/_poc_agent.py`](../../src/repo2rlenv/pipelines/_poc_agent.py) *(added in #69)* |
+| **Options model** | [`src/repo2rlenv/spec/options.py`](../../src/repo2rlenv/spec/options.py) — `CvePatchesOptions` |
+| **Doc page** | [`docs/pipelines/cve_patches.md`](../pipelines/cve_patches.md) |
+| **Findings / release notes** | *(covered in v0.8.5 release notes; standalone `findings-cve_patches.md` still TBD)* |
+| **Reference dataset** | [`AdithyaSK/repo2rlenv-cve-patches`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-cve-patches) (19 oracle-verified envs) |
+| **Follow-up PRs** | [#63](https://github.com/huggingface/Repo2RLEnv/pull/63) input-source abstraction · [#69](https://github.com/huggingface/Repo2RLEnv/pull/69) anti-contamination defenses + graded verifier + PoC agent + 19-env dataset · [#70](https://github.com/huggingface/Repo2RLEnv/pull/70) reference the dataset in docs · [#75](https://github.com/huggingface/Repo2RLEnv/pull/75) Harbor spec sidecar |

--- a/docs/rfcs/0007-pr-to-env.md
+++ b/docs/rfcs/0007-pr-to-env.md
@@ -1,0 +1,186 @@
+# RFC 0007: `pr_to_env`
+
+**Status:** draft
+**Author:** `@adithya-s-k`
+**Created:** 2026-07-15
+**Implemented by:** _(pending)_
+**Reference dataset:** _(pending)_
+
+## Summary
+
+Take a **single GitHub / GitLab PR URL** (or a curated list) and produce **one Harbor RL environment per PR**, verified end-to-end. Same task shape and verifier as `pr_runtime`; the difference is the input surface — a specific PR the user hands you, not a mining sweep over a repo's history. **First "import-shape" pipeline in the set.**
+
+## Motivation
+
+### The pattern this pipeline breaks
+
+Everything we ship today is a **mining pipeline**: `--repo <owner/name>` → walk PRs / commits / CVEs → filter → keep whatever passes the yield gate. Mining is the right shape when you want to build a 100-env reference dataset from a repo you care about. It's the *wrong* shape for three real workflows we hit repeatedly:
+
+1. **Reproducing a reported bug as an eval.** Someone (Slack, GitHub issue, a paper) says "this specific PR is a good regression to test agents on." Today the only way to consume it is `pr_runtime --repo <owner/name> --pipeline-opt limit=1000` and hope your target PR is in the surviving set. A single-URL input is a mining-shape hack.
+2. **Curated hand-picked benchmarks.** A researcher hands you 50 PR URLs across 20 repos ("these are the ones we want in the benchmark"). Today: 20 separate `pr_runtime` invocations with narrow limits, then union the outputs. Mining machinery working against you when you already know the answer.
+3. **Ad-hoc RL training on user-provided regressions.** A team wants to fine-tune their agent on the PRs *their own users* filed against their infra. They know the URLs; they don't want the mining framework.
+
+### Mining vs. import — a naming distinction worth making
+
+`pr_to_env` isn't just a mining pipeline with a smaller input; the assumption underneath it is *inverted*. Mining says "here's a corpus, tell me what qualifies." Import says "here's what qualifies, tell me if you can build it." The consequences ripple through the design:
+
+|                | **Mining** (`pr_runtime`, `commit_runtime`, `cve_patches`, ...) | **Import** (`pr_to_env`) |
+|---|---|---|
+| Input | one repo, N candidates | N specific artifacts (PRs), no filtering promise |
+| Yield semantics | `emitted ÷ candidates_examined`, expected < 100% | per-URL success/skip — user expects an env or a *specific reason* for each URL |
+| `limit` / `since` / `lite_filter` | central | absent (user did the filtering) |
+| Failure semantics | filtered → dropped silently | filtered → surface the reason per URL |
+| CLI shape | `--repo` | `--pipeline-opt url=…` or `--pipeline-opt urls_file=…` |
+
+The counter-argument: *"just add a `--pr-urls` option to `pr_runtime`."* That works up to a point but muddies the pipeline contract. `pr_runtime`'s options are all mining knobs (`limit`, `since`, `require_fail_to_pass`, `lite_filter`, `min_problem_statement_words`); the mental model is "walk history, apply gates, emit surviving." A URL-list input needs an entirely different failure-reporting story (per-URL, not aggregate) and forbids most of the mining options as meaningless.
+
+`pr_to_env` is `pr_runtime`'s *consumption-side* sibling — same output, same verifier, different input assumption. If import turns out to be a useful shape, later RFCs can add `commit_to_env` (one commit URL → one env), `issue_to_env` (one issue URL → resolve it), etc. — same category, same "per-URL result" contract.
+
+## Design
+
+### Input
+
+- **Source** — GitHub · GitLab (whatever URLs are given; the input-source abstraction routes per-URL).
+- **Trigger** — two forms:
+
+  ```bash
+  # single URL
+  repo2rlenv generate --pipeline pr_to_env \
+    --pipeline-opt url=https://github.com/pallets/click/pull/3434 \
+    --llm anthropic/claude-sonnet-4-6 \
+    --out ./datasets/click-3434
+
+  # curated file — one URL per line, comments ok
+  repo2rlenv generate --pipeline pr_to_env \
+    --pipeline-opt urls_file=./curated.txt \
+    --llm anthropic/claude-sonnet-4-6 \
+    --out ./datasets/curated
+  ```
+
+- **Options model** — `PrToEnvOptions`:
+
+  ```python
+  url: str | None = None                 # exactly one of url/urls_file must be set
+  urls_file: Path | None = None
+  strict: bool = True                     # if True, ANY per-URL failure is fatal (fail-fast)
+                                          # if False, log + skip failures, emit the rest
+  # Verification knobs inherited from pr_runtime — reused verbatim
+  require_new_test_funcs: bool = True
+  min_problem_statement_words: int = 0
+  synthesize_with_llm: bool = True        # inherit commit_runtime's LLM synthesis for
+                                          # leak-free instructions (same rationale)
+  ```
+
+  No mining knobs (`limit`, `since`, `lite_filter`) — deliberately. If the user hands over 100 URLs, they get 100 attempts. `strict` controls what happens when a URL can't produce an env.
+
+### Algorithm
+
+```mermaid
+flowchart LR
+    U[URL or urls_file] --> P[Parse: extract owner/repo/N per URL]
+    P --> M{Group by repo}
+    M --> B[Ensure bootstrap per repo<br/>(reuses pr_runtime cache)]
+    B --> F[Fetch PR data via github.fetch_pr]
+    F --> V[Validate inside sandbox<br/>(reuses pr_runtime.validate_pr)]
+    V --> I[Synthesize instruction<br/>(reuses commit_runtime.synthesize_with_llm)]
+    I --> E[Emit Harbor task]
+```
+
+1. **Parse URLs** into `(host, owner, name, pr_number)` tuples. Reject anything that isn't a PR URL with a clear error naming the URL.
+2. **Group by repo** so bootstrap runs once per unique `(owner, name, ref)` rather than once per PR — same optimization `pr_runtime` uses internally.
+3. **For each repo**: ensure bootstrap (cache-hit path is instant); for each PR in that repo, fetch the PR metadata and diff via the existing `github.fetch_pr` / `gitlab.fetch_mr` (route through the input-source abstraction).
+4. **Reuse `pr_runtime.validate_pr` verbatim** for the F2P/P2P validation inside the bootstrap container. No new verifier logic.
+5. **Synthesize a leak-free instruction** the same way `commit_runtime` v0.8.4 does — the raw PR body has the same leakage patterns as commit messages. `synthesize_with_llm=True` default.
+6. **Emit a Harbor task** with the shared shape from `pr_runtime`.
+
+### Output
+
+- **Task shape** — identical to `pr_runtime`: `environment/Dockerfile`, `environment/docker-compose.yaml` (egress guard), `tests/test.sh`, `tests/verifier.py`, `tests/f2p.json`, `tests/p2p.json`, `solution/patch.diff`, `instruction.md`, `task.toml`.
+- **Task ID** — `<owner>__<repo>-<pr_number>` (same as `pr_runtime`).
+- **`[metadata.repo2env]` provenance** — same fields as `pr_runtime`, plus:
+  - `pipeline = "pr_to_env"` (not `pr_runtime`, so consumers can distinguish curated tasks from mined ones)
+  - `source_url = "<the URL that produced this task>"` — new field, so a consumer can trace back to what the user handed in.
+
+## Verification
+
+- **Reward kind(s)** — `test_execution` + `diff_similarity` (same as `pr_runtime`).
+- **Reward formula** — graded F2P/P2P: `reward = f2p_rate × p2p_rate`. Uses `_pr_runtime_verifier.py` verbatim, no fork.
+- **Oracle invariant** — gold PR patch flips all F2P from FAIL→PASS while keeping all P2P green. `resolved=True`, `reward=1.0`. Same invariant as `pr_runtime`.
+- **Non-tamper** — reuse `pr_runtime.build_eval_script`'s existing test-file reset + heredoc'd test-patch reapply. Nothing new.
+
+## Anti-contamination
+
+Same leak surface as `pr_runtime` — the PR is on GitHub, the fix is public. The existing `_env_guard.py` defenses apply verbatim:
+
+- **Git-history scrub** — strip repo to `base_commit`, remove `origin`, prune future refs. Applies out of the box.
+- **Egress guard** — blackhole `pypi.org` / `github.com` / their CDNs. Applies out of the box.
+- **Instruction leak-strip** — reuse `commit_runtime`'s LLM synthesis path (`synthesize_with_llm=True` default) so the PR body's typical leaks (fix-commit SHA, "reverts b0e5..." lines, `Closes #N` trailers, `(#NNNN)` squash trailers) don't reach the prompt.
+
+**Pipeline-specific leak concern:** the URL itself is a fix-pointer. Do NOT stamp `source_url` into `instruction.md`. It goes only into `task.toml`'s `[metadata.repo2env]` block for provenance; the agent never sees it. Confirmed: the emitter builds `instruction.md` from the PR body / linked issue only.
+
+## LLM use
+
+- **`at bootstrap` (cached)** — one-time per (repo, ref). Reuses `pr_runtime`'s bootstrap; a curated list that reuses repos already in cache costs zero LLM.
+- **`at synthesis` (per emitted task)** — one call to rewrite the PR body into a leak-free problem statement. Same cost as `commit_runtime` v0.8.4 (single Sonnet call, ~$0.01–0.03 per task).
+
+**Cost estimate for a 100-env curated dataset**: ~$1–3 of Sonnet calls if all bootstraps are cached; $3–8/uncached-repo for fresh bootstraps.
+
+## Yield & repo suitability
+
+Yield is fundamentally different from mining pipelines. **The user chose the URLs**, so there's no candidate-vs-emitted denominator in the usual sense. The relevant number is **per-URL success rate**:
+
+- **~85–95% expected** on well-chosen PRs (has tests, tests are runnable, repo bootstraps clean).
+- **Failure modes** worth surfacing to the user with distinct exit codes / skip reasons:
+  - `no_test_patch` — PR doesn't add / modify any test file. Can't verify.
+  - `bootstrap_failed` — the repo doesn't build in a slim container.
+  - `no_fail_to_pass` — validation ran but no test flipped fail→pass with the fix applied.
+  - `apply_failed` — the merged diff doesn't apply cleanly at `base_commit` (rare, but a rebased/squashed PR can hit this).
+  - `network_error` — URL fetch failed.
+
+When `strict=True`, any of these aborts the whole run with a clear per-URL error. When `strict=False`, log + skip, emit whatever succeeded, report the per-URL outcomes in `PipelineResult.skip_reasons`.
+
+## Dependencies
+
+**Reused pipeline machinery** (imported, not copied):
+- `pr_runtime.validate_pr` — validation harness.
+- `pr_runtime.build_eval_script` — graded test.sh emitter (with `fail_to_pass` + `pass_to_pass` args — the Arc 3 lesson).
+- `pr_runtime.build_environment_dockerfile` — env Dockerfile.
+- `pr_runtime._runtime_aux_files` — plain-artifact bakery.
+- `pr_runtime._strip_info_leak`, `_reflow_pr_body`, `_linked_issue_number` — instruction hygiene.
+- `commit_runtime`'s `synthesize_with_llm` path if we make it shared (currently in `commit_runtime.py`; may want to lift to `_synthesis.py`).
+- `_env_guard.py` — anti-contamination guards.
+- `github.fetch_pr` / `gitlab.fetch_mr` — via input-source abstraction.
+
+**New code**: URL parser (owner/repo/number extraction, host detection), URL-list loader (`urls_file` reader), grouping-by-repo logic. Probably 100–150 LOC total.
+
+**No new external deps.**
+
+## Alternatives considered
+
+1. **Add `--pr-urls` to `pr_runtime`** — rejected. Overloads `pr_runtime`'s contract (mining vs. curated). See Motivation.
+2. **Make it a Python API function only** (`from repo2rlenv import pr_from_url`) — rejected. CLI parity matters for users who consume everything through `repo2rlenv generate ...`. Nothing prevents adding a Python entry point too.
+3. **Batch endpoint that takes a YAML manifest of PRs + per-PR overrides** — deferred. `urls_file` covers the common case; if users want per-URL overrides (different `require_new_test_funcs`, etc.) that's a follow-up option and a bigger design conversation.
+
+## Rollout plan
+
+1. **Smoke** — 5–10 individual PR URLs across `pallets/click`, `urfave/cli`, `gorilla/mux` (bootstraps cached from earlier arcs). Inspect emitted tasks; oracle-gate each; confirm `reward=1.0`.
+2. **Scale** — a curated 100-PR list. The natural source: pick 100 top-scoring PRs from the existing `AdithyaSK/repo2rlenv-pr-runtime` dataset and re-import them via `pr_to_env`. Same envs should come out — validates the pipeline against a known-good baseline.
+3. **Oracle gate** — every URL that produced an env must score `reward=1.0`. Any that don't get dropped or investigated. Track resolved / command_resolved / eval_grade the same way.
+4. **Real-agent eval** — stratified sample of 15 tasks with claude-code + Sonnet at `n=2`.
+5. **Publish** — HF Hub dataset if we want a public reference; more likely `pr_to_env` is used ad-hoc without a public dataset.
+6. **Docs** — `docs/pipelines/pr_to_env.md` with the "here's a URL, here's a task" walkthrough as the headline.
+7. **Ship experimental** — `experimental = True` at merge. Not a mining pipeline, so no reference dataset requirement to promote — promotion criterion is just "quality holds up on a diverse enough set of URLs."
+
+## Open questions
+
+- **Do we want `pipeline = "pr_to_env"` in the task.toml, or `pipeline = "pr_runtime"` with a `[metadata.repo2env.pr_to_env]` sub-block signaling the provenance?** The first makes the CLI + registry surfaces distinguish curated vs. mined, at the cost of two pipelines sharing a task shape. The second keeps everything as `pr_runtime` outputs but hides the difference. Leaning toward option 1 for clarity; open to being talked out of it.
+- **Should we support commit URLs too?** A commit URL points at a specific commit (which may or may not be a merged PR). Would be `commit_import` — same design, separate pipeline for the same reason. Leave for RFC 0002 if there's demand.
+- **How do we handle a URL to a merged PR whose `base_commit` no longer exists on the repo** (force-pushed / branch deleted)? Options: fail fast with a clear error, or fall back to the PR's stored `merge_base` from the API. Prefer the fallback.
+- **`urls_file` format** — plain lines vs. TOML/YAML. Plain lines is simpler; TOML/YAML admits per-URL overrides down the road. Start with plain lines + `#` comments; upgrade if needed.
+
+## References
+
+- [`docs/pipelines/pr_runtime.md`](../pipelines/pr_runtime.md) — the pipeline whose output shape + verifier `pr_to_env` reuses.
+- [`docs/pipelines/commit_runtime.md`](../pipelines/commit_runtime.md) — the pipeline whose LLM-synthesis instruction path `pr_to_env` inherits.
+- [`docs/reference/RELATED_WORK.md`](../reference/RELATED_WORK.md) — where the shipped provenance table will get its `pr_to_env` row on merge.
+- SWE-bench (arXiv:2310.06770) — the canonical "PR → RL env" mapping; `pr_to_env` differs from `pr_runtime` in *input surface*, not in the verifier.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,62 @@
+# Pipeline RFCs
+
+Design docs for new synthesis pipelines. One RFC per pipeline. Written **before** the code lands; kept in the repo after the pipeline ships as a permanent record of *why* the pipeline exists in the shape it does.
+
+## Why RFCs
+
+A pipeline is 100–300 LOC of code, but the decisions behind it — repo shape it fits, verification approach, contamination story, LLM use, yield expectations — are much harder to reconstruct from a merged diff months later. Every new pipeline in this repo has had non-obvious design choices (issue-fetch fallback in `commit_runtime`, PoC-agent for `cve_patches`, anti-contamination compose overlay, graded vs. binary reward). Those choices deserve a durable home separate from the implementation.
+
+An RFC also front-loads the audit: writing the "how does contamination get in?" section forces you to think about it *before* you've shipped 100 published envs.
+
+## When to write one
+
+- **Always** for a new pipeline (new entry in `PipelineName`).
+- **Optional** for meaningful reshapes of an existing pipeline (e.g. adding LLM synthesis to `commit_runtime` in v0.8.4 — retrospectively RFC-worthy).
+- **Skip** for polish / bug-fix work that fits in a PR description.
+
+**Retrospective RFCs.** Pipelines that shipped before this process existed (RFCs 0001–0006) have RFCs written *after* their initial merge, as archival records. They're `status: implemented` from day one and their [Implementation](#lifecycle) sections link back to the initial PR, source file, doc page, and reference dataset. Retro RFCs are lighter on the "alternatives considered" front (memory decays) and heavier on cross-referencing the current authoritative doc (`docs/pipelines/<name>.md`) as the source of truth. Do not write retro RFCs for pipelines that have been withdrawn (`mutation_bugs`, `refactor_synthesis`) — git history is enough.
+
+## Process
+
+1. **Pick a candidate** from [`plans/candidate_pipelines.md`](../../plans/candidate_pipelines.md), or propose a new one.
+2. **Copy [`TEMPLATE.md`](./TEMPLATE.md)** to `docs/rfcs/NNNN-<name>.md` (next unused 4-digit number, kebab-case name).
+3. **Fill in every section** — write "n/a" if a section genuinely doesn't apply, don't just delete it. If you don't know an answer yet, mark it `TBD` and open it in "Open questions."
+4. **PR the RFC alone** first — reviews want to look at the design without the implementation blur. RFCs at this stage should carry the label `rfc:draft` (add it via `gh pr edit --add-label rfc:draft`).
+5. **Iterate on the RFC** based on review. Update the status header as it moves through the lifecycle (see below).
+6. **Once accepted**, implement the pipeline in a follow-up PR that references the RFC number and follows [`docs/contributing/ADDING_A_PIPELINE.md`](../contributing/ADDING_A_PIPELINE.md).
+7. **After merge**, update the RFC's status to `implemented`, add the merge commit + PR link, and link the reference dataset from the "Rollout" section.
+
+## Lifecycle
+
+RFCs have a `Status:` header line that moves through these states:
+
+- `draft` — being written; not yet ready for design review.
+- `review` — ready for feedback; PR open.
+- `accepted` — design signed off; implementation can begin.
+- `implemented` — code has landed on `main`. RFC is now archival.
+- `withdrawn` — decided against. Kept for posterity; explain why in a final "Withdrawal" section.
+- `superseded` — replaced by a later RFC (link both directions).
+
+## Numbering
+
+Sequential. `0001-<name>.md`, `0002-<name>.md`, …. Never reuse a number. If an RFC is withdrawn, the number is retired with it.
+
+## Index
+
+| # | Pipeline | Status | RFC | Reference dataset |
+|---|---|---|---|---|
+| 0001 | `pr_diff` | implemented (stable) | [0001-pr-diff.md](./0001-pr-diff.md) | [`repo2rlenv-pr-diff`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-pr-diff) (181) |
+| 0002 | `pr_runtime` | implemented (stable) | [0002-pr-runtime.md](./0002-pr-runtime.md) | [`repo2rlenv-pr-runtime`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-pr-runtime) (100) |
+| 0003 | `commit_runtime` | implemented (stable) | [0003-commit-runtime.md](./0003-commit-runtime.md) | [`…commit-runtime-v2`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-commit-runtime-v2) (100) |
+| 0004 | `code_instruct` | implemented (experimental) | [0004-code-instruct.md](./0004-code-instruct.md) | — |
+| 0005 | `equivalence_tests` | implemented (experimental) | [0005-equivalence-tests.md](./0005-equivalence-tests.md) | — |
+| 0006 | `cve_patches` | implemented (experimental) | [0006-cve-patches.md](./0006-cve-patches.md) | [`…cve-patches`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-cve-patches) (19) |
+| 0007 | `pr_to_env` | draft | [0007-pr-to-env.md](./0007-pr-to-env.md) | — |
+
+<!-- Update this table whenever a new RFC lands or an RFC's status changes. -->
+
+## Related
+
+- [`plans/candidate_pipelines.md`](../../plans/candidate_pipelines.md) — the backlog. Ranking + inspirations. RFCs are drawn from here (or a fresh proposal).
+- [`docs/contributing/ADDING_A_PIPELINE.md`](../contributing/ADDING_A_PIPELINE.md) — the implementation cookbook. RFC covers the *why*; the cookbook covers the *how*.
+- [`docs/reference/RELATED_WORK.md`](../reference/RELATED_WORK.md) — provenance table for shipped pipelines. Add an entry here when an RFC ships.

--- a/docs/rfcs/TEMPLATE.md
+++ b/docs/rfcs/TEMPLATE.md
@@ -1,0 +1,117 @@
+# RFC NNNN: `<pipeline_name>`
+
+**Status:** draft
+**Author:** `<your GH handle>`
+**Created:** YYYY-MM-DD
+
+Once the RFC reaches `status: implemented`, fill in the [Implementation](#implementation) section at the bottom with pointers to the PR, source file, doc page, findings, and reference dataset.
+
+## Summary
+
+One paragraph. What the pipeline does and why anyone should care. If you can't compress it to two sentences, the design isn't crisp enough yet.
+
+## Motivation
+
+Why does this pipeline need to exist as a separate thing? What gap does it fill vs. the existing set? If there's a related paper / dataset / repo, cite it (link to `references/<name>/` if you've cloned it).
+
+Include the anti-argument too: what's the case for *not* building this / rolling it into an existing pipeline? Write the counter and explain why the RFC still stands.
+
+## Design
+
+### Input
+
+- **Source** — GitHub / GitLab / local / one of the above via an existing input-source abstraction.
+- **Trigger** — how the user invokes it: `repo2rlenv generate --pipeline <name> ...`. List the required + optional `--pipeline-opt` fields.
+- **Options model** — fields the pipeline reads from `<Name>Options`. What's mandatory, what has defaults, what's a mistake to expose.
+
+### Algorithm
+
+Ordered numbered steps. Enough detail that someone else could implement without reading external context. A mermaid diagram if it helps.
+
+```mermaid
+flowchart LR
+    A[source] --> B[synthesize] --> C[verify] --> D[Harbor task dir]
+```
+
+### Output
+
+- **Task shape** — what files ship in the emitted task dir (Dockerfile, test.sh, verifier.py, f2p.json, p2p.json, patch.diff, instruction.md, task.toml). Reuse the existing shape unless there's a good reason to differ.
+- **`[metadata.repo2env]` provenance** — what pipeline-specific fields the toml carries beyond the shared ones (`pipeline`, `repo`, `ref`, `reward_kinds`, `reward_calibration`).
+
+## Verification
+
+- **Reward kind(s)** — `test_execution` / `diff_similarity` / both.
+- **Reward formula** — the exact function. If it's graded F2P/P2P, say so; if it's binary, say why binary is defensible.
+- **Oracle invariant** — the gold patch must score exactly `1.0` (or `resolved=True`). Explicitly state this.
+- **Non-tamper** — how the emitted `test.sh` prevents an agent from passing by editing the tests. Should reuse the existing `_pr_runtime_verifier` git-reset-and-reapply pattern unless there's a strong reason.
+
+## Anti-contamination
+
+- **How does the fix leak in?** Enumerate the observed / plausible leak paths for *this* pipeline's task shape. Ex: PyPI has the fixed version, GitHub has the fix PR, the commit message names the function, the instruction quotes the CVE ID.
+- **Guards** — which of `_env_guard.py`'s existing defenses apply out of the box (git-history scrub, egress guard). What's pipeline-specific (leak-strip patterns, instruction sourcing).
+- **The principle**: the environment enforces, the prompt never asks. If your design depends on the *prompt* not telling the agent something, that's a bug in the design.
+
+## LLM use
+
+Where the model is invoked. One of:
+
+- **`at bootstrap` (cached)** — one-time env construction per (repo, ref). Doesn't add per-task cost.
+- **`at synthesis`** — the pipeline itself calls the LLM per emitted task. Track budget.
+- **`at verify`** — the LLM is called at reward computation time. Rare (only `pr_diff`'s LLM-judge). Requires the verifier to degrade gracefully when the API key is absent.
+
+Include a cost order-of-magnitude estimate for a 100-env dataset: N × K token calls × $ per call = ~$X.
+
+## Yield & repo suitability
+
+- **Expected yield** — `emitted ÷ candidates_examined`. Cite similar pipelines for anchoring.
+- **What repos work?** — pytest-clean, CPU-only, library-shaped. Any pipeline-specific extras (needs a working CI history, needs public issue trackers, …).
+- **What repos don't work?** — Be honest about limits. See `commit_runtime`'s "PR-driven repos yield ~0" note as the model.
+
+## Dependencies
+
+- **Reused pipeline machinery** — validation harness (`pr_runtime.validate_pr`), eval-script builder, `_env_guard`, verifier module. List what's imported vs. what's new.
+- **New external deps** — anything that lands in `pyproject.toml`. Prefer stdlib.
+
+## Alternatives considered
+
+Two or three design choices you made and the shapes you rejected. Not exhaustive; just the non-obvious ones.
+
+## Rollout plan
+
+The lifecycle any new pipeline goes through, adapted to yours:
+
+1. **Smoke** — a handful of tasks on 2–3 cached-bootstrap repos; manually inspect emitted content.
+2. **Scale** — target 100 tasks across 6–10 repos (or whatever the pipeline's yield realistically supports).
+3. **Oracle gate** — `harbor run -a oracle --env docker`; every task should score exactly 1.0. Drop the ones that don't.
+4. **Real-agent eval** — stratified sample with claude-code + Sonnet at `n=2` (Arc 2's OOM lesson).
+5. **Publish** — HF Hub dataset with enriched manifest.
+6. **Docs** — `docs/pipelines/<name>.md` + `docs/release_notes/vX.Y/findings-<name>.md`.
+7. **Ship experimental** — flag `experimental = True`. Real-world use for a release cycle.
+8. **Promote to stable** if quality + audit hold up. Flip the flag, update the pipeline-table stability column.
+
+## Open questions
+
+- Bulleted list of things you don't know yet and need review input on.
+
+## References
+
+- Paper / prior art you're drawing from, with arxiv IDs or DOIs.
+- Similar pipelines in-repo (link `src/repo2rlenv/pipelines/<sibling>.py`).
+- Any external repos cloned to `references/<name>/`.
+
+## Implementation
+
+*Filled in when the RFC status flips to `implemented`. Delete or leave as a placeholder while `draft` / `review` / `accepted`.*
+
+| | |
+|---|---|
+| **Initial PR** | (link) |
+| **Shipping release** | v?.?.? |
+| **Source file** | [`src/repo2rlenv/pipelines/<name>.py`](../../src/repo2rlenv/pipelines/<name>.py) |
+| **Options model** | [`src/repo2rlenv/spec/options.py`](../../src/repo2rlenv/spec/options.py) — `<Name>Options` |
+| **Doc page** | [`docs/pipelines/<name>.md`](../pipelines/<name>.md) |
+| **Findings / release notes** | [`docs/release_notes/v?.?.?/findings-<name>.md`](../release_notes/) *(if published)* |
+| **Reference dataset** | [`AdithyaSK/repo2rlenv-<name>`](https://huggingface.co/datasets/AdithyaSK/repo2rlenv-<name>) *(if published)* |
+| **Follow-up PRs** | List post-initial merges that materially changed the pipeline — `#66` LLM synthesis, `#69` hardening, etc. Keep concise; the git log is the source of truth. |
+
+Any material changes to the pipeline *after* it ships (design pivots, new options, breaking-change PRs) get appended here or in a new "Change history" subsection. Small polish PRs don't need to be listed.


### PR DESCRIPTION
## What this PR does

Adds `docs/rfcs/` — a scaffold for pipeline design docs — and backfills retrospective RFCs for every shipped pipeline.

**Motivation.** Every new pipeline has had non-obvious design decisions (issue-fetch fallback in `commit_runtime`, PoC-agent in `cve_patches`, anti-contamination compose overlay, graded vs. binary reward, the whole "mining vs. import" split). Those decisions today live in a scatter of commit messages, PR descriptions, and CLAUDE.md notes. RFCs give them a durable home. Also front-loads the audit: writing the "how does contamination get in?" section forces the thinking before 100 envs ship.

## What's in it

**New: `docs/rfcs/`**

- `README.md` — process (when to write, lifecycle: draft → review → accepted → implemented / withdrawn / superseded, numbering, index).
- `TEMPLATE.md` — 11 sections + an `Implementation` table filled in on `status: implemented`.
- **`0001-pr-diff.md`** — implemented (stable). Text-only baseline, 6-component reward, 181-env dataset.
- **`0002-pr-runtime.md`** — implemented (stable). SWE-bench-style flagship, graded F2P/P2P, 100-env dataset, tracked / command_resolved / eval_grade split.
- **`0003-commit-runtime.md`** — implemented (stable). R2E-Gym SWE-GEN commit mining, LLM-synthesized instructions, two datasets (52 + 100).
- **`0004-code-instruct.md`** — implemented (experimental). Magicoder OSS-Instruct grounded in a target repo, executable verifier.
- **`0005-equivalence-tests.md`** — implemented (experimental). R2E function-level equivalence tests. Deferred v0.8 items (iterative refinement, class methods) called out.
- **`0006-cve-patches.md`** — implemented (experimental). OSV-driven security tasks, v0.8.5 hardening (graded verifier + PoC agent + anti-contamination), 19-env dataset.
- **`0007-pr-to-env.md`** — **draft**. First "import-shape" pipeline: one PR URL → one env. Per-URL success/skip semantics rather than a mining yield gate. Reuses `pr_runtime`'s verifier + validation harness verbatim; the difference is the input surface.

**Updated:** `docs/contributing/ADDING_A_PIPELINE.md` — one-line pointer at the top saying "if this is a novel pipeline, write an RFC in `docs/rfcs/` first."

## Anatomy of a retro RFC

Each of 0001–0006 follows the template but with the framing tilted archival:
- **Motivation** — why it exists, including the counter-argument that was rejected at the time.
- **Design / Verification / Anti-contamination / LLM use / Yield & repo suitability / Dependencies / Alternatives considered** — as of today. Where the pipeline has evolved (e.g. `pr_runtime`'s binary → graded reward, `commit_runtime`'s pre- and post-LLM-synthesis states), the RFC captures the current shape and refers out to the changelog / findings docs.
- **Implementation** table at the bottom — initial PR, shipping release, source file, options model, doc page, findings doc, reference dataset, follow-up PRs (Harbor spec, anti-contamination, GitLab source, etc.).
- **References** — the paper / prior art (SWE-bench, SWE-RL, R2E-Gym, Magicoder, R2E, PatchSeeker, CVE-Bench) with arXiv IDs.

Retro RFCs are lighter on "alternatives considered" (memory decays) and heavier on cross-referencing the current `docs/pipelines/<name>.md` as the living source of truth.

## Not in this PR

- No code changes.
- No changes to the pipelines themselves.
- `plans/candidate_pipelines.md` and `plans/todo.md` (gitignored working docs) are updated locally to reflect the RFC-linked backlog — not committed.

## Test plan

Docs-only. Rendered locally to sanity-check the tables and cross-links. Full pytest still passes (unaffected):

- [x] `uv run pytest -q --collect-only` — 689 tests collected, no errors
- [x] `uv run ruff check .` — clean
- [x] All internal RFC links (`../pipelines/`, `../release_notes/`, `../../src/…`) resolve to real files
- [x] Index table in `docs/rfcs/README.md` matches the on-disk file list (7 rows, sequential numbering, no gaps)
