### PR TITLE
cli: add --llm-endpoint/--llm-key-env, keyless self-hosted LLMs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,10 @@ shell-out); gitlab → `repo.auth_token_env` then `$GITLAB_TOKEN`; github →
 
 HF Hub auth uses `huggingface_hub`'s own resolution
 (`~/.cache/huggingface/token` or `$HF_TOKEN`). LLM keys come from provider-default
-env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …) via `auth.resolve_llm_api_key()`.
+env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …) via `auth.resolve_llm_api_key()` —
+only for the providers in `auth.LLM_KEY_ENV_DEFAULTS`. Anything else is left to LiteLLM's
+own lookup, and a self-hosted `LLMSpec.endpoint` (`--llm-endpoint`) needs no key at all
+(`llm._resolve_api_key`).
 
 Registry push credentials resolve from explicit env vars first: GHCR reads
 `GHCR_TOKEN` / `GITHUB_TOKEN` (needs a one-time

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -85,7 +85,7 @@ response = complete(
 print(response.content)
 ```
 
-Single-shot LiteLLM call. Honors `spec.endpoint` for self-hosted backends; auto-points HF provider at `https://router.huggingface.co/v1`.
+Single-shot LiteLLM call. Honors `spec.endpoint` for self-hosted backends — no key required, and the provider-default key is never forwarded there unless `spec.api_key_env` names it; auto-points HF provider at `https://router.huggingface.co/v1`. Providers outside `auth.LLM_KEY_ENV_DEFAULTS` resolve their credentials inside LiteLLM. `check_provider(spec)` fails fast on an unknown provider anywhere in the fallback chain.
 
 ## `repo2rlenv.reward`
 

--- a/docs/reference/AUTH.md
+++ b/docs/reference/AUTH.md
@@ -107,7 +107,9 @@ LiteLLM resolves provider keys from provider-default env vars:
 | Together | `TOGETHER_API_KEY` |
 | Groq | `GROQ_API_KEY` |
 
-Override with `llm.api_key_env` in your config if you have non-default names.
+Override with `--llm-key-env VAR` (or `llm.api_key_env` in config) if you have non-default names. Providers not in the table are resolved by LiteLLM's own per-provider lookup.
+
+**Self-hosted models need no key.** Point `--llm-endpoint` (or `llm.endpoint`) at any OpenAI-compatible server and use `hosted_vllm/<model>` or `openai/<model>`. The provider-default key is never forwarded to a custom endpoint — `openai/` gets a placeholder, `hosted_vllm/` honours `HOSTED_VLLM_API_KEY` if set. Pass `--llm-key-env VAR` to send a specific key. `ollama/<model>` reads `OLLAMA_API_BASE` on its own.
 
 ### Container registry (image distribution for `_runtime` datasets)
 

--- a/docs/reference/BOOTSTRAP.md
+++ b/docs/reference/BOOTSTRAP.md
@@ -64,7 +64,7 @@ The `--llm` flag accepts a LiteLLM-format string. Some examples:
 | Anthropic | `anthropic/<model-name>` |
 | OpenAI | `openai/<model-name>` |
 | Hugging Face Inference Providers | `huggingface/<repo>:<provider>` (e.g. `huggingface/<org>/<model>:together`) |
-| Self-hosted vLLM / Ollama | `openai/<your-model>` with `--llm-endpoint http://...` |
+| Self-hosted vLLM / Ollama / any OpenAI-compatible server | `hosted_vllm/<model>` or `openai/<model>` with `--llm-endpoint http://host:8000/v1` — no API key needed |
 
 Anything LiteLLM supports works, including Bedrock, Vertex, Mistral, and others.
 
@@ -77,11 +77,14 @@ Set the provider's default environment variable; the CLI picks it up automatical
 | Anthropic | `ANTHROPIC_API_KEY` |
 | OpenAI | `OPENAI_API_KEY` |
 | Hugging Face | `HF_TOKEN` |
-| Other | override via `--llm-key-env` or YAML config |
+| Self-hosted (`--llm-endpoint`) | none — the provider-default key is never sent to a custom endpoint. If your server enforces one: `HOSTED_VLLM_API_KEY` for `hosted_vllm/`, or `--llm-key-env VAR` for any route |
+| Other | override via `--llm-key-env` or YAML config; otherwise LiteLLM's own per-provider lookup applies (Bedrock, Vertex, OpenRouter, …) |
 
 ### Cost guardrail
 
 Every bootstrap run is bounded by `max_llm_spend_usd` (default `$5.0`). When the running cost reaches the cap, the agent loop aborts cleanly. Set lower for tighter control:
+
+> Self-hosted models are not in LiteLLM's price table, so their calls count as `$0` and the cap never trips. `max_iterations` / `max_seconds` remain the bounds there.
 
 ```bash
 repo2rlenv generate ... --bootstrap-opt max_llm_spend_usd=1.0
@@ -128,12 +131,13 @@ repo2rlenv generate \
   --bootstrap-opt max_llm_spend_usd=3.0 \
   --out ./datasets/<name>
 
-# Self-hosted vLLM or Ollama (OpenAI-compatible endpoint)
+# Self-hosted vLLM or Ollama (OpenAI-compatible endpoint) — no API key needed
+vllm serve Qwen/Qwen3.5-4B --port 8000          # or: ollama serve
 repo2rlenv generate \
   --repo <owner>/<repo> \
   --pipeline pr_runtime --pipeline-opt limit=10 \
-  --llm "openai/<your-model>" \
-  --llm-endpoint http://your-vllm-host:8000/v1 \
+  --llm "hosted_vllm/Qwen/Qwen3.5-4B" \
+  --llm-endpoint http://localhost:8000/v1 \
   --out ./datasets/<name>
 ```
 

--- a/docs/reference/ENV.md
+++ b/docs/reference/ENV.md
@@ -35,7 +35,7 @@ For `repo2rlenv push` / `pull`. Resolved by `huggingface_hub` itself; we don't o
 
 ## LLM providers
 
-LiteLLM-resolved; per-provider defaults. Override with `llm.api_key_env` in config if you use non-default names.
+LiteLLM-resolved; per-provider defaults. Override with `--llm-key-env VAR` (or `llm.api_key_env` in config) if you use non-default names.
 
 | Variable | Provider |
 |---|---|
@@ -44,6 +44,15 @@ LiteLLM-resolved; per-provider defaults. Override with `llm.api_key_env` in conf
 | `HF_TOKEN` | Hugging Face Router |
 | `TOGETHER_API_KEY` | Together |
 | `GROQ_API_KEY` | Groq |
+
+Those five are resolved by `repo2rlenv` itself, so a missing key fails fast with the variable named. Every other LiteLLM provider resolves its own credentials inside LiteLLM (e.g. `OPENROUTER_API_KEY`, AWS credentials for Bedrock). Self-hosted servers need none:
+
+| Variable | Provider |
+|---|---|
+| `HOSTED_VLLM_API_KEY` *(optional)* | `hosted_vllm/…` — only if your vLLM was started with `--api-key`; honoured with or without `--llm-endpoint`. `HOSTED_VLLM_API_BASE` is the alternative to `--llm-endpoint`. |
+| `OLLAMA_API_KEY` *(optional)* | `ollama/…` — `OLLAMA_API_BASE` defaults to `http://localhost:11434`. |
+
+With `--llm-endpoint` (or `llm.endpoint` in config) the provider-default key — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, … — is never forwarded to the custom server: `openai/<model>` gets a placeholder, `hosted_vllm/` and `ollama/` use LiteLLM's own lookup above. Pass `--llm-key-env VAR` to send a specific key.
 
 ## Container registry (for `_runtime` image distribution on push)
 

--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -24,7 +24,7 @@ class GenerationInput(BaseModel):
 |---|---|---|
 | `RepoSpec` | `url` | `access ∈ {public, private, auto}`, optional `auth_token_env`, `ref` defaults to `HEAD` |
 | `PipelineSpec` | `name`, `options` | `name` is an enum (see [pipelines/](./pipelines/)); `options` is validated against the named pipeline's Options model with `extra="forbid"` |
-| `LLMSpec` | `provider`, `model` | `provider/model` resolves to a LiteLLM identifier; supports `endpoint` for self-hosted vLLM/Ollama |
+| `LLMSpec` | `provider`, `model` | `provider/model` resolves to a LiteLLM identifier; `endpoint` (CLI: `--llm-endpoint`) targets a self-hosted vLLM/Ollama server, `api_key_env` (CLI: `--llm-key-env`) names a non-default key var |
 | `OutputSpec` | `destination`, `org`, `dataset_name` | `destination` is a local path; publish separately via `repo2rlenv push` |
 | `QASpec` | (none) | Defaults to `[diff_parse]` for the lite path; full pipelines opt into `[determinism, oracle_consistency, llm_judge, false_negative]` |
 | `SandboxSpec` | (none) | See "Sandbox model" below — `none` for lite, `harbor` for full pipelines (delegates), `local`/`e2b` for lite consumer-side runners |

--- a/src/repo2rlenv/auth.py
+++ b/src/repo2rlenv/auth.py
@@ -60,24 +60,31 @@ def resolve_hf_token(auth: AuthSpec) -> str | None:
     return os.environ.get(auth.hf_token_env)
 
 
-def resolve_llm_api_key(provider: str, llm_api_key_env: str | None = None) -> str | None:
-    """Return an LLM provider API key based on the provider name."""
-    if llm_api_key_env:
-        v = os.environ.get(llm_api_key_env)
-        if v:
-            return v
+# Provider → env var for the hosted providers we resolve ourselves, so a missing
+# key fails fast with the var named. Everything else (Bedrock, Vertex, self-hosted
+# vLLM / Ollama, …) resolves inside LiteLLM — and the self-hosted ones need none.
+LLM_KEY_ENV_DEFAULTS: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "huggingface": "HF_TOKEN",
+    "together": "TOGETHER_API_KEY",
+    "groq": "GROQ_API_KEY",
+}
 
-    defaults = {
-        "anthropic": "ANTHROPIC_API_KEY",
-        "openai": "OPENAI_API_KEY",
-        "huggingface": "HF_TOKEN",
-        "together": "TOGETHER_API_KEY",
-        "groq": "GROQ_API_KEY",
-    }
-    env_name = defaults.get(provider.lower())
-    if env_name:
-        return os.environ.get(env_name)
-    return None
+
+def resolve_llm_api_key(provider: str, llm_api_key_env: str | None = None) -> str | None:
+    """Return the API key for `provider` from the environment, or None.
+
+    `llm_api_key_env` names the var explicitly and never falls through: if it
+    is unset the result is None, not some other provider's key. Without it,
+    only `LLM_KEY_ENV_DEFAULTS` providers are looked up here — for the rest
+    LiteLLM does its own (`HOSTED_VLLM_API_KEY`, `OLLAMA_API_KEY`, AWS
+    credentials, …). A blank value counts as unset; `.env.example` ships blanks.
+    """
+    env_name = llm_api_key_env or LLM_KEY_ENV_DEFAULTS.get(provider.lower())
+    if not env_name:
+        return None
+    return os.environ.get(env_name) or None
 
 
 def auth_clone_url(repo_url: str, token: str | None) -> str:

--- a/src/repo2rlenv/cli.py
+++ b/src/repo2rlenv/cli.py
@@ -55,7 +55,96 @@ def _parse_pipeline_opts(items: list[str] | None) -> dict[str, Any]:
     return out
 
 
+def _split_provider_model(value: str, flag: str) -> tuple[str, str]:
+    if "/" not in value:
+        raise SystemExit(f"{flag} expects provider/model, got {value!r}")
+    provider, model = value.split("/", 1)
+    return provider, model
+
+
+def _llm_overrides(args: argparse.Namespace) -> dict[str, Any]:
+    """The `llm` config block from --llm / --llm-fallback / --llm-endpoint / --llm-key-env.
+
+    Empty when none are given, so a config file's `llm:` block is left alone.
+    --llm-endpoint / --llm-key-env apply to the primary model only.
+    """
+    out: dict[str, Any] = {}
+    if args.llm:
+        out["provider"], out["model"] = _split_provider_model(args.llm, "--llm")
+    if getattr(args, "llm_fallback", None):
+        fb_provider, fb_model = _split_provider_model(args.llm_fallback, "--llm-fallback")
+        out["fallback"] = {"provider": fb_provider, "model": fb_model}
+    if getattr(args, "llm_endpoint", None):
+        out["endpoint"] = args.llm_endpoint
+    if getattr(args, "llm_key_env", None):
+        out["api_key_env"] = args.llm_key_env
+    if out and not args.llm and not getattr(args, "config", None):
+        raise SystemExit(
+            "--llm-fallback / --llm-endpoint / --llm-key-env need --llm "
+            "(or an `llm:` block in --config)"
+        )
+    return out
+
+
+def _drop_config_llm_extras(gen_input, args: argparse.Namespace, config_path: Path):
+    """`--llm` over a config whose `llm:` block names a different model.
+
+    `merge` is recursive, so the block's `endpoint` / `api_key_env` would stay
+    attached to the new model. They belong to the old one — keep only what the
+    CLI re-supplied.
+    """
+    from repo2rlenv.config import load_config_file
+
+    if gen_input.llm is None:
+        return gen_input
+    cfg_llm = load_config_file(config_path).get("llm") or {}
+    if (cfg_llm.get("provider"), cfg_llm.get("model")) == (
+        gen_input.llm.provider,
+        gen_input.llm.model,
+    ):
+        return gen_input
+    llm = gen_input.llm.model_copy(
+        update={
+            "endpoint": getattr(args, "llm_endpoint", None) or None,
+            "api_key_env": getattr(args, "llm_key_env", None) or None,
+        }
+    )
+    return gen_input.model_copy(update={"llm": llm})
+
+
+def _add_llm_args(parser: argparse.ArgumentParser, *, required: bool, fallback: bool) -> None:
+    parser.add_argument(
+        "--llm",
+        required=required,
+        help="LLM as provider/model (e.g. anthropic/claude-sonnet-4-6)",
+    )
+    if fallback:
+        parser.add_argument(
+            "--llm-fallback",
+            help=(
+                "fallback LLM as provider/model — used automatically when the primary "
+                "returns 5xx / rate-limit / network errors"
+            ),
+        )
+    parser.add_argument(
+        "--llm-endpoint",
+        metavar="URL",
+        help=(
+            "base URL of a self-hosted OpenAI-compatible server for the primary --llm "
+            "(vLLM, Ollama, …), e.g. http://localhost:8000/v1. No API key needed; the "
+            "provider-default key is never sent there — use --llm-key-env to send one"
+        ),
+    )
+    parser.add_argument(
+        "--llm-key-env",
+        metavar="VAR",
+        help="env var holding the API key for the primary --llm (overrides the provider default)",
+    )
+
+
 def cmd_generate(args: argparse.Namespace) -> int:
+    from pydantic import ValidationError
+
     from repo2rlenv.config import load_generation_input
     from repo2rlenv.pipelines import PIPELINES
     from repo2rlenv.spec.options import parse_options
@@ -69,18 +158,9 @@ def cmd_generate(args: argparse.Namespace) -> int:
             "name": args.pipeline,
             "options": _parse_pipeline_opts(args.pipeline_opt),
         }
