### PR TITLE
fix(commit_runtime): use the real host in the dataset reference URL

### DIFF
--- a/src/repo2rlenv/pipelines/commit_runtime.py
+++ b/src/repo2rlenv/pipelines/commit_runtime.py
@@ -65,7 +65,7 @@ from repo2rlenv.pipelines.pr_runtime import (
     targeted_test_cmds_for_pr,
 )
 from repo2rlenv.provider import provider_for
-from repo2rlenv.sources import Capability, capabilities_for
+from repo2rlenv.sources import Capability, SourceKind, capabilities_for
 from repo2rlenv.spec.input import GenerationInput, PipelineName
 from repo2rlenv.spec.options import CommitRuntimeOptions
 
@@ -545,6 +545,13 @@ class CommitRuntimePipeline:
         # commit_runtime task ID convention: <owner>__<repo>-<sha12>
         # (analogous to pr_runtime's <owner>__<repo>-<pr_number>)
         task_id = f"{owner}__{name}-{commit.sha[:12]}"
+        source_kind = self.input.repo.source_kind
+        commit_reference = (
+            f"https://{'gitlab.com' if source_kind is SourceKind.GITLAB else 'github.com'}"
+            f"/{owner}/{name}/commit/{commit.sha}"
+            if source_kind is not SourceKind.LOCAL
+            else None
+        )
 
         eval_script = build_eval_script(
             base_commit=commit.parent_sha,
@@ -577,7 +584,9 @@ class CommitRuntimePipeline:
             "pipeline_version": "0.8.3",
             "repo": f"{owner}/{name}",
             "ref": commit.parent_sha,
-            "reference": f"https://github.com/{owner}/{name}/commit/{commit.sha}",
+            # Omitted, not None, for a local checkout: TOML has no null and
+            # tomli_w rejects it outright.
+            **({"reference": commit_reference} if commit_reference is not None else {}),
             "source_access": self.input.repo.access,
             "built_at": datetime.now(UTC).isoformat(),
             **({"synthesis_llm": self.input.llm.qualified_name} if self.input.llm else {}),

--- a/tests/test_pipeline_commit_runtime.py
+++ b/tests/test_pipeline_commit_runtime.py
@@ -19,6 +19,7 @@ from repo2rlenv.pipelines.commit_runtime import (
     _strip_commit_prefix,
     build_instruction_from_commit,
 )
+from repo2rlenv.sources import SourceKind
 from repo2rlenv.spec.options import CommitRuntimeOptions
 
 
@@ -256,7 +257,7 @@ def test_instruction_reflows_long_body_with_template_noise():
 # -------------------------- _build_task metadata ------------------------------
 
 
-def _stub_pipeline_for_build_task(test_cmds=None, language="python"):
+def _stub_pipeline_for_build_task(test_cmds=None, language="python", source_kind=SourceKind.GITHUB):
     """A pipeline instance with just enough scaffolding to call `_build_task`."""
     from types import SimpleNamespace
     from unittest.mock import MagicMock
@@ -276,6 +277,7 @@ def _stub_pipeline_for_build_task(test_cmds=None, language="python"):
     pipe.input.repo.owner_name = ("o", "r")
     pipe.input.repo.access = "auto"
     pipe.input.repo.url = "https://github.com/o/r"
+    pipe.input.repo.source_kind = source_kind
     pipe.input.output.org = "default"
     pipe.input.llm = None
     pipe.input.bootstrap.platform = "linux/amd64"
@@ -321,6 +323,75 @@ def test_build_task_stamps_reward_calibration_and_difficulty():
     assert cal["difficulty"] in {"trivial", "small", "medium", "large"}
     # The HarborTask's difficulty is set from the bucket, not hard-coded "medium"
     assert task.difficulty == cal["difficulty"]
+
+
+@pytest.mark.parametrize(
+    ("source_kind", "expected_reference"),
+    [
+        (SourceKind.GITHUB, "https://github.com/o/r/commit/deadbeef"),
+        (SourceKind.GITLAB, "https://gitlab.com/o/r/commit/deadbeef"),
+        (SourceKind.LOCAL, None),
+    ],
+)
+def test_build_task_reference_host_matches_source(source_kind, expected_reference):
+    """The 'reference' provenance URL must point at the commit's actual host,
+    not always github.com: commit_runtime works on any source (docstring in
+    sources.py), and a GitLab- or local-sourced task previously got a
+    github.com link that does not resolve."""
+    pipe = _stub_pipeline_for_build_task(source_kind=source_kind)
+    commit = _make_commit(subject="fix: parser crashes on empty input", sha="deadbeef")
+    patch = (
+        "diff --git a/parser.py b/parser.py\n"
+        "--- a/parser.py\n"
+        "+++ b/parser.py\n"
+        "@@ -1,2 +1,2 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+    task = pipe._build_task(
+        commit,
+        patch,
+        test_patch="",
+        fail_to_pass=[],
+        pass_to_pass=[],
+        validation_status="ok",
+    )
+    if expected_reference is None:
+        # TOML has no null, so a local checkout must drop the key, not null it.
+        assert "reference" not in task.repo2env
+    else:
+        assert task.repo2env["reference"] == expected_reference
+
+
+def test_build_task_local_source_writes_a_loadable_task_toml(tmp_path):
+    """A None reference would crash tomli_w.dumps (TOML has no null) inside
+    write_harbor_task. Drive the real emitter, not just the dict, so a
+    regression here fails loudly instead of only at push time."""
+    import tomllib
+
+    from repo2rlenv.emitter.harbor import write_harbor_task
+
+    pipe = _stub_pipeline_for_build_task(source_kind=SourceKind.LOCAL)
+    commit = _make_commit(subject="fix: parser crashes on empty input", sha="deadbeef")
+    patch = (
+        "diff --git a/parser.py b/parser.py\n"
+        "--- a/parser.py\n"
+        "+++ b/parser.py\n"
+        "@@ -1,2 +1,2 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+    task = pipe._build_task(
+        commit,
+        patch,
+        test_patch="",
+        fail_to_pass=[],
+        pass_to_pass=[],
+        validation_status="ok",
+    )
+    task_path = write_harbor_task(task, tmp_path)
+    loaded = tomllib.loads((task_path / "task.toml").read_text())
+    assert "reference" not in loaded["metadata"]["repo2env"]
 
 
 # -------------------------- structural filter ---------------------------------


### PR DESCRIPTION
## Summary

- `_build_task()` always wrote the dataset's `reference` link as
  `https://github.com/{owner}/{name}/commit/{sha}`, even when the source repo is GitLab or a
  local checkout. `owner_name` strips the host, so nothing downstream knew which one it was.
- Route the host through `self.input.repo.source_kind` instead: `github.com` for GitHub,
  `gitlab.com` for GitLab, and drop `reference` entirely for a local checkout, since there's no
  real URL to point at there and TOML has no null for `tomli_w` to write anyway.

## Test plan

- [x] Added `test_build_task_reference_host_matches_source`, parametrized over GitHub/GitLab/local.
      The GitHub case passes on main (behavior unchanged); GitLab and local both fail on main
      and pass on the branch.
- [x] Added `test_build_task_local_source_writes_a_loadable_task_toml`, driving the real
      `write_harbor_task` emitter for the local case and loading the result back with `tomllib`.
      Caught a real bug in my first pass: setting `reference` to `None` instead of omitting the
      key crashes `tomli_w.dumps` (TOML has no null).
- [x] Full suite: 719 passed, 6 skipped, on 3.12 and 3.14.
- [x] `ruff check` / `ruff format --check`: clean.

## Out of scope

`code_instruct.py` and `equivalence_tests.py` build a similar `blob/...#Lx-Ly` reference the
same way and have the identical hardcoded-host bug. Same root cause, different files; happy to
send a follow-up if that's useful, didn't want to bundle three pipelines into one PR.

Closes #98
