### PR TITLE
ci: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
     name: Lint (ruff)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.3.0
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
         with:
           enable-cache: true
           # Pin a Python for the lint job — ruff itself doesn't care, this just
@@ -55,10 +55,10 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.3.0
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -74,10 +74,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test]
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.3.0
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
         with:
           enable-cache: true
           python-version: "3.12"
@@ -92,7 +92,7 @@ jobs:
           /tmp/check-install/bin/repo2rlenv --version
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: repo2rlenv-dist-${{ github.sha }}
           path: dist/

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,12 +25,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
         with:
           # git-revision-date-localized needs the full history
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -45,7 +45,7 @@ jobs:
         run: mkdocs build --verbose
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: site
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,11 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
 
-      - uses: astral-sh/setup-uv@v8.3.0
+      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -59,11 +59,11 @@ jobs:
     outputs:
       version: ${{ steps.read-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
 
-      - uses: astral-sh/setup-uv@v8.3.0
+      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
         with:
           enable-cache: true
           python-version: "3.12"
@@ -96,7 +96,7 @@ jobs:
           uv pip install --python /tmp/check-install/bin/python dist/*.whl
           /tmp/check-install/bin/repo2rlenv --version
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: release-dist
           path: dist/
@@ -110,13 +110,13 @@ jobs:
       name: pypi
       url: https://pypi.org/p/repo2rlenv
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: release-dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1
         with:
           # API-token auth via the PYPI_API_TOKEN repo secret. (We can move
           # to OIDC trusted-publishing later by deleting `password:` and adding
@@ -136,7 +136,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: release-dist
           path: dist/


### PR DESCRIPTION
## Summary

Pin every external action in CI, documentation deployment and release workflows to a verified full commit SHA. This includes the updated action versions from #117 and the Tasksmith jobs added since this PR was opened. Keep version comments so Dependabot can maintain the pins.

Disable uv dependency caches throughout the release workflow, including manual release runs. This preserves setup-uv v10's protection for publishing jobs instead of overriding it with `enable-cache: true`.

## Test plan

- All eight CI checks passed on `b07a52f`: Python 3.12/3.13/3.14, recipe and coding-runtime contracts, lint, documentation, and distribution build.
- `actionlint` passed.
- Resolved every SHA through the upstream action repository and reviewed the changes against current main.

## Out of scope

No package version change, release publication or dataset changes.