-    if args.llm:
-        if "/" not in args.llm:
-            raise SystemExit(f"--llm expects provider/model, got {args.llm!r}")
-        provider, model = args.llm.split("/", 1)
-        overrides["llm"] = {"provider": provider, "model": model}
-        if getattr(args, "llm_fallback", None):
-            if "/" not in args.llm_fallback:
-                raise SystemExit(
-                    f"--llm-fallback expects provider/model, got {args.llm_fallback!r}"
-                )
-            fb_provider, fb_model = args.llm_fallback.split("/", 1)
-            overrides["llm"]["fallback"] = {"provider": fb_provider, "model": fb_model}
+    llm_overrides = _llm_overrides(args)
+    if llm_overrides:
+        overrides["llm"] = llm_overrides
     if args.out:
         overrides["output"] = {
             "destination": args.out,
@@ -90,7 +170,16 @@ def cmd_generate(args: argparse.Namespace) -> int:
         }
 
     config_path = Path(args.config) if args.config else None
-    gen_input = load_generation_input(config_path, overrides)
+    try:
+        gen_input = load_generation_input(config_path, overrides)
+    except ValidationError as exc:
+        # e.g. --llm-endpoint with a config that has no `llm:` block — show the
+        # field errors, not a traceback.
+        console.error(f"invalid generation input:\n{exc}")
+        return 2
+
+    if args.llm and config_path is not None:
+        gen_input = _drop_config_llm_extras(gen_input, args, config_path)
 
     pipeline_cls = PIPELINES.get(gen_input.pipeline.name.value)
     if pipeline_cls is None:
