### PR TITLE
Fix pytest parsing of parametrized node IDs containing spaces

### DIFF
--- a/src/repo2rlenv/log_parsers/pytest_parser.py
+++ b/src/repo2rlenv/log_parsers/pytest_parser.py
@@ -30,9 +30,15 @@ TestStatus = Literal["PASSED", "FAILED", "SKIPPED", "ERROR"]
 _STATUSES = ("PASSED", "FAILED", "SKIPPED", "ERROR")
 
 # Verbose progress format: `tests/foo.py::test_x PASSED  [12%]` or `... FAILED`
-# Test names contain alphanumerics, _, /, ., ::, [, ], -, +
-# We require AT LEAST ONE non-whitespace token followed by whitespace + STATUS.
-_VERBOSE_RE = re.compile(r"^(?P<name>\S+)\s+(?P<status>PASSED|FAILED|SKIPPED|ERROR)\b")
+# Anchor the status to pytest's trailing reason/progress fields, so spaces and
+# status words inside a parameter ID remain part of the name.
+_VERBOSE_RE = re.compile(
+    r"^(?P<name>.+?(?:\[.*?\])?)\s+(?P<status>PASSED|FAILED|SKIPPED|ERROR)"
+    r"(?:\s+\(.*\))?(?:\s+\[\s*\d+%\])?$"
+)
+# Consume a bracketed parameter suffix before looking for the diagnostic dash.
+# Lazy matching keeps brackets in the diagnostic from becoming part of the ID.
+_SUMMARY_NAME_RE = re.compile(r"^(?P<name>.+?(?:\[.*?\])?)(?: - .*)?$")
 
 
 def parse_pytest(log: str) -> dict[str, TestStatus]:
@@ -41,8 +47,8 @@ def parse_pytest(log: str) -> dict[str, TestStatus]:
     Notes:
       - Last-write-wins. A test that appears in both progress AND summary
         ends up as whichever appeared last (typically summary, which is fine).
-      - SKIPPED lines like `SKIPPED [1] tests/foo.py:42` have the [N] count
-        prefix stripped so the test name is the third token, not '[1]'.
+      - SKIPPED lines like `SKIPPED [1] tests/foo.py:42` record the file
+        location rather than the count prefix or skip reason.
       - Lines like `FAILED tests/foo.py::test_x - AssertionError: ...`
         get the dash chunk stripped to keep the test name clean.
       - Returns an empty dict for empty/malformed input. Caller decides what
@@ -57,28 +63,22 @@ def parse_pytest(log: str) -> dict[str, TestStatus]:
             continue
 
         # --- format (2): summary lines (STATUS first) ---
-        # Has to be checked BEFORE the verbose regex because a summary line
-        # like "PASSED tests/foo.py::test_a" would also match the verbose
-        # pattern (with name="PASSED" — wrong).
+        # Handle the leading status separately from the full node ID.
         leading_status: TestStatus | None = None
         for st in _STATUSES:
             if line.startswith(st + " ") or line == st:
                 leading_status = st  # type: ignore[assignment]
                 break
         if leading_status is not None:
-            work = line
-            if leading_status == "FAILED" and " - " in work:
-                work = work.split(" - ", 1)[0]
-            tokens = work.split()
-            if len(tokens) < 2:
-                continue
-            test_name = tokens[1]
-            # SKIPPED [N] file:line  → the [N] is a count, real name is tokens[2]
-            if test_name.startswith("[") and test_name.endswith("]"):
-                if len(tokens) < 3:
+            work = line[len(leading_status) :].strip()
+            if leading_status == "SKIPPED" and re.match(r"^\[\d+\](?:\s|$)", work):
+                # Folded skips report a file location, not a parametrized ID.
+                tokens = work.split(maxsplit=2)
+                if len(tokens) < 2:
                     continue
-                test_name = tokens[2]
-            out[test_name] = leading_status
+                out[tokens[1]] = leading_status
+            elif m := _SUMMARY_NAME_RE.match(work):
+                out[m.group("name")] = leading_status
             continue
 
         # --- format (1): verbose progress (NAME first, STATUS after) ---

--- a/src/repo2rlenv/pipelines/_pr_runtime_verifier.py
+++ b/src/repo2rlenv/pipelines/_pr_runtime_verifier.py
@@ -71,7 +71,13 @@ ERROR = "ERROR"
 # ---------------------------------------------------------------------------
 
 _PYTEST_STATUSES = (PASSED, FAILED, SKIPPED, ERROR)
