### PR TITLE
Support nested task dataset layouts when pushing to Hub

### DIFF
--- a/src/repo2rlenv/hub.py
+++ b/src/repo2rlenv/hub.py
@@ -428,7 +428,7 @@ def push_to_hub(
     """
     from huggingface_hub import HfApi
 
-    from repo2rlenv.registry.integration import prepare_dataset_for_push
+    from repo2rlenv.registry.integration import _list_task_dirs, prepare_dataset_for_push
 
     token = resolve_hf_token(auth)
     if not token:
@@ -470,12 +470,8 @@ def push_to_hub(
     first_metadata: dict[str, Any] = {}
     source_repos: set[str] = set()
     has_environment = False
-    for child in sorted(local_dataset_dir.iterdir()):
-        if not child.is_dir() or child.name.startswith("."):
-            continue
+    for child in _list_task_dirs(local_dataset_dir):
         toml_path = child / "task.toml"
-        if not toml_path.exists():
-            continue
         meta = _read_task_metadata(toml_path)
         if not first_metadata:
             first_metadata = meta

--- a/src/repo2rlenv/registry/integration.py
+++ b/src/repo2rlenv/registry/integration.py
@@ -68,14 +68,30 @@ _FROM_LINE_RE = re.compile(r"^(\s*FROM\s+)(\S+)", re.IGNORECASE | re.MULTILINE)
 
 
 def _list_task_dirs(local_dir: Path) -> list[Path]:
-    """Return task directories (each containing task.toml), sorted, no hidden."""
-    out = []
-    for child in sorted(local_dir.iterdir()):
-        if not child.is_dir() or child.name.startswith("."):
-            continue
-        if (child / "task.toml").exists():
-            out.append(child)
-    return out
+    """Return task directories from flat or ``tasks/`` dataset layouts.
+
+    A dataset may contain tasks directly under its root or under the canonical
+    Hub ``tasks/`` directory. Both layouts can coexist, but duplicate task IDs
+    are rejected rather than silently choosing one copy.
+    """
+    roots = [local_dir]
+    nested_root = local_dir / "tasks"
+    if nested_root.is_dir():
+        roots.append(nested_root)
+
+    by_name: dict[str, Path] = {}
+    for root in roots:
+        for child in sorted(root.iterdir()):
+            if not child.is_dir() or child.name.startswith("."):
+                continue
+            if not (child / "task.toml").is_file():
+                continue
+            if previous := by_name.get(child.name):
+                raise RuntimeError(
+                    f"duplicate Harbor task {child.name!r} found in {previous} and {child}"
+                )
+            by_name[child.name] = child
+    return [by_name[name] for name in sorted(by_name)]
 
 
 def _bootstrap_image_refs(task_dirs: list[Path]) -> list[tuple[str, Path]]:

--- a/tests/registry/test_integration.py
+++ b/tests/registry/test_integration.py
@@ -161,6 +161,31 @@ class TestHelpers:
         assert len(out) == 1
         assert out[0].name == "task-1"
 
+    def test_list_task_dirs_accepts_nested_tasks_layout(self, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks"
+        _write_runtime_task(tasks, "task-2", bootstrap_ref="local/x:1")
+        _write_runtime_task(tasks, "task-1", bootstrap_ref="local/x:1")
+        (tasks / ".hidden").mkdir()
+        (tasks / ".hidden" / "task.toml").write_text("ignored")
+
+        out = _list_task_dirs(tmp_path)
+
+        assert [path.name for path in out] == ["task-1", "task-2"]
+        assert all(path.parent == tasks for path in out)
+
+    def test_list_task_dirs_combines_flat_and_nested_layouts(self, tmp_path: Path) -> None:
+        _write_runtime_task(tmp_path, "flat", bootstrap_ref="local/x:1")
+        _write_runtime_task(tmp_path / "tasks", "nested", bootstrap_ref="local/x:1")
+
+        assert [path.name for path in _list_task_dirs(tmp_path)] == ["flat", "nested"]
+
+    def test_list_task_dirs_rejects_duplicate_task_ids(self, tmp_path: Path) -> None:
+        _write_runtime_task(tmp_path, "duplicate", bootstrap_ref="local/x:1")
+        _write_runtime_task(tmp_path / "tasks", "duplicate", bootstrap_ref="local/x:1")
+
+        with pytest.raises(RuntimeError, match="duplicate Harbor task 'duplicate'"):
+            _list_task_dirs(tmp_path)
+
     def test_bootstrap_image_refs(self, tmp_path: Path) -> None:
         _write_runtime_task(tmp_path, "task-1", bootstrap_ref="local/r2e:1")
         _write_runtime_task(tmp_path, "task-2", bootstrap_ref="local/r2e:1")

--- a/tests/test_hub_metadata_read.py
+++ b/tests/test_hub_metadata_read.py
@@ -100,6 +100,32 @@ class TestPushAutoReadsMetadata:
         assert captured_card["pipeline"] == "pr_runtime"
         assert captured_card["repo_source"] == "pallets/click"
 
+    def test_nested_tasks_layout_is_discovered(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        tasks = tmp_path / "tasks"
+        tasks.mkdir()
+        _make_task(tasks, pipeline="pr_runtime", repo="pallets/click")
+        monkeypatch.setattr("repo2rlenv.hub.resolve_hf_token", lambda _auth: "fake-token")
+
+        captured_card: dict[str, str] = {}
+
+        def fake_build_card(**kwargs: str) -> str:
+            captured_card.update(kwargs)
+            return "fake-card"
+
+        monkeypatch.setattr("repo2rlenv.hub._build_dataset_card", fake_build_card)
+        api = self._mock_hf_api()
+        monkeypatch.setattr("huggingface_hub.HfApi", lambda token=None: api)
+
+        result = push_to_hub(tmp_path, "owner/click-r2e", AuthSpec())
+
+        assert result.task_count == 1
+        assert captured_card["pipeline"] == "pr_runtime"
+        assert captured_card["repo_source"] == "pallets/click"
+
     def test_caller_override_wins(
         self,
         tmp_path: Path,


### PR DESCRIPTION
Fixes #96

## Summary

* reuse `_list_task_dirs()` in `push_to_hub()` so Hub staging and image preparation share the same discovery logic
* support both flat task layouts and the canonical `tasks/<id>/task.toml` layout
* keep hidden directories excluded and preserve deterministic ordering
* reject duplicate task IDs across flat and nested layouts instead of silently choosing one copy
* add regression coverage for nested discovery, mixed layouts, duplicate IDs, and nested `push_to_hub()` metadata discovery

## Validation

* `uv run pytest -q tests/registry/test_integration.py tests/test_hub_metadata_read.py` → 34 passed
* `uv run ruff check src/repo2rlenv/registry/integration.py src/repo2rlenv/hub.py tests/registry/test_integration.py tests/test_hub_metadata_read.py` → passed
* `uv run ruff format --check src/repo2rlenv/registry/integration.py src/repo2rlenv/hub.py tests/registry/test_integration.py tests/test_hub_metadata_read.py` → 4 files already formatted
* `git diff --check` → clean
* full `uv run pytest -q` on Windows: 712 passed, 6 skipped, 7 platform-specific failures related to executable bits, path separators, and Windows local-path parsing; none are in files changed by this PR