@@ -172,7 +261,14 @@ def cmd_generate(args: argparse.Namespace) -> int:
     if getattr(pipeline_cls, "requires_bootstrap", False):
         from repo2rlenv.bootstrap import LanguageHint, ensure_bootstrap
         from repo2rlenv.bootstrap.runner import BootstrapError
+        from repo2rlenv.llm import check_provider
         from repo2rlenv.ui.views.bootstrap import bootstrap_view_or_plain
+
+        try:
+            check_provider(gen_input.llm)
+        except RuntimeError as exc:
+            console.error(str(exc))
+            return 2
 
         # Mutate spec with CLI overrides (language / base-image / budget / force / --bootstrap-opt)
         bspec = gen_input.bootstrap.model_copy(deep=True)
@@ -732,13 +828,17 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
     from repo2rlenv.bootstrap import LanguageHint, ensure_bootstrap
     from repo2rlenv.bootstrap.language import base_image_for
     from repo2rlenv.bootstrap.runner import BootstrapError
+    from repo2rlenv.llm import check_provider
     from repo2rlenv.spec.input import AuthSpec, BootstrapSpec, LLMSpec, RepoSpec
     from repo2rlenv.ui.views.bootstrap import bootstrap_view_or_plain
 
-    if not args.llm or "/" not in args.llm:
+    if not args.llm:
         raise SystemExit("--llm is required as provider/model (e.g. anthropic/claude-sonnet-4-6)")