-_PYTEST_VERBOSE_RE = re.compile(r"^(?P<name>\S+)\s+(?P<status>PASSED|FAILED|SKIPPED|ERROR)\b")
+# Keep these patterns in sync with log_parsers/pytest_parser.py. This module
+# also runs standalone inside task containers, without a repo2rlenv install.
+_PYTEST_VERBOSE_RE = re.compile(
+    r"^(?P<name>.+?(?:\[.*?\])?)\s+(?P<status>PASSED|FAILED|SKIPPED|ERROR)"
+    r"(?:\s+\(.*\))?(?:\s+\[\s*\d+%\])?$"
+)
+_PYTEST_SUMMARY_NAME_RE = re.compile(r"^(?P<name>.+?(?:\[.*?\])?)(?: - .*)?$")
 
 
 def parse_pytest(log: str) -> dict[str, str]:
@@ -83,26 +89,22 @@ def parse_pytest(log: str) -> dict[str, str]:
         line = raw.strip()
         if not line:
             continue
-        # Summary lines (STATUS first) — checked before verbose so a
-        # "PASSED tests/foo.py::test_a" line isn't misread as name=PASSED.
+        # Summary lines (STATUS first), preserving the full node ID.
         leading = None
         for st in _PYTEST_STATUSES:
             if line.startswith(st + " ") or line == st:
                 leading = st
                 break
         if leading is not None:
-            work = line
-            if leading == FAILED and " - " in work:
-                work = work.split(" - ", 1)[0]
-            tokens = work.split()
-            if len(tokens) < 2:
-                continue
-            name = tokens[1]
-            if name.startswith("[") and name.endswith("]"):  # SKIPPED [N] file:line
-                if len(tokens) < 3:
+            work = line[len(leading) :].strip()
+            if leading == SKIPPED and re.match(r"^\[\d+\](?:\s|$)", work):
+                # Folded skips report a file location, not a parametrized ID.
+                tokens = work.split(maxsplit=2)
+                if len(tokens) < 2:
                     continue
-                name = tokens[2]
-            out[name] = leading
+                out[tokens[1]] = leading
+            elif m := _PYTEST_SUMMARY_NAME_RE.match(work):
+                out[m.group("name")] = leading
             continue
         # Verbose progress (NAME first, STATUS after)
         m = _PYTEST_VERBOSE_RE.match(line)