-    provider, model = args.llm.split("/", 1)
-    llm = LLMSpec(provider=provider, model=model)
+    llm = LLMSpec.model_validate(_llm_overrides(args))
+    try:
+        check_provider(llm)
+    except RuntimeError as exc:
+        raise SystemExit(str(exc)) from exc
 
     repo = RepoSpec(url=args.repo, ref=args.ref, access=args.access)
     # --max-spend-usd=0 means "no cap"; map to None so the agent loop skips the check
@@ -860,14 +960,7 @@ def main(argv: list[str] | None = None) -> int:
         default=[],
         help="pipeline-specific kwarg, repeatable (key=value)",
     )
-    g.add_argument("--llm", help="LLM as provider/model (e.g. anthropic/claude-sonnet-4-6)")
-    g.add_argument(
-        "--llm-fallback",
-        help=(
-            "fallback LLM as provider/model — used automatically when the primary "
-            "returns 5xx / rate-limit / network errors"
-        ),
-    )
+    _add_llm_args(g, required=False, fallback=True)
     g.add_argument("--out", help="output directory")
     g.add_argument("--org", help="task.org for Harbor")
     g.add_argument("--dataset-name", help="dataset name")
@@ -1029,7 +1122,7 @@ def main(argv: list[str] | None = None) -> int:
     bs.add_argument("--repo", required=True, help="GitHub repo (owner/name or URL)")
     bs.add_argument("--ref", default="HEAD", help="branch/tag/commit (default: HEAD)")
     bs.add_argument("--access", choices=["public", "private", "auto"], default="auto")
-    bs.add_argument("--llm", required=True, help="provider/model, e.g. anthropic/claude-sonnet-4-6")
+    _add_llm_args(bs, required=True, fallback=False)
     bs.add_argument("--max-iterations", type=int, default=25)
     bs.add_argument("--max-seconds", type=int, default=1800)
     bs.add_argument(

--- a/src/repo2rlenv/llm.py
+++ b/src/repo2rlenv/llm.py
@@ -11,10 +11,15 @@ import logging
 import re
 from dataclasses import dataclass
 
-from repo2rlenv.auth import resolve_llm_api_key
+from repo2rlenv.auth import LLM_KEY_ENV_DEFAULTS, resolve_llm_api_key
 from repo2rlenv.spec.input import LLMSpec
 
 logger = logging.getLogger(__name__)
+
+# Sent with `endpoint` to providers whose client insists on *some* key string
+# (`openai/<model>` against vLLM, Ollama, llama.cpp — the server ignores it).
+# Same value vLLM's docs use.
+_PLACEHOLDER_API_KEY = "EMPTY"
 
 
 # Models that reject any `temperature` value (forced default). Add patterns
@@ -58,6 +63,56 @@ def _is_failover_eligible(exc: BaseException) -> bool:
     }
 
 