--- a/tests/test_pytest_node_ids.py
+++ b/tests/test_pytest_node_ids.py
@@ -1,0 +1,165 @@
+"""Node identities must survive generation-time and standalone pytest parsing."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from repo2rlenv.log_parsers.pytest_parser import parse_pytest
+from repo2rlenv.pipelines import _pr_runtime_verifier as verifier
+
+
+@pytest.fixture(params=[parse_pytest, verifier.parse_pytest], ids=["canonical", "standalone"])
+def parser(request):
+    return request.param
+
+
+@pytest.mark.parametrize(
+    "parameter",
+    [
+        "1 + 1",
+        "1  +  1",
+        "left - right",
+        "a PASSED b FAILED c SKIPPED d ERROR e",
+        "PASSED [ 50%] then FAILED",
+        "nested [value] with spaces",
+        "unmatched [ bracket",
+        "unmatched ] bracket",
+    ],
+)
+@pytest.mark.parametrize("style", ["verbose", "progress", "summary"])
+def test_preserves_complete_parameter_id(parser, parameter, style):
+    node = f"tests/test_calc.py::test_eval[{parameter}]"
+    if style == "summary":
+        log = f"FAILED {node} - AssertionError: [message] - more detail\n"
+    else:
+        log = f"{node} FAILED" + (" [ 50%]" if style == "progress" else "") + "\n"
+    assert parser(log) == {node: "FAILED"}
+
+
+@pytest.mark.parametrize("status", ["PASSED", "FAILED", "SKIPPED", "ERROR"])
+def test_summary_and_verbose_statuses_with_spaces(parser, status):
+    node = "tests/test_calc.py::test_eval[1 + 1]"
+    assert parser(f"{status} {node}\n") == {node: status}
+    assert parser(f"{node} {status} [100%]\n") == {node: status}
+
+
+def test_skipped_reason_and_count_prefix(parser):
+    node = "tests/test_calc.py::test_eval[a PASSED (b)]"
+    assert parser(f"{node} SKIPPED (requires optional dependency) [100%]\n") == {node: "SKIPPED"}
+    assert parser("SKIPPED [2] tests/test_calc.py:10: optional dependency\n") == {
+        "tests/test_calc.py:10:": "SKIPPED"
+    }
+
+
+def test_distinct_parameters_and_last_write_wins(parser):
+    first = "tests/test_calc.py::test_eval[1 + 1]"
+    second = "tests/test_calc.py::test_eval[1 + 2]"
+    log = (
+        f"{first} PASSED [ 50%]\n"
+        f"{second} PASSED [100%]\n"
+        f"ERROR {first} - RuntimeError: teardown failed [detail]\n"
+    )
+    assert parser(log) == {first: "ERROR", second: "PASSED"}
+
+
+@pytest.mark.parametrize(
+    "log",
+    ["", "FAILED", "PASSED ", "SKIPPED [2]", "Some output PASSED [100%]"],
+)
+def test_empty_malformed_and_unrelated_lines(parser, log):
+    assert parser(log) == {}
+
+
+@pytest.mark.parametrize("report_flag", ["-ra", "-rA"])
+def test_real_pytest_logs_preserve_oracle_and_standalone_grading(tmp_path: Path, report_flag):
+    """Discover F2P/P2P from actual logs, then grade using the shipped verifier."""
+    parameters = ["1 + 1", "1 + 2", "left - right", "PASSED or FAILED"]
+    test_file = tmp_path / "test_calc.py"
+    source = (
+        "import pytest\n"
+        f"@pytest.mark.parametrize('expr', {parameters!r})\n"
+        "def test_eval(expr):\n"
+        "    assert FIXED\n"
+        "@pytest.mark.parametrize('expr', ['keep passing'])\n"
+        "def test_keep(expr):\n"
+        "    assert True\n"
+    )
+    env = dict(os.environ, PYTEST_DISABLE_PLUGIN_AUTOLOAD="1", PYTEST_ADDOPTS="", COLUMNS="200")
+    logs = []
+    for fixed, expected_exit in [(False, 1), (True, 0)]:
+        test_file.write_text(source.replace("FIXED", str(fixed)), encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-v",
+                report_flag,
+                "--color=no",
+                "-p",
+                "no:cacheprovider",
+                "test_calc.py",
+            ],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == expected_exit, result.stdout + result.stderr
+        logs.append(result.stdout)
+
+    pre, post = map(parse_pytest, logs)
+    f2p = [
+        name for name, status in pre.items() if status == "FAILED" and post.get(name) == "PASSED"
+    ]
+    p2p = [
+        name for name, status in pre.items() if status == "PASSED" and post.get(name) == "PASSED"
+    ]
+    assert f2p == [f"test_calc.py::test_eval[{parameter}]" for parameter in parameters]
+    assert p2p == ["test_calc.py::test_keep[keep passing]"]
+    for log in logs:
+        assert verifier.parse_pytest(log) == parse_pytest(log)
+
+    # Run the verifier in isolation, with no installed repo2rlenv imports.
+    standalone = tmp_path / "verifier.py"
+    standalone.write_text(Path(verifier.__file__).read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / "out.log").write_text(logs[1], encoding="utf-8")
+    (tmp_path / "f2p.json").write_text(json.dumps(f2p), encoding="utf-8")
+    (tmp_path / "p2p.json").write_text(json.dumps(p2p), encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            str(standalone),
+            "--log",
+            "out.log",
+            "--f2p",
+            "f2p.json",
+            "--p2p",
+            "p2p.json",
+            "--runner",
+            "pytest",
+            "--exit-code",
+            "0",
+            "--out-dir",
+            "rewards",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    details = json.loads((tmp_path / "rewards/reward-details.json").read_text())
+    assert details["reward"] == 1.0
+    assert details["resolved"] is True
+    assert details["parse_status"] == "ok"
+    assert details["f2p_passed"] == len(parameters)
+    assert details["p2p_passed"] == 1


### PR DESCRIPTION
## Summary

Pytest node IDs containing spaces were dropped from verbose output or truncated in short summaries. This could omit tests from F2P/P2P discovery and incorrectly penalize passing tests during grading.

Update both the generation-time parser and standalone runtime verifier to preserve complete parameter IDs while separating pytest statuses, progress indicators and diagnostic messages. Preserve folded skip handling and last-write-wins behavior.

Add 72 regression cases covering spaces, repeated whitespace, embedded dashes and status words, brackets, skip reasons and distinct parameter identities. Integration tests exercise actual pytest output, F2P/P2P discovery and standalone verifier grading.

Fixes #90.

## Validation

- Python 3.12, 3.13, and 3.14: **788 passed, 5 skipped** on each.
- `ruff check .` and `ruff format --check .` passed.
- Source distribution and wheel builds passed.
- Clean wheel installation and CLI version check passed.