+def _resolve_api_key(spec: LLMSpec) -> str | None:
+    """The API key to hand LiteLLM, or None to let LiteLLM resolve it.
+
+    - `api_key_env` given → its value; raise if unset (never falls through)
+    - `endpoint` given → the provider-default key is *not* forwarded to a
+      custom server. `LLM_KEY_ENV_DEFAULTS` clients (`openai/`, …) need a key
+      string, so they get the placeholder; `hosted_vllm/`, `ollama/`, … get
+      None and LiteLLM applies its own `HOSTED_VLLM_API_KEY`-style lookup.
+    - otherwise → provider-default key; raise naming the var for
+      `LLM_KEY_ENV_DEFAULTS` providers, None (LiteLLM's call) for the rest
+    """
+    provider = spec.provider.lower()
+    if spec.api_key_env:
+        key = resolve_llm_api_key(provider, spec.api_key_env)
+        if key is None:
+            raise RuntimeError(
+                f"no API key for provider {spec.provider!r}: ${spec.api_key_env} is unset."
+            )
+        return key
+    if spec.endpoint:
+        return _PLACEHOLDER_API_KEY if provider in LLM_KEY_ENV_DEFAULTS else None
+    key = resolve_llm_api_key(provider)
+    if key is None and provider in LLM_KEY_ENV_DEFAULTS:
+        raise RuntimeError(
+            f"no API key resolved for provider {spec.provider!r}. Set "
+            f"{LLM_KEY_ENV_DEFAULTS[provider]}, or use --llm-endpoint for a self-hosted server."
+        )
+    return key
+
+
+def check_provider(spec: LLMSpec) -> None:
+    """Raise early if LiteLLM doesn't know a provider in the spec's fallback chain.
+
+    Cheap next to what follows (clone, image pull, agent loop), so the bootstrap
+    entry points call it before any of that starts.
+    """
+    import litellm  # type: ignore[import-untyped]
+
+    cur: LLMSpec | None = spec
+    while cur is not None:
+        try:
+            litellm.get_llm_provider(cur.qualified_name)
+        except Exception as exc:
+            first_line = str(exc).splitlines()[0] if str(exc) else type(exc).__name__
+            raise RuntimeError(
+                f"unknown LLM provider in {cur.qualified_name!r}: {first_line}"
+            ) from exc
+        cur = cur.fallback
+
+
 def _do_complete(
     spec: LLMSpec,
     *,
@@ -69,12 +124,7 @@ def _do_complete(
     """One non-fallback chat-completion call. Internal helper for `complete()`."""
     import litellm  # type: ignore[import-untyped]
 
-    api_key = resolve_llm_api_key(spec.provider, spec.api_key_env)
-    if api_key is None:
-        raise RuntimeError(
-            f"no API key resolved for provider {spec.provider!r}. "
-            f"Set {spec.api_key_env or 'the provider-default env var'}."
-        )
+    api_key = _resolve_api_key(spec)
 
     messages: list[dict] = []
     if system:
@@ -85,9 +135,10 @@ def _do_complete(
         "model": spec.qualified_name,
         "messages": messages,
         "max_tokens": max_tokens,
-        "api_key": api_key,
         "timeout": spec.timeout_sec,
     }
+    if api_key is not None:
+        kwargs["api_key"] = api_key
     # Newer reasoning-focused models (Opus 4.7+, GPT-5+) reject `temperature`.
     if _supports_temperature(spec.model):
         kwargs["temperature"] = temperature

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -60,3 +60,26 @@ def test_hf_token_falls_back_to_env():
         # Patch the cache file path so we don't accidentally pick up real cache
         auth = AuthSpec(use_hf_cli=False)
         assert resolve_hf_token(auth) == "hf_xxx"
+
+
+def test_llm_api_key_unknown_provider_returns_none_without_raising():
+    """Providers outside LLM_KEY_ENV_DEFAULTS are LiteLLM's to resolve."""
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert resolve_llm_api_key("hosted_vllm") is None
+        assert resolve_llm_api_key("ollama") is None
+        assert resolve_llm_api_key("bedrock") is None
+
+
+def test_llm_api_key_explicit_env_works_for_unknown_provider():
+    with mock.patch.dict(os.environ, {"VLLM_KEY": "secret"}, clear=True):
+        assert resolve_llm_api_key("hosted_vllm", "VLLM_KEY") == "secret"
+
+
+def test_llm_api_key_explicit_env_never_falls_through():
+    with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-personal"}, clear=True):
+        assert resolve_llm_api_key("openai", "PROXY_KEY") is None
+
+
+def test_llm_api_key_blank_counts_as_unset():
+    with mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=True):
+        assert resolve_llm_api_key("anthropic") is None

--- a/tests/test_cli_llm_flags.py
+++ b/tests/test_cli_llm_flags.py
@@ -1,0 +1,172 @@
+"""`--llm-endpoint` / `--llm-key-env` / `--llm-fallback` on `generate` and `bootstrap`."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+import yaml
+
+from repo2rlenv import cli as cli_mod
+from repo2rlenv.cli import _drop_config_llm_extras, _llm_overrides
+from repo2rlenv.config import load_generation_input
+
+ENDPOINT = "http://127.0.0.1:8000/v1"
+
+
+def _args(**kwargs) -> argparse.Namespace:
+    base = {"llm": None, "llm_fallback": None, "llm_endpoint": None, "llm_key_env": None}
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _write_config(tmp_path: Path, llm: dict | None) -> Path:
+    cfg = {
+        "repo": {"url": "pallets/click"},
+        "pipeline": {"name": "pr_diff"},
+        "output": {"destination": str(tmp_path), "org": "o", "dataset_name": "d"},
+    }
+    if llm is not None:
+        cfg["llm"] = llm
+    path = tmp_path / "gen.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+    return path
+
+
+class TestLLMOverrides:
+    def test_nothing_set_leaves_config_untouched(self):
+        assert _llm_overrides(_args()) == {}
+
+    def test_llm_only(self):
+        assert _llm_overrides(_args(llm="anthropic/claude-sonnet-4-6")) == {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+        }
+
+    def test_endpoint_and_key_env_ride_on_primary(self):
+        out = _llm_overrides(
+            _args(llm="hosted_vllm/Qwen/Qwen3.5-4B", llm_endpoint=ENDPOINT, llm_key_env="K")
+        )
+        assert out == {
+            "provider": "hosted_vllm",
+            "model": "Qwen/Qwen3.5-4B",  # split on the first slash only
+            "endpoint": ENDPOINT,
+            "api_key_env": "K",
+        }
+
+    def test_fallback_does_not_inherit_endpoint(self):
+        out = _llm_overrides(
+            _args(llm="openai/local", llm_fallback="anthropic/claude", llm_endpoint=ENDPOINT)
+        )
+        assert out["endpoint"] == ENDPOINT
+        assert out["fallback"] == {"provider": "anthropic", "model": "claude"}
+
+    def test_fallback_composes_with_config_like_endpoint_does(self):
+        out = _llm_overrides(_args(llm_fallback="anthropic/claude", config="x.yaml"))
+        assert out == {"fallback": {"provider": "anthropic", "model": "claude"}}
+
+    @pytest.mark.parametrize("flag", ["llm_fallback", "llm_endpoint", "llm_key_env"])
+    def test_secondary_flags_need_llm_or_config(self, flag):
+        with pytest.raises(SystemExit, match="need --llm"):
+            _llm_overrides(_args(**{flag: "anthropic/x" if flag == "llm_fallback" else "v"}))
+
+    @pytest.mark.parametrize("flag", ["llm", "llm_fallback"])
+    def test_provider_model_shape_enforced(self, flag):
+        kwargs = {"llm": "anthropic/x"} if flag == "llm_fallback" else {}
+        kwargs[flag] = "no-slash"
+        with pytest.raises(SystemExit, match="expects provider/model"):
+            _llm_overrides(_args(**kwargs))
+
+
+def test_endpoint_overrides_config_llm_block(tmp_path: Path):
+    cfg = _write_config(tmp_path, {"provider": "hosted_vllm", "model": "Qwen/Qwen3.5-4B"})
+    overrides = {"llm": _llm_overrides(_args(llm_endpoint=ENDPOINT, config=str(cfg)))}
+    gen = load_generation_input(cfg, overrides)
+    assert gen.llm is not None
+    assert (gen.llm.provider, gen.llm.model, gen.llm.endpoint) == (
+        "hosted_vllm",
+        "Qwen/Qwen3.5-4B",
+        ENDPOINT,
+    )
+
+
+class TestParser:
+    """Real argparse tree, command body swapped for a capture."""
+
+    def test_generate_accepts_flags(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        seen: dict = {}
+        monkeypatch.setattr(cli_mod, "cmd_generate", lambda a: seen.update(vars(a)) or 0)
+        rc = cli_mod.main(
+            [
+                "generate",
+                "--repo", "pallets/click",
+                "--pipeline", "pr_diff",
+                "--llm", "openai/Qwen/Qwen3.5-4B",
+                "--llm-endpoint", ENDPOINT,
+                "--llm-key-env", "MY_KEY",
+                "--out", str(tmp_path),
+            ]
+        )  # fmt: skip
+        assert rc == 0
+        assert seen["llm_endpoint"] == ENDPOINT
+        assert seen["llm_key_env"] == "MY_KEY"
+
+    def test_bootstrap_accepts_flags(self, monkeypatch: pytest.MonkeyPatch):
+        seen: dict = {}
+        monkeypatch.setattr(cli_mod, "cmd_bootstrap", lambda a: seen.update(vars(a)) or 0)
+        rc = cli_mod.main(
+            [
+                "bootstrap",
+                "--repo", "pallets/click",
+                "--llm", "hosted_vllm/Qwen/Qwen3.5-4B",
+                "--llm-endpoint", ENDPOINT,
+            ]
+        )  # fmt: skip
+        assert rc == 0
+        assert seen["llm_endpoint"] == ENDPOINT
+        assert seen["llm_key_env"] is None
+        assert "llm_fallback" not in seen
+
+
+class TestDropConfigLLMExtras:
+    @staticmethod
+    def _load(cfg: Path, **flags) -> tuple:
+        args = _args(config=str(cfg), **flags)
+        gen = load_generation_input(cfg, {"llm": _llm_overrides(args)})
+        return gen, args
+
+    def test_new_model_drops_config_endpoint_and_key_env(self, tmp_path: Path):
+        cfg = _write_config(
+            tmp_path,
+            {"provider": "hosted_vllm", "model": "Qwen", "endpoint": ENDPOINT, "api_key_env": "K"},
+        )
+        gen, args = self._load(cfg, llm="anthropic/claude-sonnet-4-6")
+        assert gen.llm.endpoint == ENDPOINT  # what a plain merge leaves behind
+        gen = _drop_config_llm_extras(gen, args, cfg)
+        assert (gen.llm.provider, gen.llm.model) == ("anthropic", "claude-sonnet-4-6")
+        assert gen.llm.endpoint is None
+        assert gen.llm.api_key_env is None
+
+    def test_same_model_keeps_config_endpoint(self, tmp_path: Path):
+        cfg = _write_config(
+            tmp_path, {"provider": "hosted_vllm", "model": "Qwen", "endpoint": ENDPOINT}
+        )
+        gen, args = self._load(cfg, llm="hosted_vllm/Qwen")
+        gen = _drop_config_llm_extras(gen, args, cfg)
+        assert gen.llm.endpoint == ENDPOINT
+
+    def test_cli_endpoint_survives_model_change(self, tmp_path: Path):
+        cfg = _write_config(
+            tmp_path, {"provider": "hosted_vllm", "model": "Qwen", "endpoint": "http://old/v1"}
+        )
+        gen, args = self._load(cfg, llm="openai/other", llm_endpoint=ENDPOINT)
+        gen = _drop_config_llm_extras(gen, args, cfg)
+        assert gen.llm.endpoint == ENDPOINT
+
+
+def test_missing_llm_block_is_a_clean_error(tmp_path: Path):
+    """No `llm:` in config, no --llm → field errors, not a traceback."""
+    cfg = _write_config(tmp_path, llm=None)
+    rc = cli_mod.main(["--no-ui", "generate", "--config", str(cfg), "--llm-endpoint", ENDPOINT])
+    assert rc == 2

--- a/tests/test_llm_local.py
+++ b/tests/test_llm_local.py
@@ -1,0 +1,156 @@
+"""API-key resolution for self-hosted / keyless backends (vLLM, Ollama, …).
+
+No live LLM and no real `litellm` import — `_do_complete` imports it lazily, so a
+stub module in `sys.modules` stands in and its `completion` kwargs are inspected.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from repo2rlenv.llm import _PLACEHOLDER_API_KEY, _do_complete, check_provider
+from repo2rlenv.spec.input import LLMSpec
+
+ENDPOINT = "http://127.0.0.1:8000/v1"
+
+
+def _fake_response(content: str = "PONG") -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=None,
+    )
+
+
+@pytest.fixture
+def litellm_stub(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    stub = SimpleNamespace(
+        completion=mock.MagicMock(return_value=_fake_response()),
+        completion_cost=lambda **kw: 0.0,
+        get_llm_provider=mock.MagicMock(return_value=("m", "p", None, None)),
+    )
+    monkeypatch.setitem(sys.modules, "litellm", stub)
+    return stub
+
+
+def _call(spec: LLMSpec) -> dict:
+    return _do_complete(spec, system=None, user="ping", max_tokens=8, temperature=0.0)
+
+
+def _kwargs(stub: SimpleNamespace) -> dict:
+    assert stub.completion.call_count == 1
+    return stub.completion.call_args.kwargs
+
+
+# --- endpoint set --------------------------------------------------------------
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_hosted_vllm_endpoint_leaves_key_to_litellm(litellm_stub):
+    spec = LLMSpec(provider="hosted_vllm", model="Qwen/Qwen3.5-4B", endpoint=ENDPOINT)
+    resp = _call(spec)
+    kw = _kwargs(litellm_stub)
+    assert resp.content == "PONG"
+    assert kw["model"] == "hosted_vllm/Qwen/Qwen3.5-4B"
+    assert kw["api_base"] == ENDPOINT
+    assert "api_key" not in kw  # LiteLLM reads HOSTED_VLLM_API_KEY itself, or fakes one
+
+
+@mock.patch.dict(os.environ, {"HOSTED_VLLM_API_KEY": "s3cret"}, clear=True)
+def test_hosted_vllm_env_key_not_shadowed(litellm_stub):
+    """A server started with `--api-key` and HOSTED_VLLM_API_KEY set must not get a placeholder."""
+    _call(LLMSpec(provider="hosted_vllm", model="m", endpoint=ENDPOINT))
+    assert "api_key" not in _kwargs(litellm_stub)
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_openai_compat_endpoint_gets_placeholder(litellm_stub):
+    """`openai/<model>` + endpoint — the OpenAI client needs *a* key string."""
+    _call(LLMSpec(provider="openai", model="Qwen/Qwen3.5-4B", endpoint=ENDPOINT))
+    kw = _kwargs(litellm_stub)
+    assert kw["api_base"] == ENDPOINT
+    assert kw["api_key"] == _PLACEHOLDER_API_KEY
+
+
+@mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-live"}, clear=True)
+def test_default_key_never_forwarded_to_custom_endpoint(litellm_stub):
+    _call(LLMSpec(provider="openai", model="m", endpoint=ENDPOINT))
+    assert _kwargs(litellm_stub)["api_key"] == _PLACEHOLDER_API_KEY
+
+
+@mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-live"}, clear=True)
+def test_explicit_key_env_is_forwarded_to_endpoint(litellm_stub):
+    spec = LLMSpec(provider="openai", model="m", endpoint=ENDPOINT, api_key_env="OPENAI_API_KEY")
+    _call(spec)
+    assert _kwargs(litellm_stub)["api_key"] == "sk-live"
+
+
+@mock.patch.dict(os.environ, {"OPENAI_API_KEY": ""}, clear=True)
+def test_blank_env_var_counts_as_unset(litellm_stub):
+    """`.env.example` ships `OPENAI_API_KEY=`; that must not become api_key=''."""
+    _call(LLMSpec(provider="openai", model="m", endpoint=ENDPOINT))
+    assert _kwargs(litellm_stub)["api_key"] == _PLACEHOLDER_API_KEY
+
+
+# --- no endpoint ---------------------------------------------------------------
+
+
+@mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-live"}, clear=True)
+def test_named_but_unset_key_env_does_not_fall_through(litellm_stub):
+    spec = LLMSpec(provider="openai", model="m", api_key_env="PROXY_KEY")
+    with pytest.raises(RuntimeError, match=r"\$PROXY_KEY is unset"):
+        _call(spec)
+    litellm_stub.completion.assert_not_called()
+
+
+@mock.patch.dict(os.environ, {"OPENAI_API_KEY": ""}, clear=True)
+def test_hosted_provider_without_key_fails_fast_naming_env_var(litellm_stub):
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        _call(LLMSpec(provider="openai", model="gpt-5.5"))
+    litellm_stub.completion.assert_not_called()
+
+
+@mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant"}, clear=True)
+def test_hosted_provider_default_key_forwarded(litellm_stub):
+    _call(LLMSpec(provider="anthropic", model="claude-sonnet-4-6"))
+    kw = _kwargs(litellm_stub)
+    assert kw["api_key"] == "sk-ant"
+    assert "api_base" not in kw
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
+@pytest.mark.parametrize("provider", ["hosted_vllm", "ollama", "bedrock", "vertex_ai"])
+def test_other_providers_are_litellms_to_resolve(litellm_stub, provider):
+    _call(LLMSpec(provider=provider, model="m"))
+    kw = _kwargs(litellm_stub)
+    assert "api_key" not in kw
+    assert "api_base" not in kw
+
+
+@mock.patch.dict(os.environ, {"HF_TOKEN": "hf_x"}, clear=True)
+def test_huggingface_router_default_base_unchanged(litellm_stub):
+    _call(LLMSpec(provider="huggingface", model="org/model:together"))
+    kw = _kwargs(litellm_stub)
+    assert kw["api_key"] == "hf_x"
+    assert kw["api_base"] == "https://router.huggingface.co/v1"
+
+
+# --- check_provider ------------------------------------------------------------
+
+
+def test_check_provider_walks_fallback_chain(litellm_stub):
+    fb = LLMSpec(provider="openai", model="gpt-5.5")
+    spec = LLMSpec(provider="anthropic", model="claude-sonnet-4-6", fallback=fb)
+    check_provider(spec)
+    seen = [c.args[0] for c in litellm_stub.get_llm_provider.call_args_list]
+    assert seen == ["anthropic/claude-sonnet-4-6", "openai/gpt-5.5"]
+
+
+def test_check_provider_names_the_bad_spec(litellm_stub):
+    litellm_stub.get_llm_provider.side_effect = ValueError("LLM Provider NOT provided\nmore")
+    with pytest.raises(RuntimeError, match=r"'antropic/claude'.*NOT provided$"):
+        check_provider(LLMSpec(provider="antropic", model="claude"))


### PR DESCRIPTION
## Summary

- Add the `--llm-endpoint` / `--llm-key-env` flags to `generate` and `bootstrap`. Both have been documented in `BOOTSTRAP.md` since v0.8.1 but never existed; the spec fields were only reachable via `--config`.
- Stop rejecting providers our key resolver doesn't know. `hosted_vllm/`, `ollama/`, Bedrock, Vertex, … are now left to LiteLLM's own credential lookup; the five hosted providers in `auth.LLM_KEY_ENV_DEFAULTS` still fail fast with the env var named.
- Make key precedence explicit and safe: `--llm-key-env` always wins and never falls through to another provider's key; with `--llm-endpoint` the provider-default key is never forwarded to the custom server (`openai/` gets a placeholder, `hosted_vllm/` honours `HOSTED_VLLM_API_KEY`); blank env values (as shipped in `.env.example`) count as unset.
- Small related fixes surfaced while testing: `--llm-fallback` now composes with a `--config` file like its siblings; `--llm` over a config whose `llm:` block names a different model drops that block's stale `endpoint` / `api_key_env`; a typo'd provider fails before clone / image pull instead of at the first agent turn; a config with no `llm:` block reports field errors instead of a traceback.

## Test plan

- [x] `uv run pytest -q` — 752 passed, 5 skipped (26 new tests; the new LLM tests stub `litellm` via `sys.modules`, so the suite does not pay its import cost)
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean
- [x] `uv run pytest tests/test_pipeline_contract.py` unchanged and green
- [x] `mkdocs build` clean apart from the pre-existing draft-RFC link warnings
- [x] Live against vLLM 0.20.2 serving `Qwen/Qwen3.5-4B` (RTX 3090), LiteLLM 1.83.14, no keys in the environment:
  - `hosted_vllm/…` + `--llm-endpoint` and `openai/…` + `--llm-endpoint` both complete
  - With a logging proxy in front of vLLM: `openai/` sends `Bearer EMPTY` even when `OPENAI_API_KEY` is set, and sends the real key only with `--llm-key-env OPENAI_API_KEY`; `hosted_vllm/` forwards `HOSTED_VLLM_API_KEY` when set and LiteLLM's own placeholder otherwise
  - `repo2rlenv bootstrap --llm hosted_vllm/… --llm-endpoint …` passes flag parsing and the provider preflight and stops at the Docker boundary on a machine without Docker; `--llm antropic/…` fails in the preflight before any work
  - The `commit_runtime` instruction-synthesis prompt run through the local model on three `pallets/click` commits produced statements that pass the pipeline's own gate

## Out of scope

- A full bootstrap + `harbor run -a oracle` cycle on a self-hosted model (needs Docker; will report separately once run).
- Adding more providers to `LLM_KEY_ENV_DEFAULTS`. Anything not listed is delegated to LiteLLM, which already knows the env var names.
- Cost tracking for self-hosted models. `litellm.completion_cost` has no price entry for them, so they count as $0 and `max_llm_spend_usd` never trips; documented in `BOOTSTRAP.md`.

Closes #103